### PR TITLE
Accept java.sql temporal types in ObjectDecoders

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/ObjectDecoders.java
@@ -169,25 +169,37 @@ public final class ObjectDecoders {
     /**
      * Creates a {@link LocalDate} decoder.
      *
-     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
-     * if the value is not a {@link LocalDate}.
+     * <p>Accepts {@link LocalDate} values directly, and converts {@link java.sql.Date}
+     * via {@link java.sql.Date#toLocalDate()}. Returns {@code required} if the value
+     * is {@code null}, and {@code type_mismatch} if the value is neither type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
      */
     public static TemporalDecoder<Object, LocalDate> date() {
-        return temporalOf(LocalDate.class, "date");
+        return new TemporalDecoder<>((in, path) -> switch (in) {
+            case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            case LocalDate d -> Result.ok(d);
+            case java.sql.Date sd -> Result.ok(sd.toLocalDate());
+            default -> typeMismatch(path, "date", in);
+        });
     }
 
     /**
      * Creates a {@link LocalTime} decoder.
      *
-     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
-     * if the value is not a {@link LocalTime}.
+     * <p>Accepts {@link LocalTime} values directly, and converts {@link java.sql.Time}
+     * via {@link java.sql.Time#toLocalTime()}. Returns {@code required} if the value
+     * is {@code null}, and {@code type_mismatch} if the value is neither type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
      */
     public static TemporalDecoder<Object, LocalTime> time() {
-        return temporalOf(LocalTime.class, "time");
+        return new TemporalDecoder<>((in, path) -> switch (in) {
+            case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            case LocalTime t -> Result.ok(t);
+            case java.sql.Time st -> Result.ok(st.toLocalTime());
+            default -> typeMismatch(path, "time", in);
+        });
     }
 
     /**
@@ -205,13 +217,19 @@ public final class ObjectDecoders {
     /**
      * Creates an {@link Instant} decoder.
      *
-     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
-     * if the value is not an {@link Instant}.
+     * <p>Accepts {@link Instant} values directly, and converts {@link java.sql.Timestamp}
+     * via {@link java.sql.Timestamp#toInstant()}. Returns {@code required} if the value
+     * is {@code null}, and {@code type_mismatch} if the value is neither type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link Instant}
      */
     public static TemporalDecoder<Object, Instant> iso8601() {
-        return temporalOf(Instant.class, "instant");
+        return new TemporalDecoder<>((in, path) -> switch (in) {
+            case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            case Instant i -> Result.ok(i);
+            case java.sql.Timestamp ts -> Result.ok(ts.toInstant());
+            default -> typeMismatch(path, "instant", in);
+        });
     }
 
     /**
@@ -224,6 +242,11 @@ public final class ObjectDecoders {
      */
     public static TemporalDecoder<Object, OffsetDateTime> offsetDateTime() {
         return temporalOf(OffsetDateTime.class, "offset-date-time");
+    }
+
+    private static <T> Result<T> typeMismatch(Path path, String expected, Object actual) {
+        return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected " + expected,
+                Map.of("expected", expected, "actual", actual.getClass().getSimpleName()));
     }
 
     private static <T extends Comparable<? super T>> TemporalDecoder<Object, T> temporalOf(

--- a/raoh/src/test/java/net/unit8/raoh/ObjectDecoderTemporalTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/ObjectDecoderTemporalTest.java
@@ -1,0 +1,177 @@
+package net.unit8.raoh;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static net.unit8.raoh.ObjectDecoders.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for temporal decoders in {@link ObjectDecoders}, including
+ * {@code java.sql.*} type conversion support.
+ */
+class ObjectDecoderTemporalTest {
+
+    // --- iso8601() : Instant ---
+
+    @Test
+    void iso8601AcceptsInstant() {
+        var instant = Instant.parse("2024-06-15T10:30:00Z");
+        switch (iso8601().decode(instant, Path.ROOT)) {
+            case Ok<Instant>(var v) -> assertEquals(instant, v);
+            case Err<Instant>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void iso8601AcceptsSqlTimestamp() {
+        var instant = Instant.parse("2024-06-15T10:30:00Z");
+        var ts = java.sql.Timestamp.from(instant);
+        switch (iso8601().decode(ts, Path.ROOT)) {
+            case Ok<Instant>(var v) -> assertEquals(instant, v);
+            case Err<Instant>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void iso8601RejectsNull() {
+        switch (iso8601().decode(null, Path.ROOT)) {
+            case Ok<Instant> _ -> fail("Expected Err for null");
+            case Err<Instant>(var issues) ->
+                    assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
+    void iso8601RejectsString() {
+        switch (iso8601().decode("not a timestamp", Path.ROOT)) {
+            case Ok<Instant> _ -> fail("Expected Err for String");
+            case Err<Instant>(var issues) ->
+                    assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- date() : LocalDate ---
+
+    @Test
+    void dateAcceptsLocalDate() {
+        var date = LocalDate.of(2024, 6, 15);
+        switch (date().decode(date, Path.ROOT)) {
+            case Ok<LocalDate>(var v) -> assertEquals(date, v);
+            case Err<LocalDate>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void dateAcceptsSqlDate() {
+        var date = LocalDate.of(2024, 6, 15);
+        var sqlDate = java.sql.Date.valueOf(date);
+        switch (date().decode(sqlDate, Path.ROOT)) {
+            case Ok<LocalDate>(var v) -> assertEquals(date, v);
+            case Err<LocalDate>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void dateRejectsNull() {
+        switch (date().decode(null, Path.ROOT)) {
+            case Ok<LocalDate> _ -> fail("Expected Err for null");
+            case Err<LocalDate>(var issues) ->
+                    assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
+    void dateRejectsWrongType() {
+        switch (date().decode(42, Path.ROOT)) {
+            case Ok<LocalDate> _ -> fail("Expected Err for Integer");
+            case Err<LocalDate>(var issues) ->
+                    assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- time() : LocalTime ---
+
+    @Test
+    void timeAcceptsLocalTime() {
+        var time = LocalTime.of(10, 30, 0);
+        switch (time().decode(time, Path.ROOT)) {
+            case Ok<LocalTime>(var v) -> assertEquals(time, v);
+            case Err<LocalTime>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void timeAcceptsSqlTime() {
+        var time = LocalTime.of(10, 30, 0);
+        var sqlTime = java.sql.Time.valueOf(time);
+        switch (time().decode(sqlTime, Path.ROOT)) {
+            case Ok<LocalTime>(var v) -> assertEquals(time, v);
+            case Err<LocalTime>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void timeRejectsNull() {
+        switch (time().decode(null, Path.ROOT)) {
+            case Ok<LocalTime> _ -> fail("Expected Err for null");
+            case Err<LocalTime>(var issues) ->
+                    assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+
+    @Test
+    void timeRejectsWrongType() {
+        switch (time().decode("10:30", Path.ROOT)) {
+            case Ok<LocalTime> _ -> fail("Expected Err for String");
+            case Err<LocalTime>(var issues) ->
+                    assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- dateTime() : LocalDateTime (unchanged, regression test) ---
+
+    @Test
+    void dateTimeAcceptsLocalDateTime() {
+        var dt = LocalDateTime.of(2024, 6, 15, 10, 30);
+        switch (dateTime().decode(dt, Path.ROOT)) {
+            case Ok<LocalDateTime>(var v) -> assertEquals(dt, v);
+            case Err<LocalDateTime>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void dateTimeRejectsNull() {
+        switch (dateTime().decode(null, Path.ROOT)) {
+            case Ok<LocalDateTime> _ -> fail("Expected Err for null");
+            case Err<LocalDateTime>(var issues) ->
+                    assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+
+    // --- offsetDateTime() : OffsetDateTime (unchanged, regression test) ---
+
+    @Test
+    void offsetDateTimeAcceptsOffsetDateTime() {
+        var odt = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.ofHours(9));
+        switch (offsetDateTime().decode(odt, Path.ROOT)) {
+            case Ok<OffsetDateTime>(var v) -> assertEquals(odt, v);
+            case Err<OffsetDateTime>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    @Test
+    void offsetDateTimeRejectsNull() {
+        switch (offsetDateTime().decode(null, Path.ROOT)) {
+            case Ok<OffsetDateTime> _ -> fail("Expected Err for null");
+            case Err<OffsetDateTime>(var issues) ->
+                    assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `iso8601()` now accepts `java.sql.Timestamp` (converts via `toInstant()`)
- `date()` now accepts `java.sql.Date` (converts via `toLocalDate()`)
- `time()` now accepts `java.sql.Time` (converts via `toLocalTime()`)
- `dateTime()` and `offsetDateTime()` are unchanged (no corresponding java.sql type)
- Extract `typeMismatch()` private helper to reduce duplication

This allows `MapDecoders.field("created_at", iso8601())` to work directly with JDBC row maps (e.g. Spring `JdbcClient.listOfRows()`) without any custom conversion.

## Test plan

- [x] 16 new tests in `ObjectDecoderTemporalTest`: java.sql conversion, java.time passthrough, null/type-mismatch errors, and regression tests for unchanged decoders
- [x] `mvn test` passes across all modules (including raoh-json `TemporalDecoderTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)