### PR TITLE
feat: add temporal constraint chain for date/time decoders

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -152,16 +152,7 @@ public final class JooqRecordDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
      */
     public static TemporalDecoder<Object, LocalDate> date() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalDate d) {
-                return Result.ok(d);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
-                    Map.of("expected", "date", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalDate.class, "date");
     }
 
     /**
@@ -170,16 +161,7 @@ public final class JooqRecordDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
      */
     public static TemporalDecoder<Object, LocalTime> time() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalTime t) {
-                return Result.ok(t);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
-                    Map.of("expected", "time", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalTime.class, "time");
     }
 
     /**
@@ -188,16 +170,7 @@ public final class JooqRecordDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalDateTime}
      */
     public static TemporalDecoder<Object, LocalDateTime> dateTime() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalDateTime dt) {
-                return Result.ok(dt);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
-                    Map.of("expected", "date-time", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalDateTime.class, "date-time");
     }
 
     /**
@@ -206,16 +179,7 @@ public final class JooqRecordDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link Instant}
      */
     public static TemporalDecoder<Object, Instant> iso8601() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof Instant i) {
-                return Result.ok(i);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
-                    Map.of("expected", "instant", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(Instant.class, "instant");
     }
 
     /**
@@ -224,15 +188,20 @@ public final class JooqRecordDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link OffsetDateTime}
      */
     public static TemporalDecoder<Object, OffsetDateTime> offsetDateTime() {
+        return temporalOf(OffsetDateTime.class, "offset-date-time");
+    }
+
+    private static <T extends Comparable<? super T>> TemporalDecoder<Object, T> temporalOf(
+            Class<T> type, String typeName) {
         return new TemporalDecoder<>((in, path) -> {
             if (in == null) {
                 return Result.fail(path, ErrorCodes.REQUIRED, "is required");
             }
-            if (in instanceof OffsetDateTime odt) {
-                return Result.ok(odt);
+            if (type.isInstance(in)) {
+                return Result.ok(type.cast(in));
             }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
-                    Map.of("expected", "offset-date-time", "actual", in.getClass().getSimpleName()));
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected " + typeName,
+                    Map.of("expected", typeName, "actual", in.getClass().getSimpleName()));
         });
     }
 

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -7,6 +7,11 @@ import net.unit8.raoh.combinator.*;
 import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -136,6 +141,98 @@ public final class JooqRecordDecoders {
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected number",
                     Map.of("expected", "number", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    // --- Temporal decoders ---
+
+    /**
+     * Decodes a field value as a {@link LocalDate}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
+     */
+    public static TemporalDecoder<Object, LocalDate> date() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalDate d) {
+                return Result.ok(d);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
+                    Map.of("expected", "LocalDate", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Decodes a field value as a {@link LocalTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
+     */
+    public static TemporalDecoder<Object, LocalTime> time() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalTime t) {
+                return Result.ok(t);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
+                    Map.of("expected", "LocalTime", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Decodes a field value as a {@link LocalDateTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalDateTime}
+     */
+    public static TemporalDecoder<Object, LocalDateTime> dateTime() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalDateTime dt) {
+                return Result.ok(dt);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
+                    Map.of("expected", "LocalDateTime", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Decodes a field value as an {@link Instant}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link Instant}
+     */
+    public static TemporalDecoder<Object, Instant> iso8601() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof Instant i) {
+                return Result.ok(i);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
+                    Map.of("expected", "Instant", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Decodes a field value as an {@link OffsetDateTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link OffsetDateTime}
+     */
+    public static TemporalDecoder<Object, OffsetDateTime> offsetDateTime() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof OffsetDateTime odt) {
+                return Result.ok(odt);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
+                    Map.of("expected", "OffsetDateTime", "actual", in.getClass().getSimpleName()));
         });
     }
 

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -160,7 +160,7 @@ public final class JooqRecordDecoders {
                 return Result.ok(d);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
-                    Map.of("expected", "LocalDate", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "date", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -178,7 +178,7 @@ public final class JooqRecordDecoders {
                 return Result.ok(t);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
-                    Map.of("expected", "LocalTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "time", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -196,7 +196,7 @@ public final class JooqRecordDecoders {
                 return Result.ok(dt);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
-                    Map.of("expected", "LocalDateTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "date-time", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -214,7 +214,7 @@ public final class JooqRecordDecoders {
                 return Result.ok(i);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
-                    Map.of("expected", "Instant", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "instant", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -232,7 +232,7 @@ public final class JooqRecordDecoders {
                 return Result.ok(odt);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
-                    Map.of("expected", "OffsetDateTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "offset-date-time", "actual", in.getClass().getSimpleName()));
         });
     }
 

--- a/raoh-json/src/test/java/net/unit8/raoh/json/TemporalDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/TemporalDecoderTest.java
@@ -1,0 +1,257 @@
+package net.unit8.raoh.json;
+
+import net.unit8.raoh.*;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static net.unit8.raoh.json.JsonDecoders.*;
+
+class TemporalDecoderTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // --- before (exclusive) ---
+
+    @Test
+    void beforeLocalDatePasses() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1)));
+        assertEquals(LocalDate.of(2024, 12, 31), assertOk(dec.decode(parse("{\"d\":\"2024-12-31\"}"))));
+    }
+
+    @Test
+    void beforeLocalDateFailsOnEqual() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1)));
+        assertErr(dec.decode(parse("{\"d\":\"2025-01-01\"}")));
+    }
+
+    @Test
+    void beforeLocalDateFailsOnLater() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1)));
+        assertErr(dec.decode(parse("{\"d\":\"2025-01-02\"}")));
+    }
+
+    // --- after (exclusive) ---
+
+    @Test
+    void afterLocalDatePasses() {
+        var dec = field("d", string().date().after(LocalDate.of(2024, 1, 1)));
+        assertEquals(LocalDate.of(2024, 1, 2), assertOk(dec.decode(parse("{\"d\":\"2024-01-02\"}"))));
+    }
+
+    @Test
+    void afterLocalDateFailsOnEqual() {
+        var dec = field("d", string().date().after(LocalDate.of(2024, 1, 1)));
+        assertErr(dec.decode(parse("{\"d\":\"2024-01-01\"}")));
+    }
+
+    @Test
+    void afterLocalDateFailsOnEarlier() {
+        var dec = field("d", string().date().after(LocalDate.of(2024, 1, 1)));
+        assertErr(dec.decode(parse("{\"d\":\"2023-12-31\"}")));
+    }
+
+    // --- between (inclusive) ---
+
+    @Test
+    void betweenLocalDatePassesOnLowerBound() {
+        var dec = field("d", string().date().between(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)));
+        assertEquals(LocalDate.of(2024, 1, 1), assertOk(dec.decode(parse("{\"d\":\"2024-01-01\"}"))));
+    }
+
+    @Test
+    void betweenLocalDatePassesOnUpperBound() {
+        var dec = field("d", string().date().between(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)));
+        assertEquals(LocalDate.of(2024, 12, 31), assertOk(dec.decode(parse("{\"d\":\"2024-12-31\"}"))));
+    }
+
+    @Test
+    void betweenLocalDateFailsBeforeLower() {
+        var dec = field("d", string().date().between(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)));
+        assertErr(dec.decode(parse("{\"d\":\"2023-12-31\"}")));
+    }
+
+    @Test
+    void betweenLocalDateFailsAfterUpper() {
+        var dec = field("d", string().date().between(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)));
+        assertErr(dec.decode(parse("{\"d\":\"2025-01-01\"}")));
+    }
+
+    @Test
+    void betweenRejectsInvertedRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                string().date().between(LocalDate.of(2025, 1, 1), LocalDate.of(2024, 1, 1)));
+    }
+
+    // --- chaining ---
+
+    @Test
+    void afterAndBeforeChain() {
+        var dec = field("d", string().date()
+                .after(LocalDate.of(2024, 1, 1))
+                .before(LocalDate.of(2024, 12, 31)));
+        assertEquals(LocalDate.of(2024, 6, 15), assertOk(dec.decode(parse("{\"d\":\"2024-06-15\"}"))));
+        assertErr(dec.decode(parse("{\"d\":\"2024-01-01\"}")));
+        assertErr(dec.decode(parse("{\"d\":\"2024-12-31\"}")));
+    }
+
+    // --- LocalTime ---
+
+    @Test
+    void beforeLocalTime() {
+        var dec = field("t", string().time().before(LocalTime.of(17, 0)));
+        assertEquals(LocalTime.of(9, 0), assertOk(dec.decode(parse("{\"t\":\"09:00:00\"}"))));
+        assertErr(dec.decode(parse("{\"t\":\"17:00:00\"}")));
+    }
+
+    // --- Instant ---
+
+    @Test
+    void afterInstant() {
+        var bound = Instant.parse("2024-01-01T00:00:00Z");
+        var dec = field("ts", string().iso8601().after(bound));
+        var result = assertOk(dec.decode(parse("{\"ts\":\"2024-06-01T00:00:00Z\"}")));
+        assertTrue(result.isAfter(bound));
+        assertErr(dec.decode(parse("{\"ts\":\"2024-01-01T00:00:00Z\"}")));
+    }
+
+    // --- LocalDateTime ---
+
+    @Test
+    void dateTimeParsing() {
+        var dec = field("dt", string().dateTime());
+        assertEquals(LocalDateTime.of(2024, 3, 15, 10, 30, 0),
+                assertOk(dec.decode(parse("{\"dt\":\"2024-03-15T10:30:00\"}"))));
+    }
+
+    @Test
+    void dateTimeWithBefore() {
+        var dec = field("dt", string().dateTime()
+                .before(LocalDateTime.of(2025, 1, 1, 0, 0)));
+        assertOk(dec.decode(parse("{\"dt\":\"2024-12-31T23:59:59\"}")));
+        assertErr(dec.decode(parse("{\"dt\":\"2025-01-01T00:00:00\"}")));
+    }
+
+    @Test
+    void dateTimeInvalidFormat() {
+        var dec = field("dt", string().dateTime());
+        assertErr(dec.decode(parse("{\"dt\":\"not-a-datetime\"}")));
+    }
+
+    // --- OffsetDateTime ---
+
+    @Test
+    void offsetDateTimeParsing() {
+        var dec = field("odt", string().offsetDateTime());
+        var result = assertOk(dec.decode(parse("{\"odt\":\"2024-03-15T10:30:00+09:00\"}")));
+        assertEquals(OffsetDateTime.of(2024, 3, 15, 10, 30, 0, 0, ZoneOffset.ofHours(9)), result);
+    }
+
+    @Test
+    void offsetDateTimeWithAfter() {
+        var bound = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        var dec = field("odt", string().offsetDateTime().after(bound));
+        assertOk(dec.decode(parse("{\"odt\":\"2024-06-01T00:00:00Z\"}")));
+        assertErr(dec.decode(parse("{\"odt\":\"2024-01-01T00:00:00Z\"}")));
+    }
+
+    @Test
+    void offsetDateTimeInvalidFormat() {
+        var dec = field("odt", string().offsetDateTime());
+        assertErr(dec.decode(parse("{\"odt\":\"2024-03-15T10:30:00\"}")));
+    }
+
+    // --- custom message ---
+
+    @Test
+    void customMessageOnBefore() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1), "too late"));
+        var result = dec.decode(parse("{\"d\":\"2025-06-01\"}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals("too late", issues.asList().getFirst().message());
+        }
+    }
+
+    // --- meta verification ---
+
+    @Test
+    void metaContainsBeforeAndActual() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1)));
+        var result = dec.decode(parse("{\"d\":\"2025-06-01\"}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+                assertEquals(LocalDate.of(2025, 1, 1), issue.meta().get("before"));
+                assertEquals(LocalDate.of(2025, 6, 1), issue.meta().get("actual"));
+            }
+        }
+    }
+
+    @Test
+    void metaContainsBetweenRange() {
+        var from = LocalDate.of(2024, 1, 1);
+        var to = LocalDate.of(2024, 12, 31);
+        var dec = field("d", string().date().between(from, to));
+        var result = dec.decode(parse("{\"d\":\"2025-06-01\"}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+                assertEquals(from, issue.meta().get("from"));
+                assertEquals(to, issue.meta().get("to"));
+                assertEquals(LocalDate.of(2025, 6, 1), issue.meta().get("actual"));
+            }
+        }
+    }
+
+    // --- parse error regression ---
+
+    @Test
+    void invalidDateStillProducesFormatError() {
+        var dec = field("d", string().date().before(LocalDate.of(2025, 1, 1)));
+        var result = dec.decode(parse("{\"d\":\"not-a-date\"}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals(ErrorCodes.INVALID_FORMAT, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- Helpers ---
+
+    static <T> T assertOk(Result<T> result) {
+        return switch (result) {
+            case Ok(var value) -> value;
+            case Err(var issues) -> { fail("Expected Ok, got: " + issues); yield null; }
+        };
+    }
+
+    static void assertErr(Result<?> result) {
+        if (result instanceof Ok<?>) {
+            fail("Expected Err, got Ok: " + result);
+        }
+    }
+
+    private static JsonNode parse(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -426,7 +427,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(Instant.parse(value));
-            } catch (Exception e) {
+            } catch (DateTimeParseException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid ISO 8601 instant");
@@ -453,7 +454,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(LocalDate.parse(value));
-            } catch (Exception e) {
+            } catch (DateTimeParseException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid date (yyyy-MM-dd)");
@@ -480,7 +481,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(LocalTime.parse(value));
-            } catch (Exception e) {
+            } catch (DateTimeParseException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid time (HH:mm:ss)");
@@ -507,10 +508,10 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(LocalDateTime.parse(value));
-            } catch (Exception e) {
+            } catch (DateTimeParseException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
-                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid date-time (yyyy-MM-ddTHH:mm:ss)");
+                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid ISO-8601 local date-time (e.g., 2024-01-15T10:30 or 2024-01-15T10:30:45)");
             }
         }));
     }
@@ -534,10 +535,10 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(OffsetDateTime.parse(value));
-            } catch (Exception e) {
+            } catch (DateTimeParseException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
-                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid offset date-time (yyyy-MM-ddTHH:mm:ss+HH:mm)");
+                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid ISO-8601 offset date-time (e.g., 2024-01-15T10:30:00+09:00)");
             }
         }));
     }

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -7,7 +7,9 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -405,12 +407,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
-    public Decoder<I, Instant> iso8601() {
+    /**
+     * Parses the string as an ISO 8601 instant (e.g., {@code 2024-01-15T10:30:00Z}).
+     *
+     * @return a temporal decoder producing {@link Instant}
+     */
+    public TemporalDecoder<I, Instant> iso8601() {
         return iso8601(null);
     }
 
-    public Decoder<I, Instant> iso8601(String message) {
-        return (in, path) -> this.decode(in, path).flatMap(value -> {
+    /**
+     * Parses the string as an ISO 8601 instant.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a temporal decoder producing {@link Instant}
+     */
+    public TemporalDecoder<I, Instant> iso8601(String message) {
+        return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(Instant.parse(value));
             } catch (Exception e) {
@@ -418,15 +431,26 @@ public class StringDecoder<I> implements Decoder<I, String> {
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid ISO 8601 instant");
             }
-        });
+        }));
     }
 
-    public Decoder<I, LocalDate> date() {
+    /**
+     * Parses the string as a local date (e.g., {@code 2024-01-15}).
+     *
+     * @return a temporal decoder producing {@link LocalDate}
+     */
+    public TemporalDecoder<I, LocalDate> date() {
         return date(null);
     }
 
-    public Decoder<I, LocalDate> date(String message) {
-        return (in, path) -> this.decode(in, path).flatMap(value -> {
+    /**
+     * Parses the string as a local date.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a temporal decoder producing {@link LocalDate}
+     */
+    public TemporalDecoder<I, LocalDate> date(String message) {
+        return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(LocalDate.parse(value));
             } catch (Exception e) {
@@ -434,15 +458,26 @@ public class StringDecoder<I> implements Decoder<I, String> {
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid date (yyyy-MM-dd)");
             }
-        });
+        }));
     }
 
-    public Decoder<I, LocalTime> time() {
+    /**
+     * Parses the string as a local time (e.g., {@code 10:30:00}).
+     *
+     * @return a temporal decoder producing {@link LocalTime}
+     */
+    public TemporalDecoder<I, LocalTime> time() {
         return time(null);
     }
 
-    public Decoder<I, LocalTime> time(String message) {
-        return (in, path) -> this.decode(in, path).flatMap(value -> {
+    /**
+     * Parses the string as a local time.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a temporal decoder producing {@link LocalTime}
+     */
+    public TemporalDecoder<I, LocalTime> time(String message) {
+        return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
             try {
                 return Result.ok(LocalTime.parse(value));
             } catch (Exception e) {
@@ -450,7 +485,61 @@ public class StringDecoder<I> implements Decoder<I, String> {
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid time (HH:mm:ss)");
             }
-        });
+        }));
+    }
+
+    /**
+     * Parses the string as a local date-time (e.g., {@code 2024-01-15T10:30:00}).
+     *
+     * @return a temporal decoder producing {@link LocalDateTime}
+     */
+    public TemporalDecoder<I, LocalDateTime> dateTime() {
+        return dateTime(null);
+    }
+
+    /**
+     * Parses the string as a local date-time.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a temporal decoder producing {@link LocalDateTime}
+     */
+    public TemporalDecoder<I, LocalDateTime> dateTime(String message) {
+        return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            try {
+                return Result.ok(LocalDateTime.parse(value));
+            } catch (Exception e) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
+                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid date-time (yyyy-MM-ddTHH:mm:ss)");
+            }
+        }));
+    }
+
+    /**
+     * Parses the string as an offset date-time (e.g., {@code 2024-01-15T10:30:00+09:00}).
+     *
+     * @return a temporal decoder producing {@link OffsetDateTime}
+     */
+    public TemporalDecoder<I, OffsetDateTime> offsetDateTime() {
+        return offsetDateTime(null);
+    }
+
+    /**
+     * Parses the string as an offset date-time.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a temporal decoder producing {@link OffsetDateTime}
+     */
+    public TemporalDecoder<I, OffsetDateTime> offsetDateTime(String message) {
+        return new TemporalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            try {
+                return Result.ok(OffsetDateTime.parse(value));
+            } catch (Exception e) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
+                        : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid offset date-time (yyyy-MM-ddTHH:mm:ss+HH:mm)");
+            }
+        }));
     }
 
     private StringDecoder<I> chain(Decoder<String, String> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
@@ -13,9 +13,9 @@ import java.util.Map;
  *
  * <p><strong>Boundary semantics</strong></p>
  * <ul>
- *   <li>{@link #before} and {@link #after} are <strong>exclusive</strong>,
+ *   <li>{@link #before(Comparable) before} and {@link #after(Comparable) after} are <strong>exclusive</strong>,
  *       consistent with {@code isBefore}/{@code isAfter} in {@code java.time}.</li>
- *   <li>{@link #between} is <strong>inclusive</strong> on both ends,
+ *   <li>{@link #between(Comparable, Comparable) between} is <strong>inclusive</strong> on both ends,
  *       consistent with SQL {@code BETWEEN}.</li>
  *   <li>For inclusive before/after, use {@link Decoder#flatMap} directly.</li>
  * </ul>

--- a/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
@@ -1,0 +1,149 @@
+package net.unit8.raoh.builtin;
+
+import net.unit8.raoh.*;
+
+import java.util.Map;
+
+/**
+ * A decoder for temporal values with a fluent API for range constraints.
+ *
+ * <p>Supports any {@link Comparable} temporal type such as {@link java.time.LocalDate},
+ * {@link java.time.LocalTime}, {@link java.time.Instant}, {@link java.time.LocalDateTime},
+ * and {@link java.time.OffsetDateTime}.
+ *
+ * <p><strong>Boundary semantics</strong></p>
+ * <ul>
+ *   <li>{@link #before} and {@link #after} are <strong>exclusive</strong>,
+ *       consistent with {@code isBefore}/{@code isAfter} in {@code java.time}.</li>
+ *   <li>{@link #between} is <strong>inclusive</strong> on both ends,
+ *       consistent with SQL {@code BETWEEN}.</li>
+ *   <li>For inclusive before/after, use {@link Decoder#flatMap} directly.</li>
+ * </ul>
+ *
+ * <p><strong>Note on {@link java.time.OffsetDateTime}</strong></p>
+ * <p>{@link java.time.OffsetDateTime#compareTo} compares by instant first, then by offset.
+ * Two values representing the same instant with different offsets (e.g.,
+ * {@code 10:00+09:00} and {@code 01:00Z}) are not considered equal by {@code compareTo}.
+ *
+ * @param <I> the input type
+ * @param <T> the temporal type (must be {@link Comparable} to itself)
+ */
+public class TemporalDecoder<I, T extends Comparable<? super T>> implements Decoder<I, T> {
+
+    private final Decoder<I, T> inner;
+
+    /**
+     * Creates a new temporal decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that produces the temporal value
+     */
+    public TemporalDecoder(Decoder<I, T> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Result<T> decode(I in, Path path) {
+        return inner.decode(in, path);
+    }
+
+    /**
+     * Constrains the value to be strictly before the given bound (exclusive).
+     *
+     * @param bound the upper bound (exclusive)
+     * @return a new decoder with the constraint applied
+     */
+    public TemporalDecoder<I, T> before(T bound) {
+        return before(bound, null);
+    }
+
+    /**
+     * Constrains the value to be strictly before the given bound (exclusive).
+     *
+     * @param bound   the upper bound (exclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder with the constraint applied
+     */
+    public TemporalDecoder<I, T> before(T bound, String message) {
+        return chain((value, path) -> {
+            if (value.compareTo(bound) >= 0) {
+                var meta = Map.<String, Object>of("before", bound, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be before %s".formatted(bound), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Constrains the value to be strictly after the given bound (exclusive).
+     *
+     * @param bound the lower bound (exclusive)
+     * @return a new decoder with the constraint applied
+     */
+    public TemporalDecoder<I, T> after(T bound) {
+        return after(bound, null);
+    }
+
+    /**
+     * Constrains the value to be strictly after the given bound (exclusive).
+     *
+     * @param bound   the lower bound (exclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder with the constraint applied
+     */
+    public TemporalDecoder<I, T> after(T bound, String message) {
+        return chain((value, path) -> {
+            if (value.compareTo(bound) <= 0) {
+                var meta = Map.<String, Object>of("after", bound, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be after %s".formatted(bound), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Constrains the value to be within the given range, inclusive on both ends.
+     *
+     * @param from the lower bound (inclusive)
+     * @param to   the upper bound (inclusive)
+     * @return a new decoder with the constraint applied
+     * @throws IllegalArgumentException if {@code from} is greater than {@code to}
+     */
+    public TemporalDecoder<I, T> between(T from, T to) {
+        return between(from, to, null);
+    }
+
+    /**
+     * Constrains the value to be within the given range, inclusive on both ends.
+     *
+     * @param from    the lower bound (inclusive)
+     * @param to      the upper bound (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder with the constraint applied
+     * @throws IllegalArgumentException if {@code from} is greater than {@code to}
+     */
+    public TemporalDecoder<I, T> between(T from, T to, String message) {
+        if (from.compareTo(to) > 0) {
+            throw new IllegalArgumentException(
+                    "from (%s) must not be greater than to (%s)".formatted(from, to));
+        }
+        return chain((value, path) -> {
+            if (value.compareTo(from) < 0 || value.compareTo(to) > 0) {
+                var meta = Map.<String, Object>of("from", from, "to", to, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be between %s and %s".formatted(from, to), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    private TemporalDecoder<I, T> chain(Decoder<T, T> constraint) {
+        return new TemporalDecoder<>((in, path) ->
+                this.decode(in, path).flatMap(value -> constraint.decode(value, path))
+        );
+    }
+}

--- a/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/TemporalDecoder.java
@@ -14,16 +14,18 @@ import java.util.Map;
  * <p><strong>Boundary semantics</strong></p>
  * <ul>
  *   <li>{@link #before(Comparable) before} and {@link #after(Comparable) after} are <strong>exclusive</strong>,
- *       consistent with {@code isBefore}/{@code isAfter} in {@code java.time}.</li>
+ *       based on the type's natural ordering ({@link Comparable#compareTo compareTo}).</li>
  *   <li>{@link #between(Comparable, Comparable) between} is <strong>inclusive</strong> on both ends,
  *       consistent with SQL {@code BETWEEN}.</li>
  *   <li>For inclusive before/after, use {@link Decoder#flatMap} directly.</li>
  * </ul>
  *
  * <p><strong>Note on {@link java.time.OffsetDateTime}</strong></p>
- * <p>{@link java.time.OffsetDateTime#compareTo} compares by instant first, then by offset.
- * Two values representing the same instant with different offsets (e.g.,
- * {@code 10:00+09:00} and {@code 01:00Z}) are not considered equal by {@code compareTo}.
+ * <p>{@link java.time.OffsetDateTime#compareTo} follows the type's natural ordering, which
+ * differs from {@code isBefore}/{@code isAfter}: {@code compareTo} compares by instant first,
+ * then by offset as a tiebreaker, so two values representing the same instant with different
+ * offsets (e.g., {@code 10:00+09:00} and {@code 01:00Z}) are <em>not</em> considered equal.
+ * This means exclusive boundaries may behave unexpectedly when comparing across offsets.
  *
  * @param <I> the input type
  * @param <T> the temporal type (must be {@link Comparable} to itself)

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -183,7 +183,7 @@ public final class MapDecoders {
                 return Result.ok(d);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
-                    Map.of("expected", "LocalDate", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "date", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -204,7 +204,7 @@ public final class MapDecoders {
                 return Result.ok(t);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
-                    Map.of("expected", "LocalTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "time", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -225,7 +225,7 @@ public final class MapDecoders {
                 return Result.ok(dt);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
-                    Map.of("expected", "LocalDateTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "date-time", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -246,7 +246,7 @@ public final class MapDecoders {
                 return Result.ok(i);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
-                    Map.of("expected", "Instant", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "instant", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -267,7 +267,7 @@ public final class MapDecoders {
                 return Result.ok(odt);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
-                    Map.of("expected", "OffsetDateTime", "actual", in.getClass().getSimpleName()));
+                    Map.of("expected", "offset-date-time", "actual", in.getClass().getSimpleName()));
         });
     }
 

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -5,6 +5,11 @@ import net.unit8.raoh.combinator.*;
 import net.unit8.raoh.builtin.*;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -156,6 +161,113 @@ public final class MapDecoders {
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected number",
                     Map.of("expected", "number", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    // --- Temporal decoders ---
+
+    /**
+     * Creates a {@link LocalDate} decoder.
+     *
+     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
+     * if the value is not a {@link LocalDate}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
+     */
+    public static TemporalDecoder<Object, LocalDate> date() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalDate d) {
+                return Result.ok(d);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
+                    Map.of("expected", "LocalDate", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates a {@link LocalTime} decoder.
+     *
+     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
+     * if the value is not a {@link LocalTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
+     */
+    public static TemporalDecoder<Object, LocalTime> time() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalTime t) {
+                return Result.ok(t);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
+                    Map.of("expected", "LocalTime", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates a {@link LocalDateTime} decoder.
+     *
+     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
+     * if the value is not a {@link LocalDateTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link LocalDateTime}
+     */
+    public static TemporalDecoder<Object, LocalDateTime> dateTime() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof LocalDateTime dt) {
+                return Result.ok(dt);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
+                    Map.of("expected", "LocalDateTime", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates an {@link Instant} decoder.
+     *
+     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
+     * if the value is not an {@link Instant}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link Instant}
+     */
+    public static TemporalDecoder<Object, Instant> iso8601() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof Instant i) {
+                return Result.ok(i);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
+                    Map.of("expected", "Instant", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates an {@link OffsetDateTime} decoder.
+     *
+     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
+     * if the value is not an {@link OffsetDateTime}.
+     *
+     * @return a temporal decoder for {@code Object} input producing {@link OffsetDateTime}
+     */
+    public static TemporalDecoder<Object, OffsetDateTime> offsetDateTime() {
+        return new TemporalDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof OffsetDateTime odt) {
+                return Result.ok(odt);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
+                    Map.of("expected", "OffsetDateTime", "actual", in.getClass().getSimpleName()));
         });
     }
 

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -175,16 +175,7 @@ public final class MapDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
      */
     public static TemporalDecoder<Object, LocalDate> date() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalDate d) {
-                return Result.ok(d);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date",
-                    Map.of("expected", "date", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalDate.class, "date");
     }
 
     /**
@@ -196,16 +187,7 @@ public final class MapDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
      */
     public static TemporalDecoder<Object, LocalTime> time() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalTime t) {
-                return Result.ok(t);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected time",
-                    Map.of("expected", "time", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalTime.class, "time");
     }
 
     /**
@@ -217,16 +199,7 @@ public final class MapDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link LocalDateTime}
      */
     public static TemporalDecoder<Object, LocalDateTime> dateTime() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof LocalDateTime dt) {
-                return Result.ok(dt);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected date-time",
-                    Map.of("expected", "date-time", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(LocalDateTime.class, "date-time");
     }
 
     /**
@@ -238,16 +211,7 @@ public final class MapDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link Instant}
      */
     public static TemporalDecoder<Object, Instant> iso8601() {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (in instanceof Instant i) {
-                return Result.ok(i);
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected instant",
-                    Map.of("expected", "instant", "actual", in.getClass().getSimpleName()));
-        });
+        return temporalOf(Instant.class, "instant");
     }
 
     /**
@@ -259,15 +223,20 @@ public final class MapDecoders {
      * @return a temporal decoder for {@code Object} input producing {@link OffsetDateTime}
      */
     public static TemporalDecoder<Object, OffsetDateTime> offsetDateTime() {
+        return temporalOf(OffsetDateTime.class, "offset-date-time");
+    }
+
+    private static <T extends Comparable<? super T>> TemporalDecoder<Object, T> temporalOf(
+            Class<T> type, String typeName) {
         return new TemporalDecoder<>((in, path) -> {
             if (in == null) {
                 return Result.fail(path, ErrorCodes.REQUIRED, "is required");
             }
-            if (in instanceof OffsetDateTime odt) {
-                return Result.ok(odt);
+            if (type.isInstance(in)) {
+                return Result.ok(type.cast(in));
             }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected offset date-time",
-                    Map.of("expected", "offset-date-time", "actual", in.getClass().getSimpleName()));
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected " + typeName,
+                    Map.of("expected", typeName, "actual", in.getClass().getSimpleName()));
         });
     }
 


### PR DESCRIPTION
## Summary

- Add `TemporalDecoder<I, T>` with `before()`/`after()` (exclusive) and `between()` (inclusive) constraint chains
- Update `StringDecoder` to return `TemporalDecoder` from `date()`/`time()`/`iso8601()` and add `dateTime()`/`offsetDateTime()` conversions
- Add temporal factory methods (`date()`, `time()`, `dateTime()`, `iso8601()`, `offsetDateTime()`) to `MapDecoders` and `JooqRecordDecoders`

Closes #1

## Test plan

- [x] `before` is exclusive (equal value fails)
- [x] `after` is exclusive (equal value fails)
- [x] `between` is inclusive (boundary values pass)
- [x] `between` rejects inverted range (`from > to` throws `IllegalArgumentException`)
- [x] Constraint chaining (`after().before()`)
- [x] All types: LocalDate, LocalTime, Instant, LocalDateTime, OffsetDateTime
- [x] Custom error messages
- [x] Error meta contains correct keys (`before`/`after`/`from`/`to`/`actual`)
- [x] Parse errors still produce `INVALID_FORMAT` (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)