### PR TITLE
Add double_(), float_(), and bytes() decoders

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
@@ -9,6 +9,8 @@ import net.unit8.raoh.Result;
 
 import net.unit8.raoh.decode.builtin.BoolDecoder;
 import net.unit8.raoh.decode.builtin.DecimalDecoder;
+import net.unit8.raoh.decode.builtin.DoubleDecoder;
+import net.unit8.raoh.decode.builtin.FloatDecoder;
 import net.unit8.raoh.decode.builtin.IntDecoder;
 import net.unit8.raoh.decode.builtin.ListDecoder;
 import net.unit8.raoh.decode.builtin.LongDecoder;
@@ -129,6 +131,56 @@ public final class ObjectDecoders {
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected long",
                     Map.of("expected", "long", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates a double decoder.
+     *
+     * <p>Accepts {@link Double} values directly, and widens other {@link Number} subtypes
+     * via {@link Number#doubleValue()}. Returns {@code required} if the value is {@code null},
+     * and {@code type_mismatch} if the value is not a number.
+     *
+     * @return a double decoder for {@code Object} input
+     */
+    public static DoubleDecoder<Object> double_() {
+        return new DoubleDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof Double d) {
+                return Result.ok(d);
+            }
+            if (in instanceof Number n) {
+                return Result.ok(n.doubleValue());
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
+                    Map.of("expected", "double", "actual", in.getClass().getSimpleName()));
+        });
+    }
+
+    /**
+     * Creates a float decoder.
+     *
+     * <p>Accepts {@link Float} values directly, and narrows other {@link Number} subtypes
+     * via {@link Number#floatValue()}. Returns {@code required} if the value is {@code null},
+     * and {@code type_mismatch} if the value is not a number.
+     *
+     * @return a float decoder for {@code Object} input
+     */
+    public static FloatDecoder<Object> float_() {
+        return new FloatDecoder<>((in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof Float f) {
+                return Result.ok(f);
+            }
+            if (in instanceof Number n) {
+                return Result.ok(n.floatValue());
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
+                    Map.of("expected", "float", "actual", in.getClass().getSimpleName()));
         });
     }
 
@@ -369,6 +421,32 @@ public final class ObjectDecoders {
             }
             return Result.ok(Map.copyOf(results));
         });
+    }
+
+    // --- bytes ---
+
+    /**
+     * Creates a {@code byte[]} decoder.
+     *
+     * <p>Accepts {@code byte[]} values directly. Returns {@code required} if the value is
+     * {@code null}, and {@code type_mismatch} if the value is not a {@code byte[]}.
+     *
+     * <p>Suitable for JDBC binary columns such as PostgreSQL {@code BYTEA}
+     * or SQL standard {@code VARBINARY}.
+     *
+     * @return a byte array decoder for {@code Object} input
+     */
+    public static Decoder<Object, byte[]> bytes() {
+        return (in, path) -> {
+            if (in == null) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (in instanceof byte[] ba) {
+                return Result.ok(ba);
+            }
+            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected byte[]",
+                    Map.of("expected", "byte[]", "actual", in.getClass().getSimpleName()));
+        };
     }
 
     // --- enumOf / literal ---

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
@@ -1,0 +1,212 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.decode.Decoder;
+import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Path;
+import net.unit8.raoh.Result;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A decoder for double values with a fluent API for numeric constraints.
+ *
+ * <p>Comparisons use {@link Double#compare(double, double)} to handle
+ * {@code NaN} and infinity correctly.
+ *
+ * @param <I> the input type
+ */
+public class DoubleDecoder<I> implements Decoder<I, Double> {
+
+    private final Decoder<I, Double> inner;
+
+    /**
+     * Creates a new double decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
+    public DoubleDecoder(Decoder<I, Double> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Result<Double> decode(I in, Path path) {
+        return inner.decode(in, path);
+    }
+
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n the minimum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
+    public DoubleDecoder<I> min(double n) {
+        return min(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n       the minimum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
+    public DoubleDecoder<I> min(double n, String message) {
+        return chain((value, path) -> {
+            if (Double.compare(value, n) < 0) {
+                var meta = Map.<String, Object>of("min", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %s".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
+    public DoubleDecoder<I> max(double n) {
+        return max(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n       the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
+    public DoubleDecoder<I> max(double n, String message) {
+        return chain((value, path) -> {
+            if (Double.compare(value, n) > 0) {
+                var meta = Map.<String, Object>of("max", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %s".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public DoubleDecoder<I> range(double min, double max) {
+        return range(min, max, null);
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min     the minimum allowed value (inclusive)
+     * @param max     the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public DoubleDecoder<I> range(double min, double max, String message) {
+        return chain((value, path) -> {
+            if (Double.compare(value, min) < 0 || Double.compare(value, max) > 0) {
+                var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be between %s and %s".formatted(min, max), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
+    public DoubleDecoder<I> positive() {
+        return chain((value, path) -> {
+            if (Double.compare(value, 0.0) <= 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive",
+                        Map.of("min", 0.0, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
+    public DoubleDecoder<I> negative() {
+        return chain((value, path) -> {
+            if (Double.compare(value, 0.0) >= 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative",
+                        Map.of("max", 0.0, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
+    public DoubleDecoder<I> nonNegative() {
+        return chain((value, path) -> {
+            if (Double.compare(value, 0.0) < 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative",
+                        Map.of("min", 0.0, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
+    public DoubleDecoder<I> nonPositive() {
+        return chain((value, path) -> {
+            if (Double.compare(value, 0.0) > 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive",
+                        Map.of("max", 0.0, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to one of the specified allowed values.
+     *
+     * @param allowed the set of allowed double values
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_ALLOWED} if the value is not in the set
+     */
+    public DoubleDecoder<I> oneOf(Double... allowed) {
+        var allowedSet = Set.of(allowed);
+        var sortedAllowed = List.copyOf(new TreeSet<>(allowedSet));
+        var message = "must be one of %s".formatted(sortedAllowed);
+        return chain((value, path) -> {
+            if (!allowedSet.contains(value)) {
+                var meta = Map.<String, Object>of("allowed", sortedAllowed, "actual", value);
+                return Result.fail(path, ErrorCodes.NOT_ALLOWED, message, meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    private DoubleDecoder<I> chain(Decoder<Double, Double> constraint) {
+        return new DoubleDecoder<>((in, path) ->
+                this.decode(in, path).flatMap(value -> constraint.decode(value, path))
+        );
+    }
+}

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
@@ -1,0 +1,212 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.decode.Decoder;
+import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Path;
+import net.unit8.raoh.Result;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A decoder for float values with a fluent API for numeric constraints.
+ *
+ * <p>Comparisons use {@link Float#compare(float, float)} to handle
+ * {@code NaN} and infinity correctly.
+ *
+ * @param <I> the input type
+ */
+public class FloatDecoder<I> implements Decoder<I, Float> {
+
+    private final Decoder<I, Float> inner;
+
+    /**
+     * Creates a new float decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
+    public FloatDecoder(Decoder<I, Float> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Result<Float> decode(I in, Path path) {
+        return inner.decode(in, path);
+    }
+
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n the minimum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
+    public FloatDecoder<I> min(float n) {
+        return min(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n       the minimum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
+    public FloatDecoder<I> min(float n, String message) {
+        return chain((value, path) -> {
+            if (Float.compare(value, n) < 0) {
+                var meta = Map.<String, Object>of("min", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %s".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
+    public FloatDecoder<I> max(float n) {
+        return max(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n       the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
+    public FloatDecoder<I> max(float n, String message) {
+        return chain((value, path) -> {
+            if (Float.compare(value, n) > 0) {
+                var meta = Map.<String, Object>of("max", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %s".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public FloatDecoder<I> range(float min, float max) {
+        return range(min, max, null);
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min     the minimum allowed value (inclusive)
+     * @param max     the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public FloatDecoder<I> range(float min, float max, String message) {
+        return chain((value, path) -> {
+            if (Float.compare(value, min) < 0 || Float.compare(value, max) > 0) {
+                var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be between %s and %s".formatted(min, max), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
+    public FloatDecoder<I> positive() {
+        return chain((value, path) -> {
+            if (Float.compare(value, 0.0f) <= 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive",
+                        Map.of("min", 0.0f, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
+    public FloatDecoder<I> negative() {
+        return chain((value, path) -> {
+            if (Float.compare(value, 0.0f) >= 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative",
+                        Map.of("max", 0.0f, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
+    public FloatDecoder<I> nonNegative() {
+        return chain((value, path) -> {
+            if (Float.compare(value, 0.0f) < 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative",
+                        Map.of("min", 0.0f, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
+    public FloatDecoder<I> nonPositive() {
+        return chain((value, path) -> {
+            if (Float.compare(value, 0.0f) > 0) {
+                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive",
+                        Map.of("max", 0.0f, "actual", value));
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to one of the specified allowed values.
+     *
+     * @param allowed the set of allowed float values
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_ALLOWED} if the value is not in the set
+     */
+    public FloatDecoder<I> oneOf(Float... allowed) {
+        var allowedSet = Set.of(allowed);
+        var sortedAllowed = List.copyOf(new TreeSet<>(allowedSet));
+        var message = "must be one of %s".formatted(sortedAllowed);
+        return chain((value, path) -> {
+            if (!allowedSet.contains(value)) {
+                var meta = Map.<String, Object>of("allowed", sortedAllowed, "actual", value);
+                return Result.fail(path, ErrorCodes.NOT_ALLOWED, message, meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    private FloatDecoder<I> chain(Decoder<Float, Float> constraint) {
+        return new FloatDecoder<>((in, path) ->
+                this.decode(in, path).flatMap(value -> constraint.decode(value, path))
+        );
+    }
+}

--- a/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
@@ -56,6 +56,24 @@ public final class ObjectEncoders {
     }
 
     /**
+     * Returns an encoder that passes a {@link Double} through as-is.
+     *
+     * @return a double encoder
+     */
+    public static Encoder<Double, Object> double_() {
+        return v -> v;
+    }
+
+    /**
+     * Returns an encoder that passes a {@link Float} through as-is.
+     *
+     * @return a float encoder
+     */
+    public static Encoder<Float, Object> float_() {
+        return v -> v;
+    }
+
+    /**
      * Returns an encoder that passes a {@link Boolean} through as-is.
      *
      * @return a boolean encoder

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -866,6 +866,29 @@ class MapDecoderTest {
     }
 
     @Test
+    void doubleNegative() {
+        var dec = field("x", double_().negative());
+        assertEquals(-1.5, assertOk(dec.decode(Map.of("x", -1.5))));
+        assertErr(dec.decode(Map.of("x", 0.0)));
+        assertErr(dec.decode(Map.of("x", 1.0)));
+    }
+
+    @Test
+    void doubleNonPositive() {
+        var dec = field("x", double_().nonPositive());
+        assertEquals(0.0, assertOk(dec.decode(Map.of("x", 0.0))));
+        assertEquals(-5.0, assertOk(dec.decode(Map.of("x", -5.0))));
+        assertErr(dec.decode(Map.of("x", 0.1)));
+    }
+
+    @Test
+    void doubleOneOf() {
+        var dec = field("x", double_().oneOf(1.0, 2.5, 3.0));
+        assertEquals(2.5, assertOk(dec.decode(Map.of("x", 2.5))));
+        assertErr(dec.decode(Map.of("x", 4.0)));
+    }
+
+    @Test
     void floatDecoder() {
         var dec = field("x", float_());
         assertEquals(2.5f, assertOk(dec.decode(Map.of("x", 2.5f))));
@@ -885,6 +908,28 @@ class MapDecoderTest {
         var dec = field("x", float_().nonNegative());
         assertEquals(0.0f, assertOk(dec.decode(Map.of("x", 0.0f))));
         assertErr(dec.decode(Map.of("x", -0.1f)));
+    }
+
+    @Test
+    void floatNegative() {
+        var dec = field("x", float_().negative());
+        assertEquals(-2.0f, assertOk(dec.decode(Map.of("x", -2.0f))));
+        assertErr(dec.decode(Map.of("x", 0.0f)));
+        assertErr(dec.decode(Map.of("x", 1.0f)));
+    }
+
+    @Test
+    void floatNonPositive() {
+        var dec = field("x", float_().nonPositive());
+        assertEquals(0.0f, assertOk(dec.decode(Map.of("x", 0.0f))));
+        assertErr(dec.decode(Map.of("x", 0.1f)));
+    }
+
+    @Test
+    void floatOneOf() {
+        var dec = field("x", float_().oneOf(1.0f, 2.5f, 3.0f));
+        assertEquals(2.5f, assertOk(dec.decode(Map.of("x", 2.5f))));
+        assertErr(dec.decode(Map.of("x", 4.0f)));
     }
 
     @Test

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -832,6 +832,80 @@ class MapDecoderTest {
         assertEquals("x-y-z", assertOk(dec.decode(Map.of("a", "x", "b", "y", "c", "z"))));
     }
 
+    // --- double / float / bytes ---
+
+    @Test
+    void doubleDecoder() {
+        var dec = field("x", double_());
+        assertEquals(3.14, assertOk(dec.decode(Map.of("x", 3.14))));
+        assertErr(dec.decode(Map.of("x", "not a number")));
+        assertErr(dec.decode(Map.of()));
+    }
+
+    @Test
+    void doubleFromNumberCoercion() {
+        var dec = field("x", double_());
+        assertEquals(42.0, assertOk(dec.decode(Map.of("x", 42))));
+        assertEquals(100.0, assertOk(dec.decode(Map.of("x", 100L))));
+    }
+
+    @Test
+    void doubleConstraints() {
+        var dec = field("x", double_().positive().max(100.0));
+        assertEquals(50.5, assertOk(dec.decode(Map.of("x", 50.5))));
+        assertErr(dec.decode(Map.of("x", -1.0)));
+        assertErr(dec.decode(Map.of("x", 200.0)));
+    }
+
+    @Test
+    void doubleRange() {
+        var dec = field("x", double_().range(0.0, 1.0));
+        assertEquals(0.5, assertOk(dec.decode(Map.of("x", 0.5))));
+        assertErr(dec.decode(Map.of("x", -0.1)));
+        assertErr(dec.decode(Map.of("x", 1.1)));
+    }
+
+    @Test
+    void floatDecoder() {
+        var dec = field("x", float_());
+        assertEquals(2.5f, assertOk(dec.decode(Map.of("x", 2.5f))));
+        assertErr(dec.decode(Map.of("x", "not a number")));
+        assertErr(dec.decode(Map.of()));
+    }
+
+    @Test
+    void floatFromNumberCoercion() {
+        var dec = field("x", float_());
+        assertEquals(42.0f, assertOk(dec.decode(Map.of("x", 42))));
+        assertEquals(3.14f, assertOk(dec.decode(Map.of("x", 3.14))));
+    }
+
+    @Test
+    void floatConstraints() {
+        var dec = field("x", float_().nonNegative());
+        assertEquals(0.0f, assertOk(dec.decode(Map.of("x", 0.0f))));
+        assertErr(dec.decode(Map.of("x", -0.1f)));
+    }
+
+    @Test
+    void bytesDecoder() {
+        var dec = field("data", bytes());
+        var input = new byte[]{1, 2, 3};
+        assertArrayEquals(input, assertOk(dec.decode(Map.of("data", input))));
+    }
+
+    @Test
+    void bytesNull() {
+        var dec = field("data", bytes());
+        assertErr(dec.decode(Map.of()));
+    }
+
+    @Test
+    void bytesTypeMismatch() {
+        var dec = field("data", bytes());
+        assertErr(dec.decode(Map.of("data", "not bytes")));
+    }
+
     // --- Helpers ---
 
     static <T> T assertOk(Result<T> result) {

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -77,4 +77,14 @@ class MapEncoderTest {
         var enc = nullable(string());
         assertEquals("hello", enc.encode("hello"));
     }
+
+    @Test
+    void doubleEncoderPassesThrough() {
+        assertEquals(3.14, double_().encode(3.14));
+    }
+
+    @Test
+    void floatEncoderPassesThrough() {
+        assertEquals(2.5f, float_().encode(2.5f));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `DoubleDecoder` and `FloatDecoder` with constraint methods (`min`, `max`, `range`, `positive`, `negative`, `nonNegative`, `nonPositive`, `oneOf`) mirroring `IntDecoder`/`LongDecoder`
- Add `ObjectDecoders.bytes()` for `byte[]` columns (BYTEA/VARBINARY)
- Add `ObjectEncoders.double_()` / `float_()` for decode/encode symmetry

Closes #33, closes #34

## Test plan

- [x] `double_()` happy path, Number coercion, constraints (positive, max, range)
- [x] `float_()` happy path, Number coercion, constraints (nonNegative)
- [x] `bytes()` happy path, null, type mismatch
- [x] Encoder `double_()`/`float_()` pass-through
- [x] `mvn clean test -pl raoh` — 215 tests pass
- [x] `mvn clean test -pl raoh-jooq` — 16 tests pass
- [x] `mvn javadoc:javadoc -pl raoh` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)