### PR TITLE
feat: add Path.of(String...) factory method

### DIFF
--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -337,7 +337,7 @@ var joinRows = List.<Map<String, Object>>of(
 
 ```java
 // 全行をデコード
-var decodedRows = Result.traverse(joinRows, rowDec::decode, Path.ROOT.append("rows"));
+var decodedRows = Result.traverse(joinRows, rowDec::decode, Path.of("rows"));
 // 親キーでグルーピング → OrderWithLines に組み上げ
 var orders = decodedRows.map(entries ->
         entries.stream()
@@ -618,7 +618,7 @@ var rows = List.<Map<String, Object>>of(
         Map.of("order_id", "A003", "total", 300)
 );
 
-Result.traverse(rows, orderDec::decode, Path.ROOT.append("orders"))
+Result.traverse(rows, orderDec::decode, Path.of("orders"))
 // ==> Err[/orders/1/order_id: is required, /orders/1/total: must be non-negative]
 ```
 
@@ -1056,7 +1056,7 @@ var rows = List.<Map<String, Object>>of(
         Map.of("email", "also-bad",           "name", "Carol", "age", -1)
 );
 
-var result = Result.traverse(rows, memberDec::decode, Path.ROOT.append("rows"));
+var result = Result.traverse(rows, memberDec::decode, Path.of("rows"));
 switch (result) {
     case Ok(var members) -> System.out.println("Imported: " + members.size());
     case Err(var issues) -> issues.flatten().forEach((path, msgs) ->

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -336,7 +336,7 @@ var joinRows = List.<Map<String, Object>>of(
 Decode all rows, group by parent key, and assemble the parent-child model:
 
 ```java
-var decodedRows = Result.traverse(joinRows, rowDec::decode, Path.ROOT.append("rows"));
+var decodedRows = Result.traverse(joinRows, rowDec::decode, Path.of("rows"));
 var orders = decodedRows.map(entries ->
         entries.stream()
                 .collect(Collectors.groupingBy(
@@ -616,7 +616,7 @@ var rows = List.<Map<String, Object>>of(
         Map.of("order_id", "A003", "total", 300)
 );
 
-Result.traverse(rows, orderDec::decode, Path.ROOT.append("orders"))
+Result.traverse(rows, orderDec::decode, Path.of("orders"))
 // ==> Err[/orders/1/order_id: is required, /orders/1/total: must be non-negative]
 ```
 
@@ -1054,7 +1054,7 @@ var rows = List.<Map<String, Object>>of(
         Map.of("email", "also-bad",           "name", "Carol", "age", -1)
 );
 
-var result = Result.traverse(rows, memberDec::decode, Path.ROOT.append("rows"));
+var result = Result.traverse(rows, memberDec::decode, Path.of("rows"));
 switch (result) {
     case Ok(var members) -> System.out.println("Imported: " + members.size());
     case Err(var issues) -> issues.flatten().forEach((path, msgs) ->

--- a/raoh/src/main/java/net/unit8/raoh/Path.java
+++ b/raoh/src/main/java/net/unit8/raoh/Path.java
@@ -24,6 +24,23 @@ public final class Path {
     }
 
     /**
+     * Creates a path from one or more segments.
+     *
+     * <p>This is a shorthand for {@code Path.ROOT.append(first).append(...)}.
+     *
+     * @param first the first segment (e.g., a field name)
+     * @param rest  additional segments
+     * @return a path with all segments appended to root
+     */
+    public static Path of(String first, String... rest) {
+        Path p = ROOT.append(first);
+        for (String segment : rest) {
+            p = p.append(segment);
+        }
+        return p;
+    }
+
+    /**
      * Appends a segment to this path in O(1).
      *
      * @param segment the segment to append (e.g., a field name or array index)

--- a/raoh/src/test/java/net/unit8/raoh/PathTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/PathTest.java
@@ -1,0 +1,31 @@
+package net.unit8.raoh;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PathTest {
+
+    @Test
+    void ofSingleSegment() {
+        Path path = Path.of("name");
+        assertEquals("/name", path.toString());
+        assertEquals(List.of("name"), path.segments());
+    }
+
+    @Test
+    void ofMultipleSegments() {
+        Path path = Path.of("address", "city");
+        assertEquals("/address/city", path.toString());
+        assertEquals(List.of("address", "city"), path.segments());
+    }
+
+    @Test
+    void ofEqualsAppendChain() {
+        Path fromOf = Path.of("orders", "items", "0");
+        Path fromAppend = Path.ROOT.append("orders").append("items").append("0");
+        assertEquals(fromAppend, fromOf);
+    }
+}


### PR DESCRIPTION
## Summary

- Added `Path.of(String first, String... rest)` as shorthand for `Path.ROOT.append(first).append(...)`
- Follows idiomatic Java factory patterns (`List.of`, `Map.of`, `java.nio.file.Path.of`)
- Added `PathTest` with tests for single segment, multiple segments, and equivalence with `append` chains

## Test plan

- [x] `mvn test` passes
- [x] `Path.of("name")` produces `/name`
- [x] `Path.of("address", "city")` produces `/address/city`
- [x] `Path.of(...)` equals equivalent `Path.ROOT.append(...)` chain

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)