### PR TITLE
refactor: rename Combiner.apply() to map()

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ JsonDecoder<User> user() {
     return combine(
             field("email", email()),
             field("age", age())
-    ).apply(User::new);
+    ).map(User::new);
 }
 ```
 
@@ -207,7 +207,7 @@ MapDecoder<Config> config() {
     return combine(
             field("host", string().nonBlank()),
             field("port", int_().range(1, 65535))
-    ).apply(Config::new);
+    ).map(Config::new);
 }
 ```
 
@@ -420,7 +420,7 @@ JsonDecoder<User> user() {
             field("id", userId()),
             field("email", email()),
             field("balance", money())
-    ).apply(User::new);
+    ).map(User::new);
 }
 ```
 
@@ -433,7 +433,7 @@ This reads naturally as:
 
 ## Composition Patterns
 
-Raoh offers four distinct composition patterns — `combine(...).apply(...)`, `flatMap(...)`, `Result.map2(...)`, and `Result.traverse(...)` / `Decoder.list()`. Choosing the right one keeps error accumulation correct.
+Raoh offers four distinct composition patterns — `combine(...).map(...)`, `flatMap(...)`, `Result.map2(...)`, and `Result.traverse(...)` / `Decoder.list()`. Choosing the right one keeps error accumulation correct.
 
 See [docs/composition-patterns.md](docs/composition-patterns.md) for details and examples.
 
@@ -445,7 +445,7 @@ Given this decoder:
 var dec = combine(
         field("email", string().email()),
         field("age", int_().range(0, 150))
-).apply((email, age) -> Map.of("email", email, "age", age));
+).map((email, age) -> Map.of("email", email, "age", age));
 ```
 
 And this input:
@@ -506,7 +506,7 @@ JsonDecoder<Comment>[] self = new JsonDecoder[1];
 self[0] = combine(
         field("body", string().nonBlank()),
         withDefault(field("replies", list(lazy(() -> self[0]))), List.of())
-).apply(Comment::new);
+).map(Comment::new);
 ```
 
 ### `oneOf(...)`
@@ -518,11 +518,11 @@ var contact = oneOf(
         combine(
                 field("kind", literal("email")),
                 field("value", string().email())
-        ).apply((kind, value) -> new EmailContact(value)),
+        ).map((kind, value) -> new EmailContact(value)),
         combine(
                 field("kind", literal("phone")),
                 field("value", string().pattern(Pattern.compile("^\\d+$")))
-        ).apply((kind, value) -> new PhoneContact(value))
+        ).map((kind, value) -> new PhoneContact(value))
 );
 ```
 
@@ -637,7 +637,7 @@ Examples:
 combine(
         field("name", string()),
         field("address", address())
-).apply(User::new);
+).map(User::new);
 ```
 
 - cross-field validation

--- a/docs/boundary-modules.md
+++ b/docs/boundary-modules.md
@@ -55,18 +55,18 @@ record UserWithAddress(User user, Address address) {}
 JooqRecordDecoder<User> userDecoder = combine(
         field("name", string()),
         field("age",  int_())
-).apply(User::new)::decode;
+).map(User::new)::decode;
 
 JooqRecordDecoder<Address> addressDecoder = combine(
         field("city", string()),
         field("zip",  string())
-).apply(Address::new)::decode;
+).map(Address::new)::decode;
 
 // SELECT u.name, u.age, a.city, a.zip FROM users u JOIN addresses a ...
 Decoder<Record, UserWithAddress> dec = combine(
         nested(userDecoder),
         nested(addressDecoder)
-).apply(UserWithAddress::new);
+).map(UserWithAddress::new);
 ```
 
 `nested(dec)` applies another `JooqRecordDecoder` to the same flat record.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -14,7 +14,7 @@ If you know Zod, the closest equivalents are:
 | `z.literal("x")` | `literal("x")` |
 | `z.array(dec)` | `list(dec)` |
 | `z.record(dec)` | `map(dec)` |
-| `z.object({...})` | `combine(field(...), ...).apply(...)` |
+| `z.object({...})` | `combine(field(...), ...).map(...)` |
 | `.optional()` | `optionalField(name, dec)` |
 | `.nullable()` | `nullable(dec)` |
 | `.default(v)` | `withDefault(dec, v)` |
@@ -37,7 +37,7 @@ So the typical Raoh shape is:
 combine(
         field("email", string().trim().toLowerCase().email().map(Email::new)),
         field("age", int_().range(0, 150).map(Age::new))
-).apply(User::new);
+).map(User::new);
 ```
 
 The schema is already the parsing pipeline.
@@ -65,14 +65,14 @@ Rough correspondences:
 | `map` | `map(...)` |
 | `andThen` | `flatMap(...)` |
 | `oneOf` | `oneOf(...)` |
-| building records with `map2`, `map3`, ... | `combine(...).apply(...)` |
+| building records with `map2`, `map3`, ... | `combine(...).map(...)` |
 
 The most important differences are:
 
 - Elm decoders are primarily JSON decoders, while Raoh is generic over input type and ships JSON and `Map<String, Object>` boundaries out of the box
 - Elm usually models failure as decoder failure text, while Raoh emphasizes structured issues with `path`, `code`, `message`, and `meta`
 - Raoh has an explicit applicative/monadic split:
-  `combine(...).apply(...)` accumulates independent field errors, while `flatMap(...)` handles dependent parsing
+  `combine(...).map(...)` accumulates independent field errors, while `flatMap(...)` handles dependent parsing
 
 If you know Elm, this Raoh code should feel familiar:
 
@@ -82,7 +82,7 @@ JsonDecoder<User> user() {
             field("id", string().uuid().map(UserId::new)),
             field("email", string().trim().toLowerCase().email().map(Email::new)),
             field("age", int_().range(0, 150).map(Age::new))
-    ).apply(User::new);
+    ).map(User::new);
 }
 ```
 

--- a/docs/composition-patterns.md
+++ b/docs/composition-patterns.md
@@ -2,7 +2,7 @@
 
 Raoh offers four distinct composition patterns. Choosing the right one keeps error accumulation correct.
 
-## Pattern 1: Same input, independent fields — `combine(...).apply(...)`
+## Pattern 1: Same input, independent fields — `combine(...).map(...)`
 
 Use this for normal object decoding from a single input source.
 All field errors are accumulated even when multiple fields fail.
@@ -11,7 +11,7 @@ All field errors are accumulated even when multiple fields fail.
 combine(
         field("name", string().nonBlank()),
         field("age", int_().range(0, 150))
-).apply(Person::new);
+).map(Person::new);
 ```
 
 If `name` and `age` are both invalid, you get both errors back.
@@ -94,7 +94,7 @@ If elements 1 and 3 fail, both errors are reported with their respective paths �
 
 | Situation | Tool |
 | --- | --- |
-| Multiple fields from the same input | `combine(...).apply(...)` |
+| Multiple fields from the same input | `combine(...).map(...)` |
 | Next step depends on a previous result | `flatMap(...)` |
 | Two independent results from different inputs | `Result.map2(...)` |
 | Variable-length list, accumulate all errors | `Result.traverse(...)` / `Decoder.list()` |

--- a/examples/spring/src/main/java/net/unit8/raoh/examples/spring/membership/JsonMembershipDecoders.java
+++ b/examples/spring/src/main/java/net/unit8/raoh/examples/spring/membership/JsonMembershipDecoders.java
@@ -34,7 +34,7 @@ public final class JsonMembershipDecoders {
                     // in the EmailAddress value object after all validations pass.
                     field("email", string().trim().toLowerCase().email()
                             .maxLength(200).map(EmailAddress::new))
-            ).apply(CreateUserCommand::new));
+            ).map(CreateUserCommand::new));
 
     /**
      * Decodes a JSON request body into a group-creation command.
@@ -48,7 +48,7 @@ public final class JsonMembershipDecoders {
                     field("name", string().trim().nonBlank().maxLength(100)),
                     Decoders.withDefault(
                             field("description", string().maxLength(500)), "")
-            ).apply(CreateGroupCommand::new));
+            ).map(CreateGroupCommand::new));
 
     /**
      * Decodes a JSON request body into a membership-addition command.
@@ -63,7 +63,7 @@ public final class JsonMembershipDecoders {
                     Decoders.withDefault(
                             field("role", enumOf(MembershipRole.class)),
                             MembershipRole.MEMBER)
-            ).apply(AddMemberCommand::new));
+            ).map(AddMemberCommand::new));
 
     // ── Command records ─────────────────────────────────────────────
 

--- a/examples/spring/src/main/java/net/unit8/raoh/examples/spring/membership/MapMembershipDecoders.java
+++ b/examples/spring/src/main/java/net/unit8/raoh/examples/spring/membership/MapMembershipDecoders.java
@@ -31,7 +31,7 @@ public final class MapMembershipDecoders {
             field("id", long_()).map(UserId::new),
             field("name", string()),
             field("email", string()).map(EmailAddress::new)
-    ).apply(User::new);
+    ).map(User::new);
 
     /** Decodes a JDBC row into a {@link Group}. */
     public static final Decoder<Map<String, Object>, Group> GROUP_ROW = combine(
@@ -39,7 +39,7 @@ public final class MapMembershipDecoders {
             field("name", string()),
             // description is NOT NULL DEFAULT '' in the schema, so string() is correct here.
             field("description", string())
-    ).apply(Group::new);
+    ).map(Group::new);
 
     /** Decodes a JDBC join row into a {@link GroupMembership}. */
     public static final Decoder<Map<String, Object>, GroupMembership> GROUP_MEMBERSHIP_ROW =
@@ -50,7 +50,7 @@ public final class MapMembershipDecoders {
                     // (case-insensitive). The DB column is NOT NULL so string() without nullable
                     // is appropriate as the base.
                     field("role", enumOf(MembershipRole.class))
-            ).apply(GroupMembership::new);
+            ).map(GroupMembership::new);
 
     /**
      * Decodes a user row plus a list of group-membership rows into {@link UserWithGroups},

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -100,7 +100,7 @@ public final class JooqRecordDecoders {
      * Decoder<Record, UserWithAddress> dec = combine(
      *     nested(userDecoder),
      *     nested(addressDecoder)
-     * ).apply(UserWithAddress::new);
+     * ).map(UserWithAddress::new);
      * }</pre>
      *
      * @param <T> the decoded value type
@@ -116,14 +116,14 @@ public final class JooqRecordDecoders {
     /**
      * Combines two field decoders, accumulating all errors.
      *
-     * <p>Overloads for 2-16 decoders are provided. Call {@code .apply(MyRecord::new)} on the
+     * <p>Overloads for 2-16 decoders are provided. Call {@code .map(MyRecord::new)} on the
      * returned combiner to produce the final {@code Decoder<Record, T>}.
      *
      * @param <A> the first decoded type
      * @param <B> the second decoded type
      * @param da  the first decoder
      * @param db  the second decoder
-     * @return a combiner that can be finished with {@code apply}
+     * @return a combiner that can be finished with {@code map}
      */
     public static <A, B> Combiner2<org.jooq.Record, A, B> combine(
             Decoder<org.jooq.Record, A> da, Decoder<org.jooq.Record, B> db) {
@@ -139,7 +139,7 @@ public final class JooqRecordDecoders {
      * @param da  the first decoder
      * @param db  the second decoder
      * @param dc  the third decoder
-     * @return a combiner that can be finished with {@code apply}
+     * @return a combiner that can be finished with {@code map}
      * @see Decoders#combine(Decoder, Decoder, Decoder)
      */
     public static <A, B, C> Combiner3<org.jooq.Record, A, B, C> combine(
@@ -159,7 +159,7 @@ public final class JooqRecordDecoders {
      * @param db  the second decoder
      * @param dc  the third decoder
      * @param dd  the fourth decoder
-     * @return a combiner that can be finished with {@code apply}
+     * @return a combiner that can be finished with {@code map}
      * @see Decoders#combine(Decoder, Decoder, Decoder, Decoder)
      */
     public static <A, B, C, D> Combiner4<org.jooq.Record, A, B, C, D> combine(
@@ -347,7 +347,7 @@ public final class JooqRecordDecoders {
      *
      * @param <T>      the output type
      * @param decoders the decoders to combine
-     * @return a combiner on which {@code .apply(f)} can be called
+     * @return a combiner on which {@code .map(f)} can be called
      * @see Decoders#combine(List)
      */
     public static <T> CombinerList<org.jooq.Record> combine(List<Decoder<org.jooq.Record, ?>> decoders) {

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -61,7 +61,7 @@ class JooqDecoderTest {
                 field("name",  string()),
                 field("age",   int_()),
                 field("email", string())
-        ).apply(User::new);
+        ).map(User::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Ok.class, result);
@@ -108,12 +108,12 @@ class JooqDecoderTest {
             field("name",  string()),
             field("age",   int_()),
             field("email", string())
-    ).apply(User::new)::decode;
+    ).map(User::new)::decode;
 
     private static final JooqRecordDecoder<Address> ADDRESS_DECODER = combine(
             field("city", string()),
             field("zip",  string())
-    ).apply(Address::new)::decode;
+    ).map(Address::new)::decode;
 
     @Test
     void flatJoinResultToNestedDomainType() {
@@ -128,7 +128,7 @@ class JooqDecoderTest {
         Decoder<org.jooq.Record, UserWithAddress> dec = combine(
                 nested(USER_DECODER),
                 nested(ADDRESS_DECODER)
-        ).apply(UserWithAddress::new);
+        ).map(UserWithAddress::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Ok.class, result);
@@ -152,7 +152,7 @@ class JooqDecoderTest {
         Decoder<org.jooq.Record, UserWithAddress> dec = combine(
                 nested(USER_DECODER),
                 nested(ADDRESS_DECODER)
-        ).apply(UserWithAddress::new);
+        ).map(UserWithAddress::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Err.class, result);
@@ -169,7 +169,7 @@ class JooqDecoderTest {
             field("name",  string()),
             field("email", string()),
             field("role",  enumOf(Role.class))
-    ).apply(Employee::new)::decode;
+    ).map(Employee::new)::decode;
 
     private static JooqRecordDecoder<Optional<Department>> optDeptDecoder() {
         return (rec, path) -> {
@@ -202,7 +202,7 @@ class JooqDecoderTest {
         Decoder<org.jooq.Record, EmployeeWithDepartment> dec = combine(
                 nested(EMPLOYEE_DECODER),
                 optDeptDecoder()
-        ).apply(EmployeeWithDepartment::new);
+        ).map(EmployeeWithDepartment::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Ok.class, result);
@@ -226,7 +226,7 @@ class JooqDecoderTest {
         Decoder<org.jooq.Record, EmployeeWithDepartment> dec = combine(
                 nested(EMPLOYEE_DECODER),
                 optDeptDecoder()
-        ).apply(EmployeeWithDepartment::new);
+        ).map(EmployeeWithDepartment::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Ok.class, result);
@@ -242,7 +242,7 @@ class JooqDecoderTest {
     private static final JooqRecordDecoder<Money> MONEY_DECODER = combine(
             field("unit_price", decimal()),
             field("currency",   string())
-    ).apply(Money::new)::decode;
+    ).map(Money::new)::decode;
 
     @Test
     void valueObjectComposedFromTwoColumns() {
@@ -259,7 +259,7 @@ class JooqDecoderTest {
                 field("name",     string()),
                 field("quantity", int_()),
                 nested(MONEY_DECODER)
-        ).apply(OrderLine::new);
+        ).map(OrderLine::new);
 
         var result = dec.decode(rec);
         assertInstanceOf(Ok.class, result);

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * var userDecoder = combine(
  *     field("name", string().minLength(1)),
  *     field("age", int_().range(0, 150))
- * ).apply(User::new);
+ * ).map(User::new);
  * }</pre>
  */
 public final class JsonDecoders {

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -73,7 +73,7 @@ class JsonDecoderTest {
                 field("prefecture", enumOf(Prefecture.class)),
                 field("city", string().maxLength(100)),
                 field("street", string().maxLength(200))
-        ).apply(Address::new);
+        ).map(Address::new);
     }
 
     static Decoder<JsonNode, User> user() {
@@ -82,7 +82,7 @@ class JsonDecoderTest {
                 field("email", email()),
                 field("age", age()),
                 field("address", address())
-        ).apply(User::new);
+        ).map(User::new);
     }
 
     static Decoder<JsonNode, Money> money() {
@@ -395,7 +395,7 @@ class JsonDecoderTest {
                 field("body", string()),
                 Decoders.withDefault(
                         field("replies", list(Decoders.lazy(() -> holder[0]))), List.of())
-        ).apply(Comment::new);
+        ).map(Comment::new);
 
         var json = parse("""
                 {
@@ -470,11 +470,11 @@ class JsonDecoderTest {
                 combine(
                         field("kind", literal("email")),
                         field("value", string().email())
-                ).apply((kind, value) -> new EmailContact(new Email(value))),
+                ).map((kind, value) -> new EmailContact(new Email(value))),
                 combine(
                         field("kind", literal("phone")),
                         field("value", string().pattern(java.util.regex.Pattern.compile("^\\d+$")))
-                ).apply((kind, value) -> new Phone(value))
+                ).map((kind, value) -> new Phone(value))
         );
         var result = dec.decode(parse("{\"kind\":\"sms\",\"value\":\"abc\"}"));
 
@@ -495,7 +495,7 @@ class JsonDecoderTest {
         var dec = strict(combine(
                 field("name", string()),
                 field("age", int_())
-        ).apply((name, age) -> Map.of("name", name, "age", age)), java.util.Set.of("name", "age"));
+        ).map((name, age) -> Map.of("name", name, "age", age)), java.util.Set.of("name", "age"));
 
         var result = dec.decode(parse("{\"name\":\"Taro\",\"age\":20,\"extra\":true}"));
         switch (result) {

--- a/raoh/src/main/java/net/unit8/raoh/Decoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/Decoders.java
@@ -141,7 +141,7 @@ public final class Decoders {
      *
      * @param <I>      the input type
      * @param decoders the decoders to combine; must not be empty
-     * @return a combiner on which {@code .apply(f)} or {@code .flatMap(f)} can be called
+     * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      */
     public static <I> CombinerList<I> combine(List<Decoder<I, ?>> decoders) {
         return new CombinerList<>(decoders);

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner10.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner10.java
@@ -45,7 +45,7 @@ public record Combiner10<I, A, B, C, D, E, F, G, H, J, K>(Decoder<I, A> da, Deco
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function10<A, B, C, D, E, F, G, H, J, K, T> f) {
+    public <T> Decoder<I, T> map(Function10<A, B, C, D, E, F, G, H, J, K, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -65,7 +65,7 @@ public record Combiner10<I, A, B, C, D, E, F, G, H, J, K>(Decoder<I, A> da, Deco
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -95,14 +95,14 @@ public record Combiner10<I, A, B, C, D, E, F, G, H, J, K>(Decoder<I, A> da, Deco
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function10<A, B, C, D, E, F, G, H, J, K, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner11.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner11.java
@@ -47,7 +47,7 @@ public record Combiner11<I, A, B, C, D, E, F, G, H, J, K, L>(Decoder<I, A> da, D
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function11<A, B, C, D, E, F, G, H, J, K, L, T> f) {
+    public <T> Decoder<I, T> map(Function11<A, B, C, D, E, F, G, H, J, K, L, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -68,7 +68,7 @@ public record Combiner11<I, A, B, C, D, E, F, G, H, J, K, L>(Decoder<I, A> da, D
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -99,14 +99,14 @@ public record Combiner11<I, A, B, C, D, E, F, G, H, J, K, L>(Decoder<I, A> da, D
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function11<A, B, C, D, E, F, G, H, J, K, L, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner12.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner12.java
@@ -49,7 +49,7 @@ public record Combiner12<I, A, B, C, D, E, F, G, H, J, K, L, M>(Decoder<I, A> da
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function12<A, B, C, D, E, F, G, H, J, K, L, M, T> f) {
+    public <T> Decoder<I, T> map(Function12<A, B, C, D, E, F, G, H, J, K, L, M, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -71,7 +71,7 @@ public record Combiner12<I, A, B, C, D, E, F, G, H, J, K, L, M>(Decoder<I, A> da
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -103,14 +103,14 @@ public record Combiner12<I, A, B, C, D, E, F, G, H, J, K, L, M>(Decoder<I, A> da
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function12<A, B, C, D, E, F, G, H, J, K, L, M, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner13.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner13.java
@@ -51,7 +51,7 @@ public record Combiner13<I, A, B, C, D, E, F, G, H, J, K, L, M, N>(Decoder<I, A>
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function13<A, B, C, D, E, F, G, H, J, K, L, M, N, T> f) {
+    public <T> Decoder<I, T> map(Function13<A, B, C, D, E, F, G, H, J, K, L, M, N, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -74,7 +74,7 @@ public record Combiner13<I, A, B, C, D, E, F, G, H, J, K, L, M, N>(Decoder<I, A>
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -107,14 +107,14 @@ public record Combiner13<I, A, B, C, D, E, F, G, H, J, K, L, M, N>(Decoder<I, A>
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function13<A, B, C, D, E, F, G, H, J, K, L, M, N, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner14.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner14.java
@@ -53,7 +53,7 @@ public record Combiner14<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O>(Decoder<I,
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function14<A, B, C, D, E, F, G, H, J, K, L, M, N, O, T> f) {
+    public <T> Decoder<I, T> map(Function14<A, B, C, D, E, F, G, H, J, K, L, M, N, O, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -77,7 +77,7 @@ public record Combiner14<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O>(Decoder<I,
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -111,14 +111,14 @@ public record Combiner14<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O>(Decoder<I,
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function14<A, B, C, D, E, F, G, H, J, K, L, M, N, O, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner15.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner15.java
@@ -55,7 +55,7 @@ public record Combiner15<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P>(Decoder
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function15<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, T> f) {
+    public <T> Decoder<I, T> map(Function15<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -80,7 +80,7 @@ public record Combiner15<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P>(Decoder
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -115,14 +115,14 @@ public record Combiner15<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P>(Decoder
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function15<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner16.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner16.java
@@ -57,7 +57,7 @@ public record Combiner16<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q>(Deco
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function16<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q, T> f) {
+    public <T> Decoder<I, T> map(Function16<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -83,7 +83,7 @@ public record Combiner16<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q>(Deco
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -119,14 +119,14 @@ public record Combiner16<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q>(Deco
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function16<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner2.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner2.java
@@ -29,7 +29,7 @@ public record Combiner2<I, A, B>(Decoder<I, A> da, Decoder<I, B> db) {
      * @param f   the constructor function
      * @return a decoder that runs all decoders and accumulates errors
      */
-    public <T> Decoder<I, T> apply(BiFunction<A, B, T> f) {
+    public <T> Decoder<I, T> map(BiFunction<A, B, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -38,7 +38,7 @@ public record Combiner2<I, A, B>(Decoder<I, A> da, Decoder<I, B> db) {
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -57,14 +57,14 @@ public record Combiner2<I, A, B>(Decoder<I, A> da, Decoder<I, B> db) {
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(BiFunction<A, B, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner3.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner3.java
@@ -31,7 +31,7 @@ public record Combiner3<I, A, B, C>(Decoder<I, A> da, Decoder<I, B> db, Decoder<
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function3<A, B, C, T> f) {
+    public <T> Decoder<I, T> map(Function3<A, B, C, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -44,7 +44,7 @@ public record Combiner3<I, A, B, C>(Decoder<I, A> da, Decoder<I, B> db, Decoder<
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -67,14 +67,14 @@ public record Combiner3<I, A, B, C>(Decoder<I, A> da, Decoder<I, B> db, Decoder<
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function3<A, B, C, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner4.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner4.java
@@ -33,7 +33,7 @@ public record Combiner4<I, A, B, C, D>(Decoder<I, A> da, Decoder<I, B> db, Decod
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function4<A, B, C, D, T> f) {
+    public <T> Decoder<I, T> map(Function4<A, B, C, D, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -47,7 +47,7 @@ public record Combiner4<I, A, B, C, D>(Decoder<I, A> da, Decoder<I, B> db, Decod
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -71,14 +71,14 @@ public record Combiner4<I, A, B, C, D>(Decoder<I, A> da, Decoder<I, B> db, Decod
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function4<A, B, C, D, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner5.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner5.java
@@ -35,7 +35,7 @@ public record Combiner5<I, A, B, C, D, E>(Decoder<I, A> da, Decoder<I, B> db, De
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function5<A, B, C, D, E, T> f) {
+    public <T> Decoder<I, T> map(Function5<A, B, C, D, E, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -50,7 +50,7 @@ public record Combiner5<I, A, B, C, D, E>(Decoder<I, A> da, Decoder<I, B> db, De
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -75,14 +75,14 @@ public record Combiner5<I, A, B, C, D, E>(Decoder<I, A> da, Decoder<I, B> db, De
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function5<A, B, C, D, E, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner6.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner6.java
@@ -37,7 +37,7 @@ public record Combiner6<I, A, B, C, D, E, F>(Decoder<I, A> da, Decoder<I, B> db,
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function6<A, B, C, D, E, F, T> f) {
+    public <T> Decoder<I, T> map(Function6<A, B, C, D, E, F, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -53,7 +53,7 @@ public record Combiner6<I, A, B, C, D, E, F>(Decoder<I, A> da, Decoder<I, B> db,
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -79,14 +79,14 @@ public record Combiner6<I, A, B, C, D, E, F>(Decoder<I, A> da, Decoder<I, B> db,
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function6<A, B, C, D, E, F, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner7.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner7.java
@@ -39,7 +39,7 @@ public record Combiner7<I, A, B, C, D, E, F, G>(Decoder<I, A> da, Decoder<I, B> 
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function7<A, B, C, D, E, F, G, T> f) {
+    public <T> Decoder<I, T> map(Function7<A, B, C, D, E, F, G, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -56,7 +56,7 @@ public record Combiner7<I, A, B, C, D, E, F, G>(Decoder<I, A> da, Decoder<I, B> 
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -83,14 +83,14 @@ public record Combiner7<I, A, B, C, D, E, F, G>(Decoder<I, A> da, Decoder<I, B> 
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function7<A, B, C, D, E, F, G, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner8.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner8.java
@@ -41,7 +41,7 @@ public record Combiner8<I, A, B, C, D, E, F, G, H>(Decoder<I, A> da, Decoder<I, 
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function8<A, B, C, D, E, F, G, H, T> f) {
+    public <T> Decoder<I, T> map(Function8<A, B, C, D, E, F, G, H, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -59,7 +59,7 @@ public record Combiner8<I, A, B, C, D, E, F, G, H>(Decoder<I, A> da, Decoder<I, 
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -87,14 +87,14 @@ public record Combiner8<I, A, B, C, D, E, F, G, H>(Decoder<I, A> da, Decoder<I, 
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function8<A, B, C, D, E, F, G, H, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Combiner9.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Combiner9.java
@@ -43,7 +43,7 @@ public record Combiner9<I, A, B, C, D, E, F, G, H, J>(Decoder<I, A> da, Decoder<
      * @return a decoder that runs all decoders and accumulates errors
      */
     @SuppressWarnings("unchecked")
-    public <T> Decoder<I, T> apply(Function9<A, B, C, D, E, F, G, H, J, T> f) {
+    public <T> Decoder<I, T> map(Function9<A, B, C, D, E, F, G, H, J, T> f) {
         return (in, path) -> {
             var va = Validated.fromResult(da.decode(in, path));
             var vb = Validated.fromResult(db.decode(in, path));
@@ -62,7 +62,7 @@ public record Combiner9<I, A, B, C, D, E, F, G, H, J>(Decoder<I, A> da, Decoder<
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * @param <T> the output type
      * @param f   a function returning a {@link Result}
@@ -91,14 +91,14 @@ public record Combiner9<I, A, B, C, D, E, F, G, H, J>(Decoder<I, A> da, Decoder<
     }
 
     /**
-     * Like {@link #apply}, but additionally rejects unknown fields.
+     * Like {@link #map}, but additionally rejects unknown fields.
      *
      * @param <T> the output type
      * @param f   the constructor function
      * @return a strict decoder that fails on unknown fields
      */
     public <T> Decoder<I, T> strict(Function9<A, B, C, D, E, F, G, H, J, T> f) {
-        return Decoders.strict(apply(f), knownFields());
+        return Decoders.strict(map(f), knownFields());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/combinator/CombinerList.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/CombinerList.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
  * Holds an arbitrary number of decoders for applicative-style validation with error accumulation.
  * Returned by {@link net.unit8.raoh.Decoders#combine(List)} as a fallback for more than 16 fields.
  *
- * <p>Because the arity is not statically known, {@link #apply} and {@link #flatMap}
+ * <p>Because the arity is not statically known, {@link #map} and {@link #flatMap}
  * receive decoded values as an untyped {@code Object[]}. To use a constructor reference
  * ({@code MyRow::new}), add an {@code Object[]}-accepting constructor to your record:
  *
@@ -26,7 +26,7 @@ import java.util.function.Function;
  *     field("name", string()),
  *     field("id",   long_()),
  *     // 17 or more fields
- * )).apply(MyRow::new)
+ * )).map(MyRow::new)
  * }</pre>
  *
  * @param <I>      the input type
@@ -43,7 +43,7 @@ public record CombinerList<I>(List<Decoder<I, ?>> decoders) {
      * @param f   a function receiving all decoded values as an untyped {@code Object[]}
      * @return a decoder that runs all decoders and accumulates errors
      */
-    public <T> Decoder<I, T> apply(Function<Object[], T> f) {
+    public <T> Decoder<I, T> map(Function<Object[], T> f) {
         return (in, path) -> {
             var vals = new Validated<?>[decoders.size()];
             for (int i = 0; i < decoders.size(); i++) {
@@ -54,7 +54,7 @@ public record CombinerList<I>(List<Decoder<I, ?>> decoders) {
     }
 
     /**
-     * Like {@link #apply}, but the constructor function may itself return a {@link Result}.
+     * Like {@link #map}, but the constructor function may itself return a {@link Result}.
      *
      * <p>If the combined decoding succeeds, the result of {@code f} is flat-mapped;
      * any issues it produces are rebased to the current path.

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -86,13 +86,13 @@ public final class MapDecoders {
      * Decoder<Map<String, Object>, Address> addressDecoder = combine(
      *     field("zip",  string().minLength(3)),
      *     field("city", string())
-     * ).apply(Address::new);
+     * ).map(Address::new);
      *
      * // nested() lets you embed it inside an outer field() call
      * Decoder<Map<String, Object>, User> userDecoder = combine(
      *     field("name",    string()),
      *     field("address", nested(addressDecoder))  // ← nested() required here
-     * ).apply(User::new);
+     * ).map(User::new);
      * }</pre>
      *
      * <p>Without {@code nested()}, the compiler rejects the second {@code field()} call because
@@ -174,14 +174,14 @@ public final class MapDecoders {
     /**
      * Combines two decoders so that all fields are decoded in parallel with error accumulation.
      *
-     * <p>Overloads for 2–16 decoders are provided. Call {@code .apply(MyRecord::new)} on the
+     * <p>Overloads for 2–16 decoders are provided. Call {@code .map(MyRecord::new)} on the
      * returned combiner to produce the final {@code Decoder<Map<String, Object>, T>}.
      *
      * @param <A> the first decoded type
      * @param <B> the second decoded type
      * @param da  the first decoder
      * @param db  the second decoder
-     * @return a combiner that can be finished with {@code apply}
+     * @return a combiner that can be finished with {@code map}
      */
     public static <A, B> Combiner2<Map<String, Object>, A, B> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db) {
@@ -196,7 +196,7 @@ public final class MapDecoders {
      * @param da  the first decoder
      * @param db  the second decoder
      * @param dc  the third decoder
-     * @return a combiner that can be finished with {@code apply}
+     * @return a combiner that can be finished with {@code map}
      */
     public static <A, B, C> Combiner3<Map<String, Object>, A, B, C> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,

--- a/raoh/src/test/java/net/unit8/raoh/CombineListTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/CombineListTest.java
@@ -58,7 +58,7 @@ class CombineListTest {
 
     @Test
     void allFieldsSucceed() {
-        var decoder = Decoders.combine(DECODERS_17).apply(Row17::new);
+        var decoder = Decoders.combine(DECODERS_17).map(Row17::new);
         var result  = decoder.decode(allValid());
         assertInstanceOf(Ok.class, result);
         var row = ((Ok<Row17>) result).value();
@@ -71,7 +71,7 @@ class CombineListTest {
         var input = new java.util.HashMap<>(allValid());
         input.remove("f5");  // missing → required error
 
-        var decoder = Decoders.combine(DECODERS_17).apply(Row17::new);
+        var decoder = Decoders.combine(DECODERS_17).map(Row17::new);
         var result  = decoder.decode(input);
         assertInstanceOf(Err.class, result);
         var issues  = ((Err<Row17>) result).issues().asList();
@@ -85,7 +85,7 @@ class CombineListTest {
         input.remove("f1");
         input.remove("f17");
 
-        var decoder = Decoders.combine(DECODERS_17).apply(Row17::new);
+        var decoder = Decoders.combine(DECODERS_17).map(Row17::new);
         var result  = decoder.decode(input);
         assertInstanceOf(Err.class, result);
         var issues  = ((Err<Row17>) result).issues().asList();
@@ -96,7 +96,7 @@ class CombineListTest {
     void constructorReferenceViaObjectArrayCtor() {
         // Verify that MyRow::new works as a method reference when
         // an Object[]-accepting constructor is defined on the record.
-        var decoder = Decoders.combine(DECODERS_17).apply(Row17::new);
+        var decoder = Decoders.combine(DECODERS_17).map(Row17::new);
         assertNotNull(decoder);
         assertInstanceOf(Ok.class, decoder.decode(allValid()));
     }

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -69,7 +69,7 @@ class MapDecoderTest {
                 field("prefecture", enumOf(Prefecture.class)),
                 field("city", string().maxLength(100)),
                 field("street", string().maxLength(200))
-        ).apply(Address::new);
+        ).map(Address::new);
     }
 
     static Decoder<Map<String, Object>, User> user() {
@@ -78,7 +78,7 @@ class MapDecoderTest {
                 field("email", email()),
                 field("age", age()),
                 field("address", nested(address()))
-        ).apply(User::new);
+        ).map(User::new);
     }
 
     static Decoder<Map<String, Object>, Money> money() {
@@ -472,8 +472,8 @@ class MapDecoderTest {
                 field("address", nested(combine(
                         field("city", string()),
                         field("zip", string().fixedLength(7))
-                ).apply((city, zip) -> Map.of("city", city, "zip", zip))))
-        ).apply((name, addr) -> Map.of("name", name, "address", addr));
+                ).map((city, zip) -> Map.of("city", city, "zip", zip))))
+        ).map((name, addr) -> Map.of("name", name, "address", addr));
 
         var input = Map.<String, Object>of(
                 "name", "Taro",
@@ -501,11 +501,11 @@ class MapDecoderTest {
                 combine(
                         field("kind", literal("email")),
                         field("value", string().email())
-                ).apply((kind, value) -> new EmailContact(new Email(value))),
+                ).map((kind, value) -> new EmailContact(new Email(value))),
                 combine(
                         field("kind", literal("phone")),
                         field("value", string().pattern(java.util.regex.Pattern.compile("^\\d+$")))
-                ).apply((kind, value) -> new Phone(value))
+                ).map((kind, value) -> new Phone(value))
         );
 
         var result = dec.decode(Map.of("kind", "sms", "value", "abc"));
@@ -530,7 +530,7 @@ class MapDecoderTest {
         var dec = strict(combine(
                 field("name", string()),
                 field("age", int_())
-        ).apply((name, age) -> Map.of("name", name, "age", age)), java.util.Set.of("name", "age"));
+        ).map((name, age) -> Map.of("name", name, "age", age)), java.util.Set.of("name", "age"));
 
         var result = dec.decode(Map.of("name", "Taro", "age", 20, "extra", true));
         switch (result) {


### PR DESCRIPTION
## Summary

- Renamed `Combiner2`〜`Combiner16` and `CombinerList` の `apply()` method to `map()`, creating a natural `map`/`flatMap` pair that is idiomatic in Java
- Updated all Javadoc references (`{@link #apply}` → `{@link #map}`, `{@code apply}` → `{@code map}`)
- Updated all test files, example code, and documentation (`docs/`, `README.md`)
- `Result.map2` is left unchanged — arity suffix is appropriate for static utility methods

## Test plan

- [x] `mvn test` — all tests pass (30 files changed, 130 insertions, 130 deletions)
- [ ] Verify no remaining `apply` references in Combiner context (`grep` for stray references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)