### PR TITLE
fix: improve Ok/Err toString() display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Notes:
 - **`nonBlank()`** currently returns error code `required` / message `is required` (not `must not be blank`). See issue #16.
 - **`Presence` toString**: `Present[value=hello]`, `PresentNull[]`, `Absent[]`.
 - **`optionalField` absent** → `Ok[Optional.empty]`, not `Ok[null]`.
-- **`oneOf` failure** → `Err[: no variant matched]`.
+- **`oneOf` failure** → `Err[/: no variant matched]`.
 - **`field("x", subDec)`** where `subDec: Decoder<Map<String,Object>,T>` requires `nested(subDec)`. See issue #17.
 - **`list(subDec)`** where `subDec: Decoder<Map<String,Object>,T>` requires `list(nested(subDec))`.
 - **`Path.of(String)`** does not exist — use `Path.ROOT.append("x")`. See issue #18.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,58 @@ When adding a new error code and its associated decoder constraint, verify all o
 - **`messages.properties` templates must reference the same meta keys**: The placeholders in `raoh.<code>=...` must match the keys actually put into the meta map by the decoder. Mismatches silently produce literal `{key}` output.
 - **`MessageResolver.DEFAULT` and `messages.properties` must both be updated**: The `ErrorCodesDefaultCoverageTest` reflection test enforces this automatically — a new `ErrorCodes` constant without coverage in both will fail the build.
 
+## Tutorial Verification with jetshell
+
+Use jetshell to verify code snippets in `docs/tutorial.ja.md`.
+
+### Setup
+
+jetshell must be on PATH. Run in non-interactive (batch) mode by piping a script file:
+
+```sh
+cat input.jsh | jetshell -nostartup
+```
+
+### Input file template
+
+Build the project first to populate `target/dependency/`:
+
+```sh
+mvn -f raoh/pom.xml dependency:copy-dependencies -q
+```
+
+Every verification script must start with these lines (adjust the path to the repo root as needed):
+
+```text
+/classpath raoh/target/raoh-*.jar
+/classpath raoh/target/dependency/*.jar
+import net.unit8.raoh.*;
+import net.unit8.raoh.map.*;
+import net.unit8.raoh.builtin.*;
+import static net.unit8.raoh.map.MapDecoders.*;
+import static net.unit8.raoh.Decoders.*;
+import java.util.*;
+```
+
+Notes:
+
+- `/classpath` takes one path per line — glob expansion does not work across `:` separators.
+- Do **not** `import static net.unit8.raoh.ObjectDecoders.*` alongside `MapDecoders.*`; both define `string()` and the import becomes ambiguous. `MapDecoders` re-exports everything needed for `Map`-based decoding.
+
+### Known gotchas
+
+- **Root-path errors** print as `Err[/: message]` (root path is shown as `/`).
+- **`nonBlank()`** currently returns error code `required` / message `is required` (not `must not be blank`). See issue #16.
+- **`Presence` toString**: `Present[value=hello]`, `PresentNull[]`, `Absent[]`.
+- **`optionalField` absent** → `Ok[Optional.empty]`, not `Ok[null]`.
+- **`oneOf` failure** → `Err[: no variant matched]`.
+- **`field("x", subDec)`** where `subDec: Decoder<Map<String,Object>,T>` requires `nested(subDec)`. See issue #17.
+- **`list(subDec)`** where `subDec: Decoder<Map<String,Object>,T>` requires `list(nested(subDec))`.
+- **`Path.of(String)`** does not exist — use `Path.ROOT.append("x")`. See issue #18.
+- **`Decoder.fail()`** does not exist — use `(in, path) -> Result.fail(path, code, message)`. See issue #19.
+- **`flatMap` returning `Decoder`** does not work — `flatMap` expects `Function<T, Result<U>>`, not `Function<T, Decoder<I,U>>`. Use a full `Decoder<I,T>` lambda instead.
+- **`sealed interface`** in JShell requires all permits classes declared in the same snippet; use plain `interface` as a workaround.
+
 ## Development Flow
 
 Features progress through this lifecycle:

--- a/raoh/src/main/java/net/unit8/raoh/Err.java
+++ b/raoh/src/main/java/net/unit8/raoh/Err.java
@@ -20,12 +20,21 @@ public record Err<T>(Issues issues) implements Result<T> {
         return (Err<U>) this;
     }
 
+    /**
+     * Returns a concise string representation of this failed result.
+     *
+     * <p>Each issue is formatted as {@code path: message}, where the root path
+     * is rendered as {@code /}. Multiple issues are comma-separated.
+     * Example: {@code Err[/: is required, /name: must not be blank]}
+     *
+     * @return a string of the form {@code Err[path: message, ...]}
+     */
     @Override
     public String toString() {
         return issues.asList().stream()
             .map(issue -> {
-                String p = issue.path().toString();
-                return (p.isEmpty() ? "/" : p) + ": " + issue.message();
+                String path = issue.path().toString();
+                return (path.isEmpty() ? "/" : path) + ": " + issue.message();
             })
             .collect(Collectors.joining(", ", "Err[", "]"));
     }

--- a/raoh/src/main/java/net/unit8/raoh/Err.java
+++ b/raoh/src/main/java/net/unit8/raoh/Err.java
@@ -1,5 +1,7 @@
 package net.unit8.raoh;
 
+import java.util.stream.Collectors;
+
 /**
  * A failed decoding result containing validation issues.
  *
@@ -16,5 +18,15 @@ public record Err<T>(Issues issues) implements Result<T> {
     @SuppressWarnings("unchecked")
     public <U> Err<U> coerce() {
         return (Err<U>) this;
+    }
+
+    @Override
+    public String toString() {
+        return issues.asList().stream()
+            .map(issue -> {
+                String p = issue.path().toString();
+                return (p.isEmpty() ? "/" : p) + ": " + issue.message();
+            })
+            .collect(Collectors.joining(", ", "Err[", "]"));
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/Ok.java
+++ b/raoh/src/main/java/net/unit8/raoh/Ok.java
@@ -7,8 +7,13 @@ package net.unit8.raoh;
  * @param <T>   the type of the decoded value
  */
 public record Ok<T>(T value) implements Result<T> {
+    /**
+     * Returns a concise string representation of this successful result.
+     *
+     * @return a string of the form {@code Ok[value]}
+     */
     @Override
-    public final String toString() {
+    public String toString() {
         return "Ok[" + value + "]";
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/Ok.java
+++ b/raoh/src/main/java/net/unit8/raoh/Ok.java
@@ -7,4 +7,8 @@ package net.unit8.raoh;
  * @param <T>   the type of the decoded value
  */
 public record Ok<T>(T value) implements Result<T> {
+    @Override
+    public final String toString() {
+        return "Ok[" + value + "]";
+    }
 }

--- a/raoh/src/test/java/net/unit8/raoh/ResultToStringTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/ResultToStringTest.java
@@ -1,0 +1,46 @@
+package net.unit8.raoh;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static net.unit8.raoh.map.MapDecoders.*;
+import static net.unit8.raoh.ObjectDecoders.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResultToStringTest {
+
+    @Test
+    void okToString() {
+        Result<String> result = Result.ok("hello");
+        assertEquals("Ok[hello]", result.toString());
+    }
+
+    @Test
+    void okToStringNull() {
+        Result<String> result = Result.ok(null);
+        assertEquals("Ok[null]", result.toString());
+    }
+
+    @Test
+    void errToStringRootPath() {
+        Result<String> result = string().decode(null, Path.ROOT);
+        assertEquals("Err[/: is required]", result.toString());
+    }
+
+    @Test
+    void errToStringFieldPath() {
+        Result<String> result = field("name", string()).decode(Map.of("name", 42), Path.ROOT);
+        assertEquals("Err[/name: expected string]", result.toString());
+    }
+
+    @Test
+    void errToStringMultipleIssues() {
+        Decoder<Map<String, Object>, ?> dec = Decoders.combine(
+                field("a", string()),
+                field("b", string())
+        ).map((a, b) -> a + b);
+        Result<?> result = dec.decode(Map.of(), Path.ROOT);
+        assertEquals("Err[/a: is required, /b: is required]", result.toString());
+    }
+}


### PR DESCRIPTION
## Summary

- **`Ok.toString()`**: added explicit override to render `Ok[value]` instead of the record default `Ok[value=value]`
- **`Err.toString()`**: root-path errors previously rendered as `Err[: message]` (empty path + colon); now renders as `Err[/: message]`, consistent with non-root format `Err[/field: message]`

## Before / After

```
// Before
Ok[value=alice]
Err[: is required]

// After
Ok[alice]
Err[/: is required]
```

## Test plan

- [x] All existing tests pass (`mvn test`)