### PR TITLE
feat: add Tuple2-Tuple8 for lightweight result destructuring

### DIFF
--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -1175,3 +1175,47 @@ appConfigDec.decode(Map.of(
 ```
 
 設定デコーダーをアプリ起動時に実行することで、環境変数の設定漏れや型ミスを本番コードに入る前に検出できます。
+
+## 28. タプル型 — 軽量な結果コンテナ
+
+`combine(...).map(...)` では通常、結果用の専用 record を定義します。
+しかし `switch` 式の中でしか使わない一時的な値であれば、
+組み込みの `Tuple2` 〜 `Tuple8` を使うことで record 定義を省略できます:
+
+```java
+import net.unit8.raoh.combinator.Tuple2;
+
+var dec = combine(
+        field("name", string()),
+        field("age", int_())
+).map(Tuple2::new);
+
+switch (dec.decode(input)) {
+    case Ok(Tuple2(var name, var age)) -> {
+        // name: String, age: Integer — バリデーション済み
+    }
+    case Err(var issues) -> { /* エラー処理 */ }
+}
+```
+
+フィールドが多い場合は `Tuple3` 〜 `Tuple8` を使用します:
+
+```java
+import net.unit8.raoh.combinator.Tuple4;
+
+var dec = combine(
+        field("customerId", long_()),
+        field("items", list(string())),
+        field("address", string()),
+        field("desiredDeliveryDate", string().date())
+).map(Tuple4::new);
+
+switch (dec.decode(input)) {
+    case Ok(Tuple4(var customerId, var items, var address, var date)) -> {
+        // 4つの値がすべて利用可能
+    }
+    case Err(var issues) -> { /* エラー処理 */ }
+}
+```
+
+パターンマッチを使わない場合は `_1`, `_2`, ... `_8` でアクセスできます。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1173,3 +1173,47 @@ appConfigDec.decode(Map.of(
 ```
 
 Running the configuration decoder at application startup lets you catch missing environment variables and type mismatches before they reach production code.
+
+## 28. Tuple types — lightweight result containers
+
+When you use `combine(...).map(...)`, you normally define a dedicated record for the result.
+If the combined value is only used in a single `switch` expression and does not warrant its own type,
+you can use the built-in `Tuple2` through `Tuple8` types instead:
+
+```java
+import net.unit8.raoh.combinator.Tuple2;
+
+var dec = combine(
+        field("name", string()),
+        field("age", int_())
+).map(Tuple2::new);
+
+switch (dec.decode(input)) {
+    case Ok(Tuple2(var name, var age)) -> {
+        // name: String, age: Integer — fully validated
+    }
+    case Err(var issues) -> { /* handle errors */ }
+}
+```
+
+For more fields, use `Tuple3` through `Tuple8`:
+
+```java
+import net.unit8.raoh.combinator.Tuple4;
+
+var dec = combine(
+        field("customerId", long_()),
+        field("items", list(string())),
+        field("address", string()),
+        field("desiredDeliveryDate", string().date())
+).map(Tuple4::new);
+
+switch (dec.decode(input)) {
+    case Ok(Tuple4(var customerId, var items, var address, var date)) -> {
+        // all four values available here
+    }
+    case Err(var issues) -> { /* handle errors */ }
+}
+```
+
+Tuple elements are accessed as `_1`, `_2`, ... `_8` when not using pattern matching.

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple2.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple2.java
@@ -1,0 +1,26 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 2-element tuple for use with {@link Combiner2#map(java.util.function.BiFunction)}.
+ *
+ * <p>Pass {@code Tuple2::new} as the mapping function to capture decoded values
+ * without defining a dedicated record, then destructure with pattern matching:
+ *
+ * <pre>{@code
+ * Decoder<Map<String, Object>, Tuple2<String, Integer>> dec = combine(
+ *     field("name", string()),
+ *     field("age", int_())
+ * ).map(Tuple2::new);
+ *
+ * switch (dec.decode(input)) {
+ *     case Ok(Tuple2(var name, var age)) -> ...
+ *     case Err(var issues) -> ...
+ * }
+ * }</pre>
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param _1 the first element
+ * @param _2 the second element
+ */
+public record Tuple2<E1, E2>(E1 _1, E2 _2) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple3.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple3.java
@@ -1,0 +1,14 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 3-element tuple for use with {@link Combiner3#map(Function3)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @see Tuple2
+ */
+public record Tuple3<E1, E2, E3>(E1 _1, E2 _2, E3 _3) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple4.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple4.java
@@ -1,0 +1,16 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 4-element tuple for use with {@link Combiner4#map(Function4)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param <E4> type of the fourth element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @param _4 the fourth element
+ * @see Tuple2
+ */
+public record Tuple4<E1, E2, E3, E4>(E1 _1, E2 _2, E3 _3, E4 _4) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple5.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple5.java
@@ -1,0 +1,18 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 5-element tuple for use with {@link Combiner5#map(Function5)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param <E4> type of the fourth element
+ * @param <E5> type of the fifth element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @param _4 the fourth element
+ * @param _5 the fifth element
+ * @see Tuple2
+ */
+public record Tuple5<E1, E2, E3, E4, E5>(E1 _1, E2 _2, E3 _3, E4 _4, E5 _5) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple6.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple6.java
@@ -1,0 +1,20 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 6-element tuple for use with {@link Combiner6#map(Function6)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param <E4> type of the fourth element
+ * @param <E5> type of the fifth element
+ * @param <E6> type of the sixth element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @param _4 the fourth element
+ * @param _5 the fifth element
+ * @param _6 the sixth element
+ * @see Tuple2
+ */
+public record Tuple6<E1, E2, E3, E4, E5, E6>(E1 _1, E2 _2, E3 _3, E4 _4, E5 _5, E6 _6) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple7.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple7.java
@@ -1,0 +1,22 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 7-element tuple for use with {@link Combiner7#map(Function7)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param <E4> type of the fourth element
+ * @param <E5> type of the fifth element
+ * @param <E6> type of the sixth element
+ * @param <E7> type of the seventh element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @param _4 the fourth element
+ * @param _5 the fifth element
+ * @param _6 the sixth element
+ * @param _7 the seventh element
+ * @see Tuple2
+ */
+public record Tuple7<E1, E2, E3, E4, E5, E6, E7>(E1 _1, E2 _2, E3 _3, E4 _4, E5 _5, E6 _6, E7 _7) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/Tuple8.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/Tuple8.java
@@ -1,0 +1,24 @@
+package net.unit8.raoh.combinator;
+
+/**
+ * A generic 8-element tuple for use with {@link Combiner8#map(Function8)}.
+ *
+ * @param <E1> type of the first element
+ * @param <E2> type of the second element
+ * @param <E3> type of the third element
+ * @param <E4> type of the fourth element
+ * @param <E5> type of the fifth element
+ * @param <E6> type of the sixth element
+ * @param <E7> type of the seventh element
+ * @param <E8> type of the eighth element
+ * @param _1 the first element
+ * @param _2 the second element
+ * @param _3 the third element
+ * @param _4 the fourth element
+ * @param _5 the fifth element
+ * @param _6 the sixth element
+ * @param _7 the seventh element
+ * @param _8 the eighth element
+ * @see Tuple2
+ */
+public record Tuple8<E1, E2, E3, E4, E5, E6, E7, E8>(E1 _1, E2 _2, E3 _3, E4 _4, E5 _5, E6 _6, E7 _7, E8 _8) {}

--- a/raoh/src/main/java/net/unit8/raoh/combinator/package-info.java
+++ b/raoh/src/main/java/net/unit8/raoh/combinator/package-info.java
@@ -2,5 +2,17 @@
  * Applicative-style combinator types for accumulating validation errors across multiple decoders.
  *
  * <p>Use {@link net.unit8.raoh.Decoders#combine} to create combiners.
+ *
+ * <p>This package also provides generic tuple types ({@link net.unit8.raoh.combinator.Tuple2}
+ * through {@link net.unit8.raoh.combinator.Tuple8}) for capturing combiner results without
+ * defining a dedicated record. These are especially useful with Java 21+ record patterns:
+ *
+ * <pre>{@code
+ * var dec = combine(field("name", string()), field("age", int_())).map(Tuple2::new);
+ * switch (dec.decode(input)) {
+ *     case Ok(Tuple2(var name, var age)) -> ...
+ *     case Err(var issues) -> ...
+ * }
+ * }</pre>
  */
 package net.unit8.raoh.combinator;

--- a/raoh/src/test/java/net/unit8/raoh/TupleTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/TupleTest.java
@@ -1,0 +1,146 @@
+package net.unit8.raoh;
+
+import net.unit8.raoh.combinator.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static net.unit8.raoh.ObjectDecoders.*;
+import static net.unit8.raoh.map.MapDecoders.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TupleTest {
+
+    @Test
+    void tuple2WithCombineAndPatternMatch() {
+        var dec = combine(
+                field("name", string()),
+                field("age", int_())
+        ).map(Tuple2::new);
+
+        var result = dec.decode(Map.of("name", "Alice", "age", 30));
+        switch (result) {
+            case Ok(Tuple2(var name, var age)) -> {
+                assertEquals("Alice", name);
+                assertEquals(30, age);
+            }
+            case Err(var issues) -> fail("Expected Ok, got: " + issues);
+        }
+    }
+
+    @Test
+    void tuple3WithCombine() {
+        var dec = combine(
+                field("a", string()),
+                field("b", int_()),
+                field("c", bool())
+        ).map(Tuple3::new);
+
+        var result = dec.decode(Map.of("a", "x", "b", 1, "c", true));
+        switch (result) {
+            case Ok(Tuple3(var a, var b, var c)) -> {
+                assertEquals("x", a);
+                assertEquals(1, b);
+                assertTrue(c);
+            }
+            case Err(var issues) -> fail("Expected Ok, got: " + issues);
+        }
+    }
+
+    @Test
+    void tuple4WithCombine() {
+        var dec = combine(
+                field("a", string()),
+                field("b", string()),
+                field("c", string()),
+                field("d", string())
+        ).map(Tuple4::new);
+
+        var result = dec.decode(Map.of("a", "1", "b", "2", "c", "3", "d", "4"));
+        switch (result) {
+            case Ok(Tuple4(var a, var b, var c, var d)) -> {
+                assertEquals("1", a);
+                assertEquals("4", d);
+            }
+            case Err(var issues) -> fail("Expected Ok, got: " + issues);
+        }
+    }
+
+    @Test
+    void tuple5WithCombine() {
+        var dec = combine(
+                field("a", string()), field("b", string()), field("c", string()),
+                field("d", string()), field("e", string())
+        ).map(Tuple5::new);
+
+        var result = dec.decode(Map.of("a", "1", "b", "2", "c", "3", "d", "4", "e", "5"));
+        assertInstanceOf(Ok.class, result);
+        var t = ((Ok<Tuple5<String, String, String, String, String>>) result).value();
+        assertEquals("5", t._5());
+    }
+
+    @Test
+    void tuple6WithCombine() {
+        var dec = combine(
+                field("a", string()), field("b", string()), field("c", string()),
+                field("d", string()), field("e", string()), field("f", string())
+        ).map(Tuple6::new);
+
+        var result = dec.decode(Map.of("a", "1", "b", "2", "c", "3", "d", "4", "e", "5", "f", "6"));
+        assertInstanceOf(Ok.class, result);
+        var t = ((Ok<Tuple6<String, String, String, String, String, String>>) result).value();
+        assertEquals("6", t._6());
+    }
+
+    @Test
+    void tuple7WithCombine() {
+        var dec = combine(
+                field("a", string()), field("b", string()), field("c", string()),
+                field("d", string()), field("e", string()), field("f", string()),
+                field("g", string())
+        ).map(Tuple7::new);
+
+        var result = dec.decode(Map.of("a", "1", "b", "2", "c", "3", "d", "4", "e", "5", "f", "6", "g", "7"));
+        assertInstanceOf(Ok.class, result);
+        var t = ((Ok<Tuple7<String, String, String, String, String, String, String>>) result).value();
+        assertEquals("7", t._7());
+    }
+
+    @Test
+    void tuple8WithCombine() {
+        var dec = combine(
+                field("a", string()), field("b", string()), field("c", string()),
+                field("d", string()), field("e", string()), field("f", string()),
+                field("g", string()), field("h", string())
+        ).map(Tuple8::new);
+
+        var input = Map.<String, Object>of("a", "1", "b", "2", "c", "3", "d", "4",
+                "e", "5", "f", "6", "g", "7", "h", "8");
+        var result = dec.decode(input);
+        assertInstanceOf(Ok.class, result);
+        var t = ((Ok<Tuple8<String, String, String, String, String, String, String, String>>) result).value();
+        assertEquals("8", t._8());
+    }
+
+    @Test
+    void tupleErrorAccumulation() {
+        var dec = combine(
+                field("name", string().nonBlank()),
+                field("age", int_().positive())
+        ).map(Tuple2::new);
+
+        var result = dec.decode(Map.of("name", "  ", "age", -1));
+        switch (result) {
+            case Ok(_) -> fail("Expected Err");
+            case Err(var issues) -> assertEquals(2, issues.asList().size());
+        }
+    }
+
+    @Test
+    void tupleEquality() {
+        var t1 = new Tuple2<>("a", 1);
+        var t2 = new Tuple2<>("a", 1);
+        assertEquals(t1, t2);
+        assertEquals(t1.hashCode(), t2.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Tuple2` through `Tuple8` generic record types in `net.unit8.raoh.combinator`
- Enable `combine(...).map(TupleN::new)` pattern for capturing decoded values without defining a dedicated record
- Support Java 21+ record pattern matching in `switch` expressions

## Motivation

`combine().map()` の結果を `switch` で分解するケースで、毎回専用の record を定義するのは冗長。
[実例](https://github.com/kawasima/jjug-ccc-2025-fall/blob/main/src/main/java/newlegacy/specdriven/web/OrderController.java) では `Tuple4` を自前定義して使用していた。

```java
// Before: 自前で Tuple を定義
record Tuple4<E1, E2, E3, E4>(E1 _1, E2 _2, E3 _3, E4 _4) {}

// After: raoh 組み込み
import net.unit8.raoh.combinator.Tuple4;

var dec = combine(
    field("customerId", long_()),
    field("items", list(string())),
    field("address", string()),
    field("date", string().date())
).map(Tuple4::new);

switch (dec.decode(input)) {
    case Ok(Tuple4(var id, var items, var addr, var date)) -> { ... }
    case Err(var issues) -> { ... }
}
```

## Test plan

- [x] `Tuple2`〜`Tuple8` が `CombinerN.map(TupleN::new)` で型推論が通ることを確認
- [x] record パターンマッチ（`case Ok(Tuple2(var a, var b))`）が動作することを確認
- [x] エラー蓄積テスト
- [x] equality テスト
- [x] `mvn test` 全モジュール通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)