### PR TITLE
feat: add raoh-encoder module for domain object encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>raoh</module>
         <module>raoh-json</module>
         <module>raoh-jooq</module>
+        <module>raoh-encoder</module>
         <module>raoh-gsh</module>
         <module>raoh-gsh-weaver</module>
         <module>raoh-gsh-maven-plugin</module>

--- a/raoh-encoder/pom.xml
+++ b/raoh-encoder/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.unit8.raoh</groupId>
+        <artifactId>raoh-parent</artifactId>
+        <version>0.4.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>raoh-encoder</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Raoh Encoder</name>
+    <description>Domain object encoder library for Raoh — the dual of Decoder</description>
+    <url>https://github.com/kawasima/raoh</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.unit8.raoh</groupId>
+            <artifactId>raoh</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
@@ -59,6 +59,8 @@ public interface Encoder<T, O> {
      * {@code next}.
      *
      * <pre>{@code
+     * import static net.unit8.raoh.encoder.ObjectEncoders.*;
+     *
      * Encoder<Instant, String> enc = iso8601().andThen(o -> o.toString().replace("T", " "));
      * }</pre>
      *

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
@@ -57,7 +57,7 @@ public interface Encoder<T, O> {
      * {@code next}.
      *
      * <pre>{@code
-     * Encoder<Instant, String> enc = iso8601().andThen(s -> s.replace("T", " "));
+     * Encoder<Instant, String> enc = iso8601().andThen(o -> o.toString().replace("T", " "));
      * }</pre>
      *
      * @param <P>  the final output type

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
@@ -13,11 +13,13 @@ import java.util.function.Function;
  * {@link #andThen} (post-process the output):
  *
  * <pre>{@code
+ * import static net.unit8.raoh.encoder.ObjectEncoders.*;
+ *
  * // Pre-process: unwrap a value object before encoding
  * Encoder<UserId, Object> userIdEncoder = long_().contramap(UserId::value);
  *
  * // Post-process: convert to a different output type
- * Encoder<Long, String> longString = long_().andThen(o -> o.toString());
+ * Encoder<Long, String> longString = long_().andThen(o -> String.valueOf(o));
  * }</pre>
  *
  * @param <T> the domain type to encode from

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/Encoder.java
@@ -1,0 +1,70 @@
+package net.unit8.raoh.encoder;
+
+import java.util.function.Function;
+
+/**
+ * A function that encodes a domain object {@code T} into an external representation {@code O}.
+ *
+ * <p>This is the dual of {@link net.unit8.raoh.Decoder Decoder}: where a decoder converts
+ * an untrusted external value into a validated domain object (and may fail), an encoder
+ * converts a trusted domain object into an external representation and never fails.
+ *
+ * <p>Encoders compose via {@link #contramap} (pre-process the input) and
+ * {@link #andThen} (post-process the output):
+ *
+ * <pre>{@code
+ * // Pre-process: unwrap a value object before encoding
+ * Encoder<UserId, Object> userIdEncoder = long_().contramap(UserId::value);
+ *
+ * // Post-process: convert to a different output type
+ * Encoder<Long, String> longString = long_().andThen(o -> o.toString());
+ * }</pre>
+ *
+ * @param <T> the domain type to encode from
+ * @param <O> the external representation type to encode to
+ */
+@FunctionalInterface
+public interface Encoder<T, O> {
+
+    /**
+     * Encodes the given domain value into an external representation.
+     *
+     * @param value the domain value to encode; must not be {@code null}
+     * @return the encoded external representation
+     */
+    O encode(T value);
+
+    /**
+     * Returns an encoder that first applies {@code f} to its input, then encodes the result.
+     *
+     * <p>This is the standard {@code contramap} operation for encoders.
+     * Use it to unwrap value objects before encoding:
+     *
+     * <pre>{@code
+     * Encoder<UserId, Object> enc = long_().contramap(UserId::value);
+     * }</pre>
+     *
+     * @param <S> the new input type
+     * @param f   the function to apply to the input before encoding
+     * @return a new encoder whose input type is {@code S}
+     */
+    default <S> Encoder<S, O> contramap(Function<S, T> f) {
+        return value -> this.encode(f.apply(value));
+    }
+
+    /**
+     * Returns an encoder that encodes with {@code this} and then transforms the output with
+     * {@code next}.
+     *
+     * <pre>{@code
+     * Encoder<Instant, String> enc = iso8601().andThen(s -> s.replace("T", " "));
+     * }</pre>
+     *
+     * @param <P>  the final output type
+     * @param next the encoder to apply to the output of {@code this}
+     * @return a composed encoder
+     */
+    default <P> Encoder<T, P> andThen(Encoder<O, P> next) {
+        return value -> next.encode(this.encode(value));
+    }
+}

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
@@ -1,0 +1,128 @@
+package net.unit8.raoh.encoder;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Factory for encoders that produce {@code Map<String, Object>} — the format consumed by
+ * Spring JDBC's {@code JdbcClient} named-parameter binding.
+ *
+ * <p>This is the encoding counterpart of
+ * {@link net.unit8.raoh.map.MapDecoders MapDecoders}. The API mirrors the decoder side
+ * deliberately so that decoder and encoder definitions can be written side by side:
+ *
+ * <pre>{@code
+ * import static net.unit8.raoh.map.MapDecoders.*;
+ * import static net.unit8.raoh.ObjectDecoders.*;
+ * import static net.unit8.raoh.encoder.MapEncoders.*;
+ * import static net.unit8.raoh.encoder.ObjectEncoders.*;
+ *
+ * // Decoder: Map → Table
+ * static final Decoder<Map<String, Object>, Table> TABLE_DECODER = combine(
+ *     field("id",           long_()).map(TableId::new),
+ *     field("table_number", int_()),
+ *     field("capacity",     int_())
+ * ).map(Table::new);
+ *
+ * // Encoder: Table → Map  (mirror image)
+ * static final Encoder<Table, Map<String, Object>> TABLE_ENCODER = object(
+ *     property("id",           Table::id,          long_().contramap(TableId::value)),
+ *     property("table_number", Table::tableNumber, int_()),
+ *     property("capacity",     Table::capacity,    int_())
+ * );
+ * }</pre>
+ *
+ * <p>Usage: {@code import static net.unit8.raoh.encoder.MapEncoders.*;}
+ */
+public final class MapEncoders {
+
+    private MapEncoders() {}
+
+    /**
+     * Creates a {@link PropertyEncoder} that binds a map key to a getter and a value encoder.
+     *
+     * <p>Corresponds to {@link net.unit8.raoh.map.MapDecoders#field(String, net.unit8.raoh.Decoder)
+     * MapDecoders.field()} on the decoder side.
+     *
+     * @param <T>          the domain type
+     * @param <V>          the property value type
+     * @param key          the output map key (e.g., column name)
+     * @param getter       extracts the property value from the domain object
+     * @param valueEncoder encodes the extracted value to {@code Object}
+     * @return a property encoder for use with {@link #object(PropertyEncoder[])}
+     */
+    public static <T, V> PropertyEncoder<T> property(
+            String key,
+            Function<T, V> getter,
+            Encoder<V, Object> valueEncoder) {
+        return new PropertyEncoder<>(key, getter, valueEncoder);
+    }
+
+    /**
+     * Creates an encoder that builds a {@code Map<String, Object>} from a domain object
+     * by applying each property encoder in order.
+     *
+     * <p>The resulting map preserves insertion order (backed by {@link LinkedHashMap}).
+     * Corresponds to {@code combine(...).map(Constructor::new)} on the decoder side.
+     *
+     * @param <T>        the domain type to encode
+     * @param properties the property encoders that define the output map entries
+     * @return an encoder producing {@code Map<String, Object>}
+     */
+    @SafeVarargs
+    public static <T> Encoder<T, Map<String, Object>> object(PropertyEncoder<T>... properties) {
+        return value -> {
+            var map = new LinkedHashMap<String, Object>(properties.length * 2);
+            for (var prop : properties) {
+                map.put(prop.key(), prop.encode(value));
+            }
+            return map;
+        };
+    }
+
+    /**
+     * Adapts an {@code Encoder<T, Map<String, Object>>} for use as a value encoder
+     * (i.e., as the third argument to {@link #property}).
+     *
+     * <p>Corresponds to {@link net.unit8.raoh.map.MapDecoders#nested(net.unit8.raoh.Decoder)
+     * MapDecoders.nested()} on the decoder side. Use it to embed a structured encoder
+     * inside a parent {@link #object}:
+     *
+     * <pre>{@code
+     * static final Encoder<Restaurant, Map<String, Object>> RESTAURANT_ENCODER = object(
+     *     property("id",     Restaurant::id,     long_().contramap(RestaurantId::value)),
+     *     property("name",   Restaurant::name,   string()),
+     *     property("tables", Restaurant::tables, list(nested(TABLE_ENCODER)))
+     * );
+     * }</pre>
+     *
+     * @param <T> the domain type of the nested encoder
+     * @param enc the encoder to adapt
+     * @return an encoder whose output type is {@code Object}
+     */
+    public static <T> Encoder<T, Object> nested(Encoder<T, Map<String, Object>> enc) {
+        return value -> enc.encode(value);
+    }
+
+    /**
+     * Creates an encoder that applies an element encoder to every item in a {@link List}.
+     *
+     * <p>Corresponds to {@link net.unit8.raoh.Decoder#list() Decoder.list()} on the decoder
+     * side. Commonly used with {@link #nested} to encode a list of nested objects:
+     *
+     * <pre>{@code
+     * property("tables", Restaurant::tables, list(nested(TABLE_ENCODER)))
+     * }</pre>
+     *
+     * @param <T>            the element domain type
+     * @param elementEncoder the encoder for each list element
+     * @return an encoder that produces {@code List<Object>}
+     */
+    public static <T> Encoder<List<T>, Object> list(Encoder<T, Object> elementEncoder) {
+        return values -> values.stream()
+                .map(elementEncoder::encode)
+                .toList();
+    }
+}

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
@@ -34,6 +34,16 @@ import java.util.function.Function;
  * );
  * }</pre>
  *
+ * <p>The {@code Map<String, Object>} output integrates naturally with other libraries:
+ * <ul>
+ *   <li><strong>Spring JDBC</strong> — pass directly to {@code JdbcClient} named-parameter
+ *       binding via {@code .params(map)}</li>
+ *   <li><strong>jOOQ</strong> — populate a typed record via
+ *       {@code record.fromMap(map)} (note: key matching is case-sensitive per jOOQ convention)</li>
+ *   <li><strong>Jackson</strong> — convert to {@code ObjectNode} via
+ *       {@code objectMapper.valueToTree(map)}</li>
+ * </ul>
+ *
  * <p>Usage: {@code import static net.unit8.raoh.encoder.MapEncoders.*;}
  */
 public final class MapEncoders {

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/MapEncoders.java
@@ -103,7 +103,7 @@ public final class MapEncoders {
      * @return an encoder whose output type is {@code Object}
      */
     public static <T> Encoder<T, Object> nested(Encoder<T, Map<String, Object>> enc) {
-        return value -> enc.encode(value);
+        return enc::encode;
     }
 
     /**

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
@@ -101,8 +101,11 @@ public final class ObjectEncoders {
     }
 
     /**
-     * Returns an encoder that converts a {@link LocalDateTime} to its ISO-8601 string
-     * representation.
+     * Returns an encoder that converts a {@link LocalDateTime} to a string via
+     * {@link LocalDateTime#toString()}.
+     *
+     * <p>The output follows ISO-8601 but omits trailing zero seconds and nanoseconds
+     * (e.g., {@code "2024-06-15T10:30"} rather than {@code "2024-06-15T10:30:00"}).
      *
      * @return a local date-time encoder
      */
@@ -111,8 +114,11 @@ public final class ObjectEncoders {
     }
 
     /**
-     * Returns an encoder that converts an {@link OffsetDateTime} to its ISO-8601 string
-     * representation.
+     * Returns an encoder that converts an {@link OffsetDateTime} to a string via
+     * {@link OffsetDateTime#toString()}.
+     *
+     * <p>The output follows ISO-8601 but omits trailing zero seconds and nanoseconds
+     * (e.g., {@code "2024-06-15T10:30+09:00"} rather than {@code "2024-06-15T10:30:00+09:00"}).
      *
      * @return an offset date-time encoder
      */

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
@@ -135,4 +135,22 @@ public final class ObjectEncoders {
     public static <E extends Enum<E>> Encoder<E, Object> enumOf() {
         return v -> v.name();
     }
+
+    /**
+     * Wraps an encoder to accept {@code null} input, passing {@code null} through to the output.
+     *
+     * <p>Use this for nullable columns in UPDATE statements where the domain object may carry
+     * a {@code null} value:
+     *
+     * <pre>{@code
+     * property("description", Item::description, nullable(string()))
+     * }</pre>
+     *
+     * @param <T> the domain value type
+     * @param enc the inner encoder to apply when the value is non-null
+     * @return an encoder that passes {@code null} through without invoking {@code enc}
+     */
+    public static <T> Encoder<T, Object> nullable(Encoder<T, Object> enc) {
+        return v -> v == null ? null : enc.encode(v);
+    }
 }

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
@@ -1,0 +1,132 @@
+package net.unit8.raoh.encoder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+/**
+ * Factory for primitive {@code Encoder} instances that encode domain values to {@code Object}.
+ *
+ * <p>These encoders are the dual of the primitive decoders in
+ * {@link net.unit8.raoh.ObjectDecoders ObjectDecoders}. Each encoder corresponds to the
+ * decoder of the same name and produces an {@code Object} suitable for use as a JDBC parameter.
+ *
+ * <p>Combine with {@link Encoder#contramap} to unwrap value objects:
+ *
+ * <pre>{@code
+ * import static net.unit8.raoh.encoder.ObjectEncoders.*;
+ *
+ * Encoder<UserId, Object> enc = long_().contramap(UserId::value);
+ * }</pre>
+ *
+ * <p>Usage: {@code import static net.unit8.raoh.encoder.ObjectEncoders.*;}
+ */
+public final class ObjectEncoders {
+
+    private ObjectEncoders() {}
+
+    /**
+     * Returns an encoder that passes a {@link String} through as-is.
+     *
+     * @return a string encoder
+     */
+    public static Encoder<String, Object> string() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that passes an {@link Integer} through as-is.
+     *
+     * @return an integer encoder
+     */
+    public static Encoder<Integer, Object> int_() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that passes a {@link Long} through as-is.
+     *
+     * @return a long encoder
+     */
+    public static Encoder<Long, Object> long_() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that passes a {@link Boolean} through as-is.
+     *
+     * @return a boolean encoder
+     */
+    public static Encoder<Boolean, Object> bool() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that passes a {@link BigDecimal} through as-is.
+     *
+     * @return a decimal encoder
+     */
+    public static Encoder<BigDecimal, Object> decimal() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that converts an {@link Instant} to its ISO-8601 string representation.
+     *
+     * @return an instant encoder
+     */
+    public static Encoder<Instant, Object> iso8601() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts a {@link LocalDate} to its ISO-8601 string representation.
+     *
+     * @return a local date encoder
+     */
+    public static Encoder<LocalDate, Object> date() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts a {@link LocalTime} to its ISO-8601 string representation.
+     *
+     * @return a local time encoder
+     */
+    public static Encoder<LocalTime, Object> time() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts a {@link LocalDateTime} to its ISO-8601 string
+     * representation.
+     *
+     * @return a local date-time encoder
+     */
+    public static Encoder<LocalDateTime, Object> dateTime() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts an {@link OffsetDateTime} to its ISO-8601 string
+     * representation.
+     *
+     * @return an offset date-time encoder
+     */
+    public static Encoder<OffsetDateTime, Object> offsetDateTime() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts an enum constant to its {@link Enum#name() name} string.
+     *
+     * @param <E> the enum type
+     * @return an enum encoder
+     */
+    public static <E extends Enum<E>> Encoder<E, Object> enumOf() {
+        return v -> v.name();
+    }
+}

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/ObjectEncoders.java
@@ -143,6 +143,9 @@ public final class ObjectEncoders {
      * a {@code null} value:
      *
      * <pre>{@code
+     * import static net.unit8.raoh.encoder.MapEncoders.*;
+     * import static net.unit8.raoh.encoder.ObjectEncoders.*;
+     *
      * property("description", Item::description, nullable(string()))
      * }</pre>
      *

--- a/raoh-encoder/src/main/java/net/unit8/raoh/encoder/PropertyEncoder.java
+++ b/raoh-encoder/src/main/java/net/unit8/raoh/encoder/PropertyEncoder.java
@@ -1,0 +1,58 @@
+package net.unit8.raoh.encoder;
+
+import java.util.function.Function;
+
+/**
+ * A named property encoder that extracts a field from a domain object and encodes its value.
+ *
+ * <p>Analogous to {@link net.unit8.raoh.FieldDecoder FieldDecoder} on the decoder side,
+ * a {@code PropertyEncoder} binds together:
+ *
+ * <ul>
+ *   <li>a map key (the column or JSON field name)</li>
+ *   <li>a getter that extracts the field value from the domain object</li>
+ *   <li>a value encoder that converts the extracted value to {@code Object}</li>
+ * </ul>
+ *
+ * <p>Created via {@link MapEncoders#property(String, Function, Encoder)} and consumed by
+ * {@link MapEncoders#object(PropertyEncoder[])}.
+ *
+ * @param <T> the domain type from which the property is extracted
+ */
+public final class PropertyEncoder<T> {
+
+    private final String key;
+    private final Function<T, Object> extractor;
+
+    /**
+     * Creates a property encoder.
+     *
+     * @param <V>          the property value type
+     * @param key          the output map key
+     * @param getter       extracts the property value from the domain object
+     * @param valueEncoder encodes the extracted value to {@code Object}
+     */
+    <V> PropertyEncoder(String key, Function<T, V> getter, Encoder<V, Object> valueEncoder) {
+        this.key = key;
+        this.extractor = value -> valueEncoder.encode(getter.apply(value));
+    }
+
+    /**
+     * Returns the map key for this property.
+     *
+     * @return the map key
+     */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * Extracts and encodes the property value from the given domain object.
+     *
+     * @param value the domain object
+     * @return the encoded property value
+     */
+    public Object encode(T value) {
+        return extractor.apply(value);
+    }
+}

--- a/raoh-encoder/src/test/java/net/unit8/raoh/encoder/MapEncoderTest.java
+++ b/raoh-encoder/src/test/java/net/unit8/raoh/encoder/MapEncoderTest.java
@@ -1,0 +1,68 @@
+package net.unit8.raoh.encoder;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static net.unit8.raoh.encoder.MapEncoders.*;
+import static net.unit8.raoh.encoder.ObjectEncoders.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for flat (non-nested) object encoding with {@link MapEncoders}.
+ */
+class MapEncoderTest {
+
+    // --- Domain model ---
+
+    record ItemId(long value) {}
+
+    record Item(ItemId id, String name, BigDecimal price) {}
+
+    // --- Encoders ---
+
+    static final Encoder<Item, Map<String, Object>> ITEM_ENCODER = object(
+            property("id",    Item::id,    long_().contramap(ItemId::value)),
+            property("name",  Item::name,  string()),
+            property("price", Item::price, decimal())
+    );
+
+    // --- Tests ---
+
+    @Test
+    void encodesAllFields() {
+        var item = new Item(new ItemId(42L), "Widget", new BigDecimal("9.99"));
+        var row = ITEM_ENCODER.encode(item);
+
+        assertEquals(42L,                    row.get("id"));
+        assertEquals("Widget",               row.get("name"));
+        assertEquals(new BigDecimal("9.99"), row.get("price"));
+    }
+
+    @Test
+    void preservesInsertionOrder() {
+        var item = new Item(new ItemId(1L), "A", BigDecimal.ONE);
+        var keys = ITEM_ENCODER.encode(item).keySet().stream().toList();
+        assertEquals(java.util.List.of("id", "name", "price"), keys);
+    }
+
+    @Test
+    void contramapUnwrapsValueObject() {
+        var enc = long_().contramap(ItemId::value);
+        assertEquals(7L, enc.encode(new ItemId(7L)));
+    }
+
+    @Test
+    void andThenTransformsOutput() {
+        var enc = long_().andThen(o -> "id=" + o);
+        assertEquals("id=42", enc.encode(42L));
+    }
+
+    @Test
+    void enumOfEncodesName() {
+        enum Color { RED, GREEN, BLUE }
+        Encoder<Color, Object> enc = enumOf();
+        assertEquals("GREEN", enc.encode(Color.GREEN));
+    }
+}

--- a/raoh-encoder/src/test/java/net/unit8/raoh/encoder/MapEncoderTest.java
+++ b/raoh-encoder/src/test/java/net/unit8/raoh/encoder/MapEncoderTest.java
@@ -65,4 +65,16 @@ class MapEncoderTest {
         Encoder<Color, Object> enc = enumOf();
         assertEquals("GREEN", enc.encode(Color.GREEN));
     }
+
+    @Test
+    void nullablePassesThroughNull() {
+        var enc = nullable(string());
+        assertNull(enc.encode(null));
+    }
+
+    @Test
+    void nullableDelegatesToInnerEncoderWhenNonNull() {
+        var enc = nullable(string());
+        assertEquals("hello", enc.encode("hello"));
+    }
 }

--- a/raoh-encoder/src/test/java/net/unit8/raoh/encoder/NestedEncoderTest.java
+++ b/raoh-encoder/src/test/java/net/unit8/raoh/encoder/NestedEncoderTest.java
@@ -1,0 +1,94 @@
+package net.unit8.raoh.encoder;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static net.unit8.raoh.encoder.MapEncoders.*;
+import static net.unit8.raoh.encoder.ObjectEncoders.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for nested and list encoding with {@link MapEncoders#nested} and
+ * {@link MapEncoders#list}.
+ *
+ * <p>Uses a Restaurant / Table domain to demonstrate a dependent relationship
+ * where the parent (Restaurant) holds a collection of children (Table).
+ * This mirrors the decoder-side pattern of {@code nested()} + {@code list()}.
+ */
+class NestedEncoderTest {
+
+    // --- Domain model ---
+
+    record TableId(long value) {}
+
+    record Table(TableId id, int tableNumber, int capacity) {}
+
+    record RestaurantId(long value) {}
+
+    record Restaurant(RestaurantId id, String name, List<Table> tables) {}
+
+    // --- Encoders ---
+
+    static final Encoder<Table, Map<String, Object>> TABLE_ENCODER = object(
+            property("id",           Table::id,          long_().contramap(TableId::value)),
+            property("table_number", Table::tableNumber, int_()),
+            property("capacity",     Table::capacity,    int_())
+    );
+
+    static final Encoder<Restaurant, Map<String, Object>> RESTAURANT_ENCODER = object(
+            property("id",     Restaurant::id,     long_().contramap(RestaurantId::value)),
+            property("name",   Restaurant::name,   string()),
+            property("tables", Restaurant::tables, list(nested(TABLE_ENCODER)))
+    );
+
+    // --- Tests ---
+
+    @Test
+    void encodesNestedList() {
+        var restaurant = new Restaurant(
+                new RestaurantId(1L),
+                "Sakura",
+                List.of(
+                        new Table(new TableId(10L), 1, 4),
+                        new Table(new TableId(11L), 2, 2)
+                )
+        );
+
+        var row = RESTAURANT_ENCODER.encode(restaurant);
+
+        assertEquals(1L,      row.get("id"));
+        assertEquals("Sakura", row.get("name"));
+
+        @SuppressWarnings("unchecked")
+        var tables = (List<Object>) row.get("tables");
+        assertEquals(2, tables.size());
+
+        @SuppressWarnings("unchecked")
+        var table0 = (Map<String, Object>) tables.get(0);
+        assertEquals(10L, table0.get("id"));
+        assertEquals(1,   table0.get("table_number"));
+        assertEquals(4,   table0.get("capacity"));
+    }
+
+    @Test
+    void encodesEmptyList() {
+        var restaurant = new Restaurant(new RestaurantId(2L), "Empty", List.of());
+        var row = RESTAURANT_ENCODER.encode(restaurant);
+
+        @SuppressWarnings("unchecked")
+        var tables = (List<Object>) row.get("tables");
+        assertTrue(tables.isEmpty());
+    }
+
+    @Test
+    void tableEncoderCanBeUsedStandalone() {
+        var table = new Table(new TableId(5L), 3, 6);
+        var row = TABLE_ENCODER.encode(table);
+
+        assertEquals(5L, row.get("id"));
+        assertEquals(3,  row.get("table_number"));
+        assertEquals(6,  row.get("capacity"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `raoh-encoder` as the dual of `raoh`'s `Decoder<I, T>` — an `Encoder<T, O>` that converts trusted domain objects to external representations (never fails)
- Motivated by value-object unwrapping repetition across INSERT/UPDATE/multiple output destinations in Spring JDBC code
- Mirrors the `MapDecoders` API so decoder and encoder definitions can be written side-by-side as a mirror image

## Core API

```java
// Decoder: Map → Table
static final Decoder<Map<String, Object>, Table> TABLE_DECODER = combine(
    field("id",           long_()).map(TableId::new),
    field("table_number", int_()),
    field("capacity",     int_())
).map(Table::new);

// Encoder: Table → Map  (mirror image)
static final Encoder<Table, Map<String, Object>> TABLE_ENCODER = object(
    property("id",           Table::id,          long_().contramap(TableId::value)),
    property("table_number", Table::tableNumber, int_()),
    property("capacity",     Table::capacity,    int_())
);
```

The encoded map can be passed directly to Spring JDBC's named-parameter binding, shared across INSERT and UPDATE without duplicating value-object unwrapping.

## Design decisions

- `Encoder<T, O>` is a `@FunctionalInterface` — `T -> O` with no error path (domain objects are already valid)
- `contramap(Function<S, T>)` on the interface for pre-processing (unwrapping value objects)
- `andThen(Encoder<O, P>)` for post-processing output
- `object()` / `property()` naming follows Elm's `Json.Encode` convention (intentionally different from `combine`/`field` on the decoder side)
- `nested()` and `list()` match `MapDecoders.nested()` / `Decoder.list()` exactly
- No external dependencies — `raoh-encoder` depends only on `raoh`

## Test plan

- [x] `MapEncoderTest`: flat object encoding, insertion-order preservation, `contramap`, `andThen`, `enumOf`
- [x] `NestedEncoderTest`: nested object via `nested()`, list of nested objects via `list(nested(...))`, standalone child encoder reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)