### PR TITLE
feat: add string coerce methods (toInt/toLong/toDecimal/toBool)

### DIFF
--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -128,6 +128,62 @@ string().iso8601().decode("2025-06-15T10:30:00Z")
 // ==> Ok[2025-06-15T10:30:00Z]
 ```
 
+### 文字列からの型変換（coerce）
+
+フォームデータやクエリパラメータでは、数値や真偽値もすべて文字列として届きます。`toInt()`, `toLong()`, `toDecimal()`, `toBool()` を使うと、文字列をパースして型付きデコーダーに変換できます。変換後はそのまま制約をチェーンできます。
+
+```java
+string().toInt().decode("42")
+// ==> Ok[42]
+
+string().toInt().range(0, 150).decode("25")
+// ==> Ok[25]
+
+string().toInt().decode("abc")
+// ==> Err[/: expected integer]
+
+string().toLong().decode("9999999999")
+// ==> Ok[9999999999]
+
+string().toDecimal().scale(2).decode("19.99")
+// ==> Ok[19.99]
+
+string().toDecimal().decode("abc")
+// ==> Err[/: expected decimal]
+```
+
+`toBool()` はフォームデータでよく使われる文字列をケース非依存で認識します。
+
+```java
+string().toBool().decode("true")
+// ==> Ok[true]
+
+string().toBool().decode("1")
+// ==> Ok[true]
+
+string().toBool().decode("no")
+// ==> Ok[false]
+
+string().toBool().decode("maybe")
+// ==> Err[/: expected boolean]
+
+// isTrue() で「利用規約への同意」を強制
+string().toBool().isTrue().decode("true")
+// ==> Ok[true]
+
+string().toBool().isTrue().decode("false")
+// ==> Err[/: must be true]
+```
+
+`toBool()` が認識する値: `true`/`1`/`yes`/`on` → `true`、`false`/`0`/`no`/`off` → `false`。
+
+前段で `trim()` を挟むと、ホワイトスペース付きの入力にも対応できます。
+
+```java
+string().trim().toInt().decode("  42  ")
+// ==> Ok[42]
+```
+
 ---
 
 ## 3. ドメインプリミティブへの変換

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -129,6 +129,62 @@ string().iso8601().decode("2025-06-15T10:30:00Z")
 // ==> Ok[2025-06-15T10:30:00Z]
 ```
 
+### String-to-type conversions (coerce)
+
+In form data and query parameters, numbers and booleans arrive as strings. `toInt()`, `toLong()`, `toDecimal()`, and `toBool()` parse the string and return a typed decoder. Constraints can be chained directly after the conversion.
+
+```java
+string().toInt().decode("42")
+// ==> Ok[42]
+
+string().toInt().range(0, 150).decode("25")
+// ==> Ok[25]
+
+string().toInt().decode("abc")
+// ==> Err[/: expected integer]
+
+string().toLong().decode("9999999999")
+// ==> Ok[9999999999]
+
+string().toDecimal().scale(2).decode("19.99")
+// ==> Ok[19.99]
+
+string().toDecimal().decode("abc")
+// ==> Err[/: expected decimal]
+```
+
+`toBool()` recognises common form-data representations, case-insensitively.
+
+```java
+string().toBool().decode("true")
+// ==> Ok[true]
+
+string().toBool().decode("1")
+// ==> Ok[true]
+
+string().toBool().decode("no")
+// ==> Ok[false]
+
+string().toBool().decode("maybe")
+// ==> Err[/: expected boolean]
+
+// Use isTrue() to enforce agreement (e.g., terms of service)
+string().toBool().isTrue().decode("true")
+// ==> Ok[true]
+
+string().toBool().isTrue().decode("false")
+// ==> Err[/: must be true]
+```
+
+Recognised values: `true`/`1`/`yes`/`on` → `true`, `false`/`0`/`no`/`off` → `false`.
+
+Chain `trim()` before conversion to handle whitespace-padded input.
+
+```java
+string().trim().toInt().decode("  42  ")
+// ==> Ok[42]
+```
+
 ---
 
 ## 3. Mapping to domain primitives

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -13,6 +13,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -703,7 +704,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
      */
     public BoolDecoder<I> toBool(String message) {
         return new BoolDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
-            Boolean parsed = switch (value.toLowerCase()) {
+            Boolean parsed = switch (value.toLowerCase(Locale.ROOT)) {
                 case "true", "1", "yes", "on" -> Boolean.TRUE;
                 case "false", "0", "no", "off" -> Boolean.FALSE;
                 default -> null;

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -680,14 +680,14 @@ public class StringDecoder<I> implements Decoder<I, String> {
     /**
      * Parses the string as a boolean.
      *
-     * <p>Recognises common form-data representations (case-insensitive):
+     * <p>Recognises common form-data representations (case-insensitive):</p>
      * <ul>
      *   <li>true: {@code "true"}, {@code "1"}, {@code "yes"}, {@code "on"}</li>
      *   <li>false: {@code "false"}, {@code "0"}, {@code "no"}, {@code "off"}</li>
      * </ul>
      *
      * <p>Produces a {@link ErrorCodes#TYPE_MISMATCH} error for any other value.
-     * The returned {@link BoolDecoder} supports {@code isTrue()} and {@code isFalse()} constraints.
+     * The returned {@link BoolDecoder} supports {@code isTrue()} and {@code isFalse()} constraints.</p>
      *
      * @return a boolean decoder with the parsed value
      */

--- a/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/builtin/StringDecoder.java
@@ -2,6 +2,7 @@ package net.unit8.raoh.builtin;
 
 import net.unit8.raoh.*;
 
+import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -571,6 +572,150 @@ public class StringDecoder<I> implements Decoder<I, String> {
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid ISO-8601 offset date-time (e.g., 2024-01-15T10:30:00+09:00)");
             }
+        }));
+    }
+
+    // --- Numeric / boolean type conversions ---
+
+    /**
+     * Parses the string as an integer.
+     *
+     * <p>Produces a {@link ErrorCodes#TYPE_MISMATCH} error when the string
+     * cannot be parsed as an integer. The returned {@link IntDecoder} supports
+     * further numeric constraints such as {@code range()}, {@code positive()}, etc.
+     *
+     * @return an integer decoder with the parsed value
+     */
+    public IntDecoder<I> toInt() {
+        return toInt(null);
+    }
+
+    /**
+     * Parses the string as an integer.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return an integer decoder with the parsed value
+     */
+    public IntDecoder<I> toInt(String message) {
+        return new IntDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            try {
+                return Result.ok(Integer.parseInt(value));
+            } catch (NumberFormatException e) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.TYPE_MISMATCH, message,
+                                Map.of("expected", "integer"))
+                        : Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected integer",
+                                Map.of("expected", "integer"));
+            }
+        }));
+    }
+
+    /**
+     * Parses the string as a long integer.
+     *
+     * <p>Produces a {@link ErrorCodes#TYPE_MISMATCH} error when the string
+     * cannot be parsed as a long. The returned {@link LongDecoder} supports
+     * further numeric constraints such as {@code range()}, {@code positive()}, etc.
+     *
+     * @return a long decoder with the parsed value
+     */
+    public LongDecoder<I> toLong() {
+        return toLong(null);
+    }
+
+    /**
+     * Parses the string as a long integer.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a long decoder with the parsed value
+     */
+    public LongDecoder<I> toLong(String message) {
+        return new LongDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            try {
+                return Result.ok(Long.parseLong(value));
+            } catch (NumberFormatException e) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.TYPE_MISMATCH, message,
+                                Map.of("expected", "long"))
+                        : Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected long",
+                                Map.of("expected", "long"));
+            }
+        }));
+    }
+
+    /**
+     * Parses the string as a {@link BigDecimal}.
+     *
+     * <p>Produces a {@link ErrorCodes#TYPE_MISMATCH} error when the string
+     * cannot be parsed as a decimal number. The returned {@link DecimalDecoder} supports
+     * further numeric constraints such as {@code scale()}, {@code positive()}, etc.
+     *
+     * @return a decimal decoder with the parsed value
+     */
+    public DecimalDecoder<I> toDecimal() {
+        return toDecimal(null);
+    }
+
+    /**
+     * Parses the string as a {@link BigDecimal}.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a decimal decoder with the parsed value
+     */
+    public DecimalDecoder<I> toDecimal(String message) {
+        return new DecimalDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            try {
+                return Result.ok(new BigDecimal(value));
+            } catch (NumberFormatException e) {
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.TYPE_MISMATCH, message,
+                                Map.of("expected", "decimal"))
+                        : Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected decimal",
+                                Map.of("expected", "decimal"));
+            }
+        }));
+    }
+
+    /**
+     * Parses the string as a boolean.
+     *
+     * <p>Recognises common form-data representations (case-insensitive):
+     * <ul>
+     *   <li>true: {@code "true"}, {@code "1"}, {@code "yes"}, {@code "on"}</li>
+     *   <li>false: {@code "false"}, {@code "0"}, {@code "no"}, {@code "off"}</li>
+     * </ul>
+     *
+     * <p>Produces a {@link ErrorCodes#TYPE_MISMATCH} error for any other value.
+     * The returned {@link BoolDecoder} supports {@code isTrue()} and {@code isFalse()} constraints.
+     *
+     * @return a boolean decoder with the parsed value
+     */
+    public BoolDecoder<I> toBool() {
+        return toBool(null);
+    }
+
+    /**
+     * Parses the string as a boolean.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a boolean decoder with the parsed value
+     * @see #toBool()
+     */
+    public BoolDecoder<I> toBool(String message) {
+        return new BoolDecoder<>((in, path) -> this.decode(in, path).flatMap(value -> {
+            Boolean parsed = switch (value.toLowerCase()) {
+                case "true", "1", "yes", "on" -> Boolean.TRUE;
+                case "false", "0", "no", "off" -> Boolean.FALSE;
+                default -> null;
+            };
+            if (parsed != null) {
+                return Result.ok(parsed);
+            }
+            return message != null
+                    ? Result.failCustom(path, ErrorCodes.TYPE_MISMATCH, message,
+                            Map.of("expected", "boolean"))
+                    : Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected boolean",
+                            Map.of("expected", "boolean"));
         }));
     }
 

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -626,6 +626,135 @@ class MapDecoderTest {
         }
     }
 
+    // --- String coerce ---
+
+    @Test
+    void toIntValid() {
+        var dec = field("age", string().toInt());
+        assertEquals(42, assertOk(dec.decode(Map.of("age", "42"))));
+        assertEquals(-7, assertOk(dec.decode(Map.of("age", "-7"))));
+    }
+
+    @Test
+    void toIntInvalid() {
+        var dec = field("age", string().toInt());
+        var result = dec.decode(Map.of("age", "abc"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> {
+                assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+                assertEquals("integer", issues.asList().getFirst().meta().get("expected"));
+            }
+        }
+    }
+
+    @Test
+    void toIntChainRange() {
+        var dec = field("age", string().toInt().range(0, 150));
+        assertEquals(25, assertOk(dec.decode(Map.of("age", "25"))));
+        assertErr(dec.decode(Map.of("age", "200")));
+    }
+
+    @Test
+    void toIntCustomMessage() {
+        var dec = field("n", string().toInt("整数を入力してください"));
+        var result = dec.decode(Map.of("n", "abc"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals("整数を入力してください", issues.asList().getFirst().message());
+        }
+    }
+
+    @Test
+    void toLongValid() {
+        var dec = field("id", string().toLong());
+        assertEquals(9999999999L, assertOk(dec.decode(Map.of("id", "9999999999"))));
+    }
+
+    @Test
+    void toLongInvalid() {
+        var dec = field("id", string().toLong());
+        assertErr(dec.decode(Map.of("id", "not-a-number")));
+    }
+
+    @Test
+    void toDecimalValid() {
+        var dec = field("price", string().toDecimal());
+        assertEquals(0, new BigDecimal("19.99").compareTo(assertOk(dec.decode(Map.of("price", "19.99")))));
+    }
+
+    @Test
+    void toDecimalChainScale() {
+        var dec = field("price", string().toDecimal().scale(2));
+        assertOk(dec.decode(Map.of("price", "19.99")));
+        assertErr(dec.decode(Map.of("price", "19.999")));
+    }
+
+    @Test
+    void toDecimalInvalid() {
+        var dec = field("price", string().toDecimal());
+        var result = dec.decode(Map.of("price", "abc"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
+    void toBoolTrue() {
+        var dec = field("agree", string().toBool());
+        for (var input : new String[]{"true", "TRUE", "1", "yes", "YES", "on", "On"}) {
+            assertTrue(assertOk(dec.decode(Map.of("agree", input))),
+                    "expected true for input: " + input);
+        }
+    }
+
+    @Test
+    void toBoolFalse() {
+        var dec = field("agree", string().toBool());
+        for (var input : new String[]{"false", "FALSE", "0", "no", "NO", "off", "Off"}) {
+            assertFalse(assertOk(dec.decode(Map.of("agree", input))),
+                    "expected false for input: " + input);
+        }
+    }
+
+    @Test
+    void toBoolInvalid() {
+        var dec = field("agree", string().toBool());
+        var result = dec.decode(Map.of("agree", "maybe"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> {
+                assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+                assertEquals("boolean", issues.asList().getFirst().meta().get("expected"));
+            }
+        }
+    }
+
+    @Test
+    void toBoolChainIsTrue() {
+        var dec = field("terms", string().toBool().isTrue());
+        assertTrue(assertOk(dec.decode(Map.of("terms", "true"))));
+        assertErr(dec.decode(Map.of("terms", "false")));
+    }
+
+    @Test
+    void toBoolCustomMessage() {
+        var dec = field("flag", string().toBool("真偽値を入力してください"));
+        var result = dec.decode(Map.of("flag", "maybe"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals("真偽値を入力してください", issues.asList().getFirst().message());
+        }
+    }
+
+    @Test
+    void trimThenToInt() {
+        var dec = field("age", string().trim().toInt());
+        assertEquals(42, assertOk(dec.decode(Map.of("age", "  42  "))));
+        assertErr(dec.decode(Map.of("age", "  abc  ")));
+    }
+
     // --- Helpers ---
 
     static <T> T assertOk(Result<T> result) {


### PR DESCRIPTION
## Summary

- Add `toInt()`, `toLong()`, `toDecimal()`, `toBool()` type conversion methods to `StringDecoder`
- Enable constraint chaining after coercion: `string().toInt().range(0, 150)`, `string().toDecimal().scale(2)`, `string().toBool().isTrue()`
- `toBool()` recognises common form-data representations case-insensitively: `true/1/yes/on` → `true`, `false/0/no/off` → `false`
- All methods support custom error message overloads

## Test plan

- [x] `toInt` valid/invalid parsing, range chaining, custom message
- [x] `toLong` valid/invalid parsing
- [x] `toDecimal` valid/invalid parsing, scale chaining
- [x] `toBool` true/false variants (7 each), invalid input, `isTrue()` chaining, custom message
- [x] `trim().toInt()` whitespace-tolerant pattern
- [x] All existing tests pass (`mvn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)