### PR TITLE
feat: add oneOf constraint to StringDecoder, IntDecoder, and LongDecoder

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
+++ b/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
@@ -76,6 +76,11 @@ public final class ErrorCodes {
     /** Input contains a field that is not declared in the known-fields list. */
     public static final String UNKNOWN_FIELD = "unknown_field";
 
+    // --- Allowed values ---
+
+    /** Value is not in the set of allowed values. */
+    public static final String NOT_ALLOWED = "not_allowed";
+
     // --- Union ---
 
     /** None of the candidates in a {@code oneOf} decoder matched the input. */

--- a/raoh/src/main/java/net/unit8/raoh/MessageResolver.java
+++ b/raoh/src/main/java/net/unit8/raoh/MessageResolver.java
@@ -90,6 +90,7 @@ public interface MessageResolver {
         case ErrorCodes.TOO_BIG         -> "must have at most %s elements".formatted(meta.get("max"));
         case ErrorCodes.INVALID_SIZE    -> "must have exactly %s elements".formatted(meta.get("expected"));
         case ErrorCodes.NOT_MULTIPLE_OF -> "must be a multiple of %s".formatted(meta.get("divisor"));
+        case ErrorCodes.NOT_ALLOWED     -> "must be one of %s".formatted(meta.get("allowed"));
         case ErrorCodes.ONE_OF_FAILED   -> "no variant matched";
         case ErrorCodes.UNKNOWN_FIELD   -> "unknown field";
         case ErrorCodes.INVALID_SCALE   -> "too many decimal places (max %s)".formatted(meta.get("maxScale"));

--- a/raoh/src/main/java/net/unit8/raoh/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/IntDecoder.java
@@ -2,7 +2,10 @@ package net.unit8.raoh.builtin;
 
 import net.unit8.raoh.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A decoder for integer values with a fluent API for numeric constraints.
@@ -105,6 +108,25 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
             if (value > 0) {
                 return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive",
                         Map.of("max", 0, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to one of the specified allowed values.
+     *
+     * @param allowed the set of allowed integer values
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_ALLOWED} if the value is not in the set
+     */
+    public IntDecoder<I> oneOf(Integer... allowed) {
+        var allowedSet = Set.of(allowed);
+        var sortedAllowed = List.copyOf(new TreeSet<>(allowedSet));
+        var message = "must be one of %s".formatted(sortedAllowed);
+        return chain((value, path) -> {
+            if (!allowedSet.contains(value)) {
+                var meta = Map.<String, Object>of("allowed", sortedAllowed, "actual", value);
+                return Result.fail(path, ErrorCodes.NOT_ALLOWED, message, meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/LongDecoder.java
@@ -2,7 +2,10 @@ package net.unit8.raoh.builtin;
 
 import net.unit8.raoh.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A decoder for long integer values with a fluent API for numeric constraints.
@@ -101,6 +104,25 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         return chain((value, path) -> {
             if (value > 0) {
                 return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", Map.of("max", 0L, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to one of the specified allowed values.
+     *
+     * @param allowed the set of allowed long values
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_ALLOWED} if the value is not in the set
+     */
+    public LongDecoder<I> oneOf(Long... allowed) {
+        var allowedSet = Set.of(allowed);
+        var sortedAllowed = List.copyOf(new TreeSet<>(allowedSet));
+        var message = "must be one of %s".formatted(sortedAllowed);
+        return chain((value, path) -> {
+            if (!allowedSet.contains(value)) {
+                var meta = Map.<String, Object>of("allowed", sortedAllowed, "actual", value);
+                return Result.fail(path, ErrorCodes.NOT_ALLOWED, message, meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -11,7 +11,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -144,6 +147,25 @@ public class StringDecoder<I> implements Decoder<I, String> {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_LENGTH, message, meta)
                         : Result.fail(path, ErrorCodes.INVALID_LENGTH, "must be exactly %d characters".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to one of the specified allowed values.
+     *
+     * @param allowed the set of allowed string values
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_ALLOWED} if the value is not in the set
+     */
+    public StringDecoder<I> oneOf(String... allowed) {
+        var allowedSet = Set.of(allowed);
+        var sortedAllowed = List.copyOf(new TreeSet<>(allowedSet));
+        var message = "must be one of %s".formatted(sortedAllowed);
+        return chain((value, path) -> {
+            if (!allowedSet.contains(value)) {
+                var meta = Map.<String, Object>of("allowed", sortedAllowed, "actual", value);
+                return Result.fail(path, ErrorCodes.NOT_ALLOWED, message, meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/resources/net/unit8/raoh/messages.properties
+++ b/raoh/src/main/resources/net/unit8/raoh/messages.properties
@@ -9,6 +9,7 @@ raoh.too_small=must have at least {min} elements
 raoh.too_big=must have at most {max} elements
 raoh.invalid_size=must have exactly {expected} elements
 raoh.invalid_value=must be {expected}
+raoh.not_allowed=must be one of {allowed}
 raoh.invalid_format=invalid format
 raoh.type_mismatch=expected {expected}
 raoh.unknown_field=unknown field

--- a/raoh/src/test/java/net/unit8/raoh/ErrorCodesDefaultCoverageTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/ErrorCodesDefaultCoverageTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -25,9 +26,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class ErrorCodesDefaultCoverageTest {
 
     /** Shared meta map with enough keys to satisfy any built-in placeholder. */
-    private static final Map<String, Object> FULL_META = Map.of(
-            "min", 1, "max", 10, "expected", "foo", "actual", "bar",
-            "divisor", 2, "maxScale", 3, "length", 5, "size", 5
+    private static final Map<String, Object> FULL_META = Map.ofEntries(
+            Map.entry("min", 1), Map.entry("max", 10),
+            Map.entry("expected", "foo"), Map.entry("actual", "bar"),
+            Map.entry("divisor", 2), Map.entry("maxScale", 3),
+            Map.entry("length", 5), Map.entry("size", 5),
+            Map.entry("allowed", List.of("a", "b"))
     );
 
     /**

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -168,6 +168,45 @@ class MapDecoderTest {
     }
 
     @Test
+    void stringOneOf() {
+        var dec = field("status", string().oneOf("active", "inactive", "pending"));
+        assertEquals("active", assertOk(dec.decode(Map.of("status", "active"))));
+        assertEquals("pending", assertOk(dec.decode(Map.of("status", "pending"))));
+        var result = dec.decode(Map.of("status", "deleted"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+                assertEquals(List.of("active", "inactive", "pending"), issue.meta().get("allowed"));
+                assertEquals("deleted", issue.meta().get("actual"));
+            }
+        }
+    }
+
+    @Test
+    void intOneOf() {
+        var dec = field("priority", int_().oneOf(1, 2, 3));
+        assertEquals(2, assertOk(dec.decode(Map.of("priority", 2))));
+        var result = dec.decode(Map.of("priority", 5));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals(ErrorCodes.NOT_ALLOWED, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
+    void longOneOf() {
+        var dec = field("id", long_().oneOf(100L, 200L, 300L));
+        assertEquals(200L, assertOk(dec.decode(Map.of("id", 200))));
+        var result = dec.decode(Map.of("id", 999));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals(ErrorCodes.NOT_ALLOWED, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
     void intConstraints() {
         var dec = field("n", int_().positive().multipleOf(3));
         assertEquals(9, assertOk(dec.decode(Map.of("n", 9))));


### PR DESCRIPTION
## Summary

- Add `oneOf(T...)` constraint method to `StringDecoder`, `IntDecoder`, and `LongDecoder`
- Introduce new `ErrorCodes.NOT_ALLOWED = "not_allowed"` error code
- Add default English message to `MessageResolver.DEFAULT` and `messages.properties`
- Allowed values are stored as an immutable sorted list for consistent error messages and O(1) lookup
- Error meta includes `allowed` (sorted list) and `actual` (the rejected value)

## Background

`enumOf(MyEnum.class)` covers Java enum only. The `flatMap` workaround is too verbose for this common pattern. `oneOf` fills the gap for arbitrary fixed-value lists on string and numeric types.

`DecimalDecoder` is excluded because `BigDecimal.equals` is scale-sensitive, making equality comparisons on decimal values unreliable.

## Test plan

- [ ] `stringOneOf` — verifies accepted values pass, rejected values produce `NOT_ALLOWED` with correct `allowed` and `actual` meta
- [ ] `intOneOf` — verifies accepted value passes, rejected value produces `NOT_ALLOWED`
- [ ] `longOneOf` — verifies accepted value passes, rejected value produces `NOT_ALLOWED`
- [ ] `ErrorCodesDefaultCoverageTest` — automatically verifies `NOT_ALLOWED` is covered in `MessageResolver.DEFAULT` and `messages.properties` via reflection

🤖 Generated with [Claude Code](https://claude.com/claude-code)