### PR TITLE
feat: align decoder module APIs (discriminate, combine(List))

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -382,8 +382,8 @@ public final class JooqRecordDecoders {
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
      * @param <T>      the output type
-     * @param decoders the decoders to combine
-     * @return a combiner on which {@code .map(f)} can be called
+     * @param decoders the decoders to combine; must not be empty
+     * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */
     public static <T> CombinerList<org.jooq.Record> combine(List<Decoder<org.jooq.Record, ?>> decoders) {

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -135,9 +135,10 @@ public final class JooqRecordDecoders {
                 case Ok<String> ok -> {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
+                        var allowed = variants.keySet().stream().sorted().toList();
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
-                                Map.of("allowed", variants.keySet()));
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + allowed,
+                                Map.of("allowed", allowed));
                     }
                     @SuppressWarnings("unchecked")
                     var result = (Result<T>) dec.decode(in, path);

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -136,7 +136,7 @@ public final class JooqRecordDecoders {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.INVALID_FORMAT, "invalid value",
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
                                 Map.of("allowed", variants.keySet()));
                     }
                     @SuppressWarnings("unchecked")
@@ -382,7 +382,7 @@ public final class JooqRecordDecoders {
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
      * @param <T>      the output type
-     * @param decoders the decoders to combine; must not be empty
+     * @param decoders the decoders to combine
      * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -4,6 +4,7 @@ import net.unit8.raoh.*;
 import net.unit8.raoh.combinator.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -109,6 +110,41 @@ public final class JooqRecordDecoders {
      */
     public static <T> JooqRecordDecoder<T> nested(JooqRecordDecoder<T> dec) {
         return dec::decode;
+    }
+
+    // --- discriminate ---
+
+    /**
+     * Creates a decoder that dispatches to different decoders based on a discriminator column.
+     *
+     * <p>Useful for single-table inheritance patterns where a column (e.g., {@code "type"})
+     * determines which decoder should be applied to the record.
+     *
+     * @param <T>       the decoded type
+     * @param fieldName the discriminator column name (e.g., {@code "type"})
+     * @param variants  a map from discriminator values to decoders
+     * @return a discriminating decoder
+     */
+    public static <T> JooqRecordDecoder<T> discriminate(
+            String fieldName,
+            Map<String, Decoder<org.jooq.Record, ? extends T>> variants) {
+        return (in, path) -> {
+            var tag = field(fieldName, ObjectDecoders.allowBlankString()).decode(in, path);
+            return switch (tag) {
+                case Err<String> err -> err.coerce();
+                case Ok<String> ok -> {
+                    var dec = variants.get(ok.value());
+                    if (dec == null) {
+                        yield Result.fail(path.append(fieldName),
+                                ErrorCodes.INVALID_FORMAT, "invalid value",
+                                Map.of("allowed", variants.keySet()));
+                    }
+                    @SuppressWarnings("unchecked")
+                    var result = (Result<T>) dec.decode(in, path);
+                    yield result;
+                }
+            };
+        };
     }
 
     // --- combine delegates ---

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -6,6 +6,7 @@ import org.jooq.impl.DSL;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.Optional;
 
 import static net.unit8.raoh.jooq.JooqRecordDecoders.*;
@@ -308,5 +309,57 @@ class JooqDecoderTest {
         var result = JooqRecordDecoders.<String>optionalNullableField("email", string()).decode(rec);
         assertInstanceOf(Ok.class, result);
         assertInstanceOf(Presence.PresentNull.class, ((Ok<?>) result).value());
+    }
+
+    // -------------------------------------------------------------------------
+    // discriminate — single-table inheritance
+    // -------------------------------------------------------------------------
+
+    sealed interface Payment permits CreditCard, BankTransfer {}
+    record CreditCard(String cardNumber) implements Payment {}
+    record BankTransfer(String bankCode) implements Payment {}
+
+    @Test
+    void discriminateDispatchesCorrectly() {
+        Decoder<org.jooq.Record, Payment> dec = discriminate("type", Map.of(
+                "credit_card", field("card_number", string()).map(CreditCard::new),
+                "bank_transfer", field("bank_code", string()).map(BankTransfer::new)
+        ));
+
+        var ccRec = record("type", "credit_card", "card_number", "4111-1111-1111-1111", "bank_code", "");
+        var ccResult = dec.decode(ccRec);
+        assertInstanceOf(Ok.class, ccResult);
+        assertInstanceOf(CreditCard.class, ((Ok<Payment>) ccResult).value());
+        assertEquals("4111-1111-1111-1111", ((CreditCard) ((Ok<Payment>) ccResult).value()).cardNumber());
+
+        var btRec = record("type", "bank_transfer", "card_number", "", "bank_code", "MUFG");
+        var btResult = dec.decode(btRec);
+        assertInstanceOf(Ok.class, btResult);
+        assertInstanceOf(BankTransfer.class, ((Ok<Payment>) btResult).value());
+    }
+
+    @Test
+    void discriminateUnknownTag() {
+        Decoder<org.jooq.Record, Payment> dec = discriminate("type", Map.of(
+                "credit_card", field("card_number", string()).map(CreditCard::new)
+        ));
+
+        var rec = record("type", "crypto", "card_number", "");
+        var result = dec.decode(rec);
+        assertInstanceOf(Err.class, result);
+        var issue = ((Err<Payment>) result).issues().asList().get(0);
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("/type", issue.path().toJsonPointer());
+    }
+
+    @Test
+    void discriminateMissingTagField() {
+        Decoder<org.jooq.Record, Payment> dec = discriminate("type", Map.of(
+                "credit_card", field("card_number", string()).map(CreditCard::new)
+        ));
+
+        var rec = record("card_number", "4111");
+        var result = dec.decode(rec);
+        assertInstanceOf(Err.class, result);
     }
 }

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -348,7 +348,7 @@ class JooqDecoderTest {
         var result = dec.decode(rec);
         assertInstanceOf(Err.class, result);
         var issue = ((Err<Payment>) result).issues().asList().get(0);
-        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
         assertEquals("/type", issue.path().toJsonPointer());
     }
 
@@ -361,5 +361,8 @@ class JooqDecoderTest {
         var rec = record("card_number", "4111");
         var result = dec.decode(rec);
         assertInstanceOf(Err.class, result);
+        var issue = ((Err<Payment>) result).issues().asList().get(0);
+        assertEquals(ErrorCodes.MISSING_FIELD, issue.code());
+        assertEquals("/type", issue.path().toJsonPointer());
     }
 }

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -352,9 +352,10 @@ public final class JsonDecoders {
                 case Ok<String> ok -> {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
+                        var allowed = variants.keySet().stream().sorted().toList();
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
-                                Map.of("allowed", variants.keySet()));
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + allowed,
+                                Map.of("allowed", allowed));
                     }
                     @SuppressWarnings("unchecked")
                     var result = (Result<T>) dec.decode(in, path);

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -589,8 +589,8 @@ public final class JsonDecoders {
     /**
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
-     * @param decoders the decoders to combine
-     * @return a combiner on which {@code .map(f)} can be called
+     * @param decoders the decoders to combine; must not be empty
+     * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */
     public static CombinerList<JsonNode> combine(List<Decoder<JsonNode, ?>> decoders) {

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -353,7 +353,7 @@ public final class JsonDecoders {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.INVALID_FORMAT, "invalid value",
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
                                 Map.of("allowed", variants.keySet()));
                     }
                     @SuppressWarnings("unchecked")
@@ -589,7 +589,7 @@ public final class JsonDecoders {
     /**
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
-     * @param decoders the decoders to combine; must not be empty
+     * @param decoders the decoders to combine
      * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -585,4 +585,15 @@ public final class JsonDecoders {
             Decoder<JsonNode, Q> dq) {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_, dp, dq);
     }
+
+    /**
+     * Returns a {@link CombinerList} for combining more than 16 decoders.
+     *
+     * @param decoders the decoders to combine
+     * @return a combiner on which {@code .map(f)} can be called
+     * @see Decoders#combine(List)
+     */
+    public static CombinerList<JsonNode> combine(List<Decoder<JsonNode, ?>> decoders) {
+        return Decoders.combine(decoders);
+    }
 }

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -569,6 +569,19 @@ class JsonDecoderTest {
         }
     }
 
+    // --- combine(List) ---
+
+    @Test
+    void combineListDecoder() {
+        var dec = combine(List.<Decoder<JsonNode, ?>>of(
+                field("a", string()),
+                field("b", string()),
+                field("c", string())
+        )).map(args -> args[0] + "-" + args[1] + "-" + args[2]);
+
+        assertEquals("x-y-z", assertOk(dec.decode(parse("{\"a\":\"x\",\"b\":\"y\",\"c\":\"z\"}"))));
+    }
+
     // --- Helpers ---
 
     static <T> T assertOk(Result<T> result) {

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -181,9 +181,10 @@ public final class MapDecoders {
                 case Ok<String> ok -> {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
+                        var allowed = variants.keySet().stream().sorted().toList();
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
-                                Map.of("allowed", variants.keySet()));
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + allowed,
+                                Map.of("allowed", allowed));
                     }
                     @SuppressWarnings("unchecked")
                     var result = (Result<T>) dec.decode(in, path);

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -3,6 +3,7 @@ package net.unit8.raoh.map;
 import net.unit8.raoh.*;
 import net.unit8.raoh.combinator.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -154,6 +155,41 @@ public final class MapDecoders {
             }
             return dec.decode(value, fieldPath)
                     .map(v -> (Presence<T>) new Presence.Present<>(v));
+        };
+    }
+
+    // --- discriminate ---
+
+    /**
+     * Creates a decoder that dispatches to different decoders based on a discriminator field.
+     *
+     * <p>Extracts the value of the given field as a string, looks up the corresponding
+     * decoder in the variants map, and delegates decoding to it.
+     *
+     * @param <T>       the decoded type
+     * @param fieldName the discriminator field name (e.g., {@code "type"})
+     * @param variants  a map from discriminator values to decoders
+     * @return a discriminating decoder
+     */
+    public static <T> Decoder<Map<String, Object>, T> discriminate(
+            String fieldName,
+            Map<String, Decoder<Map<String, Object>, ? extends T>> variants) {
+        return (in, path) -> {
+            var tag = field(fieldName, ObjectDecoders.allowBlankString()).decode(in, path);
+            return switch (tag) {
+                case Err<String> err -> err.coerce();
+                case Ok<String> ok -> {
+                    var dec = variants.get(ok.value());
+                    if (dec == null) {
+                        yield Result.fail(path.append(fieldName),
+                                ErrorCodes.INVALID_FORMAT, "invalid value",
+                                Map.of("allowed", variants.keySet()));
+                    }
+                    @SuppressWarnings("unchecked")
+                    var result = (Result<T>) dec.decode(in, path);
+                    yield result;
+                }
+            };
         };
     }
 
@@ -335,5 +371,16 @@ public final class MapDecoders {
             Decoder<Map<String, Object>, N> dn, Decoder<Map<String, Object>, O> do_,
             Decoder<Map<String, Object>, P> dp, Decoder<Map<String, Object>, Q> dq) {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_, dp, dq);
+    }
+
+    /**
+     * Returns a {@link CombinerList} for combining more than 16 decoders.
+     *
+     * @param decoders the decoders to combine
+     * @return a combiner on which {@code .map(f)} can be called
+     * @see Decoders#combine(List)
+     */
+    public static CombinerList<Map<String, Object>> combine(List<Decoder<Map<String, Object>, ?>> decoders) {
+        return Decoders.combine(decoders);
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -376,8 +376,8 @@ public final class MapDecoders {
     /**
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
-     * @param decoders the decoders to combine
-     * @return a combiner on which {@code .map(f)} can be called
+     * @param decoders the decoders to combine; must not be empty
+     * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */
     public static CombinerList<Map<String, Object>> combine(List<Decoder<Map<String, Object>, ?>> decoders) {

--- a/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/map/MapDecoders.java
@@ -182,7 +182,7 @@ public final class MapDecoders {
                     var dec = variants.get(ok.value());
                     if (dec == null) {
                         yield Result.fail(path.append(fieldName),
-                                ErrorCodes.INVALID_FORMAT, "invalid value",
+                                ErrorCodes.NOT_ALLOWED, "must be one of " + variants.keySet(),
                                 Map.of("allowed", variants.keySet()));
                     }
                     @SuppressWarnings("unchecked")
@@ -376,7 +376,7 @@ public final class MapDecoders {
     /**
      * Returns a {@link CombinerList} for combining more than 16 decoders.
      *
-     * @param decoders the decoders to combine; must not be empty
+     * @param decoders the decoders to combine
      * @return a combiner on which {@code .map(f)} or {@code .flatMap(f)} can be called
      * @see Decoders#combine(List)
      */

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -789,7 +789,7 @@ class MapDecoderTest {
             case Ok(_) -> fail("Expected Err");
             case Err(var issues) -> {
                 var issue = issues.asList().getFirst();
-                assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+                assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
                 assertEquals("/type", issue.path().toJsonPointer());
             }
         }

--- a/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/MapDecoderTest.java
@@ -755,6 +755,72 @@ class MapDecoderTest {
         assertErr(dec.decode(Map.of("age", "  abc  ")));
     }
 
+    // --- discriminate ---
+
+    sealed interface Shape permits Circle, Rect {}
+    record Circle(double radius) implements Shape {}
+    record Rect(double width, double height) implements Shape {}
+
+    @Test
+    void discriminateDispatchesCorrectly() {
+        Decoder<Map<String, Object>, Shape> dec = discriminate("type", Map.of(
+                "circle", field("radius", decimal()).map(r -> new Circle(r.doubleValue())),
+                "rect", combine(field("width", decimal()), field("height", decimal()))
+                        .map((w, h) -> new Rect(w.doubleValue(), h.doubleValue()))
+        ));
+
+        var circle = assertOk(dec.decode(Map.of("type", "circle", "radius", 5.0)));
+        assertInstanceOf(Circle.class, circle);
+        assertEquals(5.0, ((Circle) circle).radius());
+
+        var rect = assertOk(dec.decode(Map.of("type", "rect", "width", 3.0, "height", 4.0)));
+        assertInstanceOf(Rect.class, rect);
+        assertEquals(3.0, ((Rect) rect).width());
+    }
+
+    @Test
+    void discriminateUnknownTag() {
+        Decoder<Map<String, Object>, Shape> dec = discriminate("type", Map.of(
+                "circle", field("radius", decimal()).map(r -> new Circle(r.doubleValue()))
+        ));
+
+        var result = dec.decode(Map.of("type", "triangle", "sides", 3));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+                assertEquals("/type", issue.path().toJsonPointer());
+            }
+        }
+    }
+
+    @Test
+    void discriminateMissingTagField() {
+        Decoder<Map<String, Object>, Shape> dec = discriminate("type", Map.of(
+                "circle", field("radius", decimal()).map(r -> new Circle(r.doubleValue()))
+        ));
+
+        var result = dec.decode(Map.of("radius", 5.0));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- combine(List) ---
+
+    @Test
+    void combineListDecoder() {
+        var dec = combine(List.<Decoder<Map<String, Object>, ?>>of(
+                field("a", string()),
+                field("b", string()),
+                field("c", string())
+        )).map(args -> args[0] + "-" + args[1] + "-" + args[2]);
+
+        assertEquals("x-y-z", assertOk(dec.decode(Map.of("a", "x", "b", "y", "c", "z"))));
+    }
+
     // --- Helpers ---
 
     static <T> T assertOk(Result<T> result) {


### PR DESCRIPTION
## Summary

- Add `discriminate(fieldName, variants)` to `MapDecoders` and `JooqRecordDecoders` — previously only available in `JsonDecoders`
- Add `combine(List)` to `MapDecoders` and `JsonDecoders` — previously missing (already existed in `JooqRecordDecoders` and core `Decoders`)

## Breaking change

- **`JsonDecoders.discriminate()`**: unknown discriminator value now returns `ErrorCodes.NOT_ALLOWED` (was `INVALID_FORMAT`). This aligns with the `meta.allowed` key and `messages.properties` template (`must be one of {allowed}`). The previous `INVALID_FORMAT` code did not surface the allowed values through the default message resolver.

## Motivation

API 総点検で見つかったモジュール間の非対称性を解消。
- `discriminate()`: Map 入力のポリモーフィックなデコードや、jOOQ の単一テーブル継承 (STI) パターンで有用
- `combine(List)`: 17+ フィールド対応。全モジュールで統一

## Test plan

- [x] `MapDecoders.discriminate()`: 正常ディスパッチ、未知タグ、タグフィールド欠損
- [x] `JooqRecordDecoders.discriminate()`: 正常ディスパッチ、未知タグ、タグフィールド欠損
- [x] `MapDecoders.combine(List)`: 3 フィールドの結合
- [x] `JsonDecoders.combine(List)`: 3 フィールドの結合
- [x] `mvn test` 全モジュール通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)