### PR TITLE
fix: give nonBlank() its own BLANK error code distinct from REQUIRED

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
+++ b/raoh/src/main/java/net/unit8/raoh/ErrorCodes.java
@@ -23,6 +23,9 @@ public final class ErrorCodes {
     /** Value is absent or null when a non-null value was expected. */
     public static final String REQUIRED = "required";
 
+    /** Value is present but consists entirely of whitespace characters. */
+    public static final String BLANK = "blank";
+
     // --- String length ---
 
     /** String is shorter than the minimum allowed length. */

--- a/raoh/src/main/java/net/unit8/raoh/MessageResolver.java
+++ b/raoh/src/main/java/net/unit8/raoh/MessageResolver.java
@@ -72,6 +72,7 @@ public interface MessageResolver {
     /** A default resolver that provides English messages for all built-in error codes. */
     MessageResolver DEFAULT = (code, meta) -> switch (code) {
         case ErrorCodes.REQUIRED        -> "is required";
+        case ErrorCodes.BLANK           -> "must not be blank";
         case ErrorCodes.TOO_SHORT       -> "must be at least %s characters".formatted(meta.get("min"));
         case ErrorCodes.TOO_LONG        -> "must be at most %s characters".formatted(meta.get("max"));
         case ErrorCodes.OUT_OF_RANGE    -> {

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -80,10 +80,19 @@ public class StringDecoder<I> implements Decoder<I, String> {
 
     // --- Constraints ---
 
+    /**
+     * Requires the string value to contain at least one non-whitespace character.
+     *
+     * <p>Fails with {@link ErrorCodes#BLANK} when the value is {@code null} or consists
+     * entirely of whitespace. Use this after {@link #trim()} to reject strings that become
+     * empty after trimming, or stand-alone to reject blank-only input.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#BLANK} for blank values
+     */
     public StringDecoder<I> nonBlank() {
         return chain((value, path) -> {
             if (value == null || value.isBlank()) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+                return Result.fail(path, ErrorCodes.BLANK, "must not be blank");
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -83,7 +83,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
     /**
      * Requires the string value to contain at least one non-whitespace character.
      *
-     * <p>Fails with {@link ErrorCodes#BLANK} when the value is {@code null} or consists
+     * <p>Fails with {@link ErrorCodes#BLANK} when the decoded string is empty or consists
      * entirely of whitespace. Use this after {@link #trim()} to reject strings that become
      * empty after trimming, or stand-alone to reject blank-only input.
      *

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -91,7 +91,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
      */
     public StringDecoder<I> nonBlank() {
         return chain((value, path) -> {
-            if (value == null || value.isBlank()) {
+            if (value.isBlank()) {
                 return Result.fail(path, ErrorCodes.BLANK, "must not be blank");
             }
             return Result.ok(value);

--- a/raoh/src/main/resources/net/unit8/raoh/messages.properties
+++ b/raoh/src/main/resources/net/unit8/raoh/messages.properties
@@ -1,4 +1,5 @@
 raoh.required=is required
+raoh.blank=must not be blank
 raoh.too_short=must be at least {min} characters
 raoh.too_long=must be at most {max} characters
 raoh.invalid_length=must be exactly {expected} characters

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -447,8 +447,30 @@ class MapDecoderTest {
     @Test
     void nonBlankStringRejectsBlank() {
         var dec = field("name", string().nonBlank());
-        assertErr(dec.decode(Map.of("name", "")));
+        var blankResult = dec.decode(Map.of("name", ""));
+        assertErr(blankResult);
+        switch (blankResult) {
+            case Err<?> err -> assertEquals(ErrorCodes.BLANK, err.issues().asList().getFirst().code());
+            default -> fail("expected Err");
+        }
         assertErr(dec.decode(Map.of("name", "   ")));
+    }
+
+    @Test
+    void nonBlankStringHasDifferentCodeFromRequired() {
+        var dec = field("name", string().nonBlank());
+        // missing key → REQUIRED
+        var missingResult = dec.decode(Map.of());
+        switch (missingResult) {
+            case Err<?> err -> assertEquals(ErrorCodes.REQUIRED, err.issues().asList().getFirst().code());
+            default -> fail("expected Err");
+        }
+        // blank value → BLANK
+        var blankResult = dec.decode(Map.of("name", "   "));
+        switch (blankResult) {
+            case Err<?> err -> assertEquals(ErrorCodes.BLANK, err.issues().asList().getFirst().code());
+            default -> fail("expected Err");
+        }
     }
 
     @Test

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -447,13 +447,14 @@ class MapDecoderTest {
     @Test
     void nonBlankStringRejectsBlank() {
         var dec = field("name", string().nonBlank());
-        var blankResult = dec.decode(Map.of("name", ""));
-        assertErr(blankResult);
-        switch (blankResult) {
-            case Err<?> err -> assertEquals(ErrorCodes.BLANK, err.issues().asList().getFirst().code());
-            default -> fail("expected Err");
+        for (var input : new String[]{"", "   "}) {
+            var result = dec.decode(Map.of("name", input));
+            assertErr(result);
+            switch (result) {
+                case Err<?> err -> assertEquals(ErrorCodes.BLANK, err.issues().asList().getFirst().code());
+                default -> fail("expected Err for input: " + input);
+            }
         }
-        assertErr(dec.decode(Map.of("name", "   ")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `nonBlank()` previously emitted `ErrorCodes.REQUIRED` for blank values, which is the same code as a missing field
- Added `ErrorCodes.BLANK = "blank"` to distinguish "value is blank" from "value is absent"
- Updated `nonBlank()` in `StringDecoder` to emit `BLANK` with message `"must not be blank"`
- Added `BLANK` to `MessageResolver.DEFAULT` and `messages.properties` to satisfy `ErrorCodesDefaultCoverageTest`
- Added two new tests: one asserting the error code for a blank value, one asserting `REQUIRED` vs `BLANK` are distinct

## Test plan

- [ ] `mvn test` passes (all 4 modules)
- [ ] `nonBlankStringRejectsBlank` now asserts `ErrorCodes.BLANK`
- [ ] `nonBlankStringHasDifferentCodeFromRequired` confirms missing field → `REQUIRED`, blank field → `BLANK`
- [ ] `ErrorCodesDefaultCoverageTest` covers the new `BLANK` constant automatically via reflection

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)