### PR TITLE
feat: add isTrue / isFalse constraints to BoolDecoder

### DIFF
--- a/raoh-json/src/test/java/net/unit8/raoh/json/BoolDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/BoolDecoderTest.java
@@ -1,0 +1,96 @@
+package net.unit8.raoh.json;
+
+import net.unit8.raoh.*;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static net.unit8.raoh.json.JsonDecoders.*;
+
+class BoolDecoderTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // --- isTrue ---
+
+    @Test
+    void isTruePassesOnTrue() {
+        var dec = field("accepted", bool().isTrue());
+        assertEquals(true, assertOk(dec.decode(parse("{\"accepted\":true}"))));
+    }
+
+    @Test
+    void isTrueFailsOnFalse() {
+        var dec = field("accepted", bool().isTrue());
+        var result = dec.decode(parse("{\"accepted\":false}"));
+        assertErr(result, ErrorCodes.INVALID_VALUE);
+    }
+
+    @Test
+    void isTrueCustomMessage() {
+        var dec = field("accepted", bool().isTrue("you must accept the terms"));
+        var result = dec.decode(parse("{\"accepted\":false}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals("you must accept the terms", issues.asList().getFirst().message());
+        }
+    }
+
+    // --- isFalse ---
+
+    @Test
+    void isFalsePassesOnFalse() {
+        var dec = field("disabled", bool().isFalse());
+        assertEquals(false, assertOk(dec.decode(parse("{\"disabled\":false}"))));
+    }
+
+    @Test
+    void isFalseFailsOnTrue() {
+        var dec = field("disabled", bool().isFalse());
+        var result = dec.decode(parse("{\"disabled\":true}"));
+        assertErr(result, ErrorCodes.INVALID_VALUE);
+    }
+
+    @Test
+    void isFalseCustomMessage() {
+        var dec = field("disabled", bool().isFalse("must not be disabled"));
+        var result = dec.decode(parse("{\"disabled\":true}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals("must not be disabled", issues.asList().getFirst().message());
+        }
+    }
+
+    // --- type mismatch still works ---
+
+    @Test
+    void nonBooleanInputFails() {
+        var dec = field("accepted", bool().isTrue());
+        assertErr(dec.decode(parse("{\"accepted\":\"yes\"}")), ErrorCodes.TYPE_MISMATCH);
+    }
+
+    // --- Helpers ---
+
+    static <T> T assertOk(Result<T> result) {
+        return switch (result) {
+            case Ok(var value) -> value;
+            case Err(var issues) -> { fail("Expected Ok, got: " + issues); yield null; }
+        };
+    }
+
+    static void assertErr(Result<?> result, String expectedCode) {
+        switch (result) {
+            case Ok(_) -> fail("Expected Err, got Ok");
+            case Err(var issues) -> assertEquals(expectedCode, issues.asList().getFirst().code());
+        }
+    }
+
+    private static JsonNode parse(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/raoh-json/src/test/java/net/unit8/raoh/json/BoolDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/BoolDecoderTest.java
@@ -62,6 +62,36 @@ class BoolDecoderTest {
         }
     }
 
+    // --- meta verification ---
+
+    @Test
+    void isTrueMetaContainsExpectedAndActual() {
+        var dec = field("accepted", bool().isTrue());
+        var result = dec.decode(parse("{\"accepted\":false}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(true, issue.meta().get("expected"));
+                assertEquals(false, issue.meta().get("actual"));
+            }
+        }
+    }
+
+    @Test
+    void isFalseMetaContainsExpectedAndActual() {
+        var dec = field("disabled", bool().isFalse());
+        var result = dec.decode(parse("{\"disabled\":true}"));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(false, issue.meta().get("expected"));
+                assertEquals(true, issue.meta().get("actual"));
+            }
+        }
+    }
+
     // --- type mismatch still works ---
 
     @Test

--- a/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
+++ b/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
@@ -56,6 +56,11 @@ public final class ErrorCodes {
     /** Collection size does not match the required exact size. */
     public static final String INVALID_SIZE = "invalid_size";
 
+    // --- Value ---
+
+    /** Value does not satisfy a required value constraint (e.g., must be {@code true} or {@code false}). */
+    public static final String INVALID_VALUE = "invalid_value";
+
     // --- Format ---
 
     /** Value does not match the required format (e.g., email, URL, UUID). */

--- a/raoh/src/main/java/net/unit8/raoh/builtin/BoolDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/BoolDecoder.java
@@ -53,14 +53,7 @@ public class BoolDecoder<I> implements Decoder<I, Boolean> {
      * @return a new decoder with the constraint applied
      */
     public BoolDecoder<I> isTrue(String message) {
-        return chain((value, path) -> {
-            if (!value) {
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.INVALID_VALUE, message, Map.of())
-                        : Result.fail(path, ErrorCodes.INVALID_VALUE, "must be true");
-            }
-            return Result.ok(value);
-        });
+        return booleanConstraint(true, message);
     }
 
     /**
@@ -81,11 +74,17 @@ public class BoolDecoder<I> implements Decoder<I, Boolean> {
      * @return a new decoder with the constraint applied
      */
     public BoolDecoder<I> isFalse(String message) {
+        return booleanConstraint(false, message);
+    }
+
+    private BoolDecoder<I> booleanConstraint(boolean expected, String message) {
         return chain((value, path) -> {
-            if (value) {
+            if (value != expected) {
+                var meta = Map.<String, Object>of("expected", expected, "actual", value);
                 return message != null
-                        ? Result.failCustom(path, ErrorCodes.INVALID_VALUE, message, Map.of())
-                        : Result.fail(path, ErrorCodes.INVALID_VALUE, "must be false");
+                        ? Result.failCustom(path, ErrorCodes.INVALID_VALUE, message, meta)
+                        : Result.fail(path, ErrorCodes.INVALID_VALUE,
+                                "must be %s".formatted(expected), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/builtin/BoolDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/BoolDecoder.java
@@ -2,8 +2,10 @@ package net.unit8.raoh.builtin;
 
 import net.unit8.raoh.*;
 
+import java.util.Map;
+
 /**
- * A decoder for boolean values.
+ * A decoder for boolean values with optional value constraints.
  *
  * @param <I> the input type
  */
@@ -30,5 +32,68 @@ public class BoolDecoder<I> implements Decoder<I, Boolean> {
     @Override
     public Result<Boolean> decode(I in, Path path) {
         return inner.decode(in, path);
+    }
+
+    /**
+     * Constrains the value to be {@code true}.
+     *
+     * <p>Produces an {@code invalid_value} error when the decoded value is {@code false}.
+     * Useful for "must accept terms" or similar required-confirmation fields.
+     *
+     * @return a new decoder with the constraint applied
+     */
+    public BoolDecoder<I> isTrue() {
+        return isTrue(null);
+    }
+
+    /**
+     * Constrains the value to be {@code true}.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder with the constraint applied
+     */
+    public BoolDecoder<I> isTrue(String message) {
+        return chain((value, path) -> {
+            if (!value) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.INVALID_VALUE, message, Map.of())
+                        : Result.fail(path, ErrorCodes.INVALID_VALUE, "must be true");
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Constrains the value to be {@code false}.
+     *
+     * <p>Produces an {@code invalid_value} error when the decoded value is {@code true}.
+     *
+     * @return a new decoder with the constraint applied
+     */
+    public BoolDecoder<I> isFalse() {
+        return isFalse(null);
+    }
+
+    /**
+     * Constrains the value to be {@code false}.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder with the constraint applied
+     */
+    public BoolDecoder<I> isFalse(String message) {
+        return chain((value, path) -> {
+            if (value) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.INVALID_VALUE, message, Map.of())
+                        : Result.fail(path, ErrorCodes.INVALID_VALUE, "must be false");
+            }
+            return Result.ok(value);
+        });
+    }
+
+    private BoolDecoder<I> chain(Decoder<Boolean, Boolean> constraint) {
+        return new BoolDecoder<>((in, path) ->
+                this.decode(in, path).flatMap(value -> constraint.decode(value, path))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `BoolDecoder#isTrue()` / `isTrue(String)` — produces `invalid_value` error when the decoded value is `false`
- Add `BoolDecoder#isFalse()` / `isFalse(String)` — produces `invalid_value` error when the decoded value is `true`
- Add `ErrorCodes.INVALID_VALUE` constant

Closes #5

## Test plan

- [x] `isTrue()` passes on `true`
- [x] `isTrue()` fails on `false` with `INVALID_VALUE`
- [x] `isFalse()` passes on `false`
- [x] `isFalse()` fails on `true` with `INVALID_VALUE`
- [x] Custom error messages
- [x] Type mismatch on non-boolean input still produces `TYPE_MISMATCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)