### PR TITLE
Change StringDecoder.url() to return Decoder<I, URI>

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Collection/value-container decoders:
 - `toLowerCase()`
 - `toUpperCase()`
 - `uuid()`
-- `uri()`
+- `uri()` — accepts any scheme, returns `URI`
 - `iso8601()`
 - `date()`
 - `time()`

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Collection/value-container decoders:
 - `includes(...)`
 - `oneOf(...)`
 - `email()`
-- `url()`
+- `url()` — validates http/https and returns `URI`
 - `ipv4()`
 - `ipv6()`
 - `ip()`

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -270,16 +270,35 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
-    public StringDecoder<I> url() {
+    /**
+     * Decodes the string value to a {@link URI}, validating that it is a valid http or https URL.
+     *
+     * <p>Requires an absolute URL with the {@code http} or {@code https} scheme and a
+     * non-empty host. The maximum accepted length is 2048 characters.
+     * Uses {@link URI} parsing to avoid ReDoS from regex backtracking.
+     *
+     * <p>This is a terminal method — the returned decoder produces {@link URI},
+     * not {@link String}, so no further {@link StringDecoder} constraints can be chained.
+     * For URLs that accept any scheme, use {@link #uri()}.
+     *
+     * @return a decoder producing {@link URI} from validated http/https URLs
+     */
+    public Decoder<I, URI> url() {
         return url(null);
     }
 
     /**
-     * Validates that the value is a valid http/https URL.
+     * Decodes the string value to a {@link URI}, validating that it is a valid http or https URL.
+     *
+     * <p>Requires an absolute URL with the {@code http} or {@code https} scheme and a
+     * non-empty host. The maximum accepted length is 2048 characters.
      * Uses {@link URI} parsing to avoid ReDoS from regex backtracking.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a decoder producing {@link URI} from validated http/https URLs
      */
-    public StringDecoder<I> url(String message) {
-        return chain((value, path) -> {
+    public Decoder<I, URI> url(String message) {
+        return (in, path) -> this.decode(in, path).flatMap(value -> {
             if (value.length() > MAX_URL_LENGTH) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
@@ -294,12 +313,12 @@ public class StringDecoder<I> implements Decoder<I, String> {
                             ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                             : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid URL");
                 }
+                return Result.ok(uri);
             } catch (IllegalArgumentException e) {
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_FORMAT, message, Map.of())
                         : Result.fail(path, ErrorCodes.INVALID_FORMAT, "not a valid URL");
             }
-            return Result.ok(value);
         });
     }
 

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -14,6 +14,7 @@ import net.unit8.raoh.decode.Decoders;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -949,6 +950,74 @@ class MapDecoderTest {
     void bytesTypeMismatch() {
         var dec = field("data", bytes());
         assertErr(dec.decode(Map.of("data", "not bytes")));
+    }
+
+    // --- url / uri ---
+
+    @Test
+    void urlReturnsUri() {
+        var dec = field("link", string().url());
+        assertEquals(URI.create("https://example.com/path"), assertOk(dec.decode(Map.of("link", "https://example.com/path"))));
+        assertEquals(URI.create("http://localhost:8080"), assertOk(dec.decode(Map.of("link", "http://localhost:8080"))));
+    }
+
+    @Test
+    void urlRejectsNonHttp() {
+        var dec = field("link", string().url());
+        assertErr(dec.decode(Map.of("link", "ftp://example.com")));
+        assertErr(dec.decode(Map.of("link", "file:///tmp/x")));
+    }
+
+    @Test
+    void urlRejectsInvalid() {
+        var dec = field("link", string().url());
+        assertErr(dec.decode(Map.of("link", "not a url")));
+    }
+
+    @Test
+    void urlRejectsExceedingLength() {
+        var dec = field("link", string().url());
+        var longUrl = "https://example.com/" + "a".repeat(2030);
+        assertErr(dec.decode(Map.of("link", longUrl)));
+    }
+
+    @Test
+    void urlRejectsNoHost() {
+        var dec = field("link", string().url());
+        assertErr(dec.decode(Map.of("link", "http://")));
+    }
+
+    @Test
+    void urlWithCustomMessage() {
+        var dec = field("link", string().url("bad link"));
+        var result = dec.decode(Map.of("link", "not-a-url"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals("bad link", issues.asList().getFirst().message());
+        }
+    }
+
+    @Test
+    void uriReturnsUri() {
+        var dec = field("ref", string().uri());
+        assertEquals(URI.create("file:///tmp/x"), assertOk(dec.decode(Map.of("ref", "file:///tmp/x"))));
+        assertEquals(URI.create("mailto:user@example.com"), assertOk(dec.decode(Map.of("ref", "mailto:user@example.com"))));
+    }
+
+    @Test
+    void uriRejectsInvalid() {
+        var dec = field("ref", string().uri());
+        assertErr(dec.decode(Map.of("ref", "://bad")));
+    }
+
+    @Test
+    void uriWithCustomMessage() {
+        var dec = field("ref", string().uri("bad ref"));
+        var result = dec.decode(Map.of("ref", "://bad"));
+        switch (result) {
+            case Ok(var v) -> fail("Expected Err, got Ok: " + v);
+            case Err(var issues) -> assertEquals("bad ref", issues.asList().getFirst().message());
+        }
     }
 
     // --- Helpers ---


### PR DESCRIPTION
## Summary

- `url()` now returns `Decoder<I, URI>` instead of `StringDecoder<I>`, performing http/https validation + URI type conversion in one step
- `uri()` unchanged (any scheme → `URI`)
- Adds first-ever tests for both `url()` and `uri()` (9 test cases)

BREAKING CHANGE: `url()` return type changed from `StringDecoder<I>` to `Decoder<I, URI>`

Closes #35

## Test plan

- [x] `url()` returns `URI` for valid http/https URLs
- [x] `url()` rejects non-http schemes, invalid URLs, exceeding length, missing host
- [x] `url(message)` uses custom error message
- [x] `uri()` returns `URI` for any valid URI (file, mailto)
- [x] `uri()` rejects invalid URIs
- [x] `uri(message)` uses custom error message
- [x] `mvn clean test -pl raoh` — 230 tests pass
- [x] `mvn clean test -pl raoh-json` — 69 tests pass
- [x] `mvn javadoc:javadoc -pl raoh` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)