### PR TITLE
Add withDefault() to ObjectEncoders

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
@@ -1,6 +1,7 @@
 package net.unit8.raoh.encode;
 
 import java.math.BigDecimal;
+import java.util.function.Supplier;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -173,5 +174,41 @@ public final class ObjectEncoders {
      */
     public static <T> Encoder<T, Object> nullable(Encoder<T, Object> enc) {
         return v -> v == null ? null : enc.encode(v);
+    }
+
+    /**
+     * Wraps an encoder to substitute a default value when the input is {@code null}.
+     *
+     * <p>Unlike {@link #nullable(Encoder)}, which passes {@code null} through to the output,
+     * this method encodes the given {@code defaultValue} instead. This is the encoder-side
+     * counterpart of {@link net.unit8.raoh.decode.Decoders#withDefault(net.unit8.raoh.decode.Decoder, Object)
+     * Decoders.withDefault}.
+     *
+     * <pre>{@code
+     * import static net.unit8.raoh.encode.MapEncoders.*;
+     * import static net.unit8.raoh.encode.ObjectEncoders.*;
+     *
+     * property("tags", Article::tags, withDefault(list(nested(TAG_ENCODER)), List.of()))
+     * }</pre>
+     *
+     * @param <T>          the domain value type
+     * @param enc          the inner encoder to apply
+     * @param defaultValue the value to encode when the input is {@code null}
+     * @return an encoder that substitutes {@code defaultValue} for {@code null} input
+     */
+    public static <T> Encoder<T, Object> withDefault(Encoder<T, Object> enc, T defaultValue) {
+        return v -> v == null ? enc.encode(defaultValue) : enc.encode(v);
+    }
+
+    /**
+     * Like {@link #withDefault(Encoder, Object)}, but the default is lazily computed.
+     *
+     * @param <T>          the domain value type
+     * @param enc          the inner encoder to apply
+     * @param defaultValue supplies the value to encode when the input is {@code null}
+     * @return an encoder that substitutes the supplied default for {@code null} input
+     */
+    public static <T> Encoder<T, Object> withDefault(Encoder<T, Object> enc, Supplier<T> defaultValue) {
+        return v -> v == null ? enc.encode(defaultValue.get()) : enc.encode(v);
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
@@ -1,12 +1,12 @@
 package net.unit8.raoh.encode;
 
 import java.math.BigDecimal;
-import java.util.function.Supplier;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.function.Supplier;
 
 /**
  * Factory for primitive {@code Encoder} instances that encode domain values to {@code Object}.
@@ -202,6 +202,15 @@ public final class ObjectEncoders {
 
     /**
      * Like {@link #withDefault(Encoder, Object)}, but the default is lazily computed.
+     *
+     * <p>Note: when passing a lambda directly, the compiler may not distinguish
+     * between this overload and {@link #withDefault(Encoder, Object)}. In that case,
+     * assign the lambda to a typed variable first:
+     *
+     * <pre>{@code
+     * Supplier<List<Tag>> defaultTags = () -> List.of(Tag.UNTAGGED);
+     * property("tags", Article::tags, withDefault(list(nested(TAG_ENCODER)), defaultTags))
+     * }</pre>
      *
      * @param <T>          the domain value type
      * @param enc          the inner encoder to apply

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -87,4 +87,30 @@ class MapEncoderTest {
     void floatEncoderPassesThrough() {
         assertEquals(2.5f, float_().encode(2.5f));
     }
+
+    @Test
+    void withDefaultEncodesDefaultWhenNull() {
+        var enc = withDefault(string(), "N/A");
+        assertEquals("N/A", enc.encode(null));
+    }
+
+    @Test
+    void withDefaultEncodesValueWhenNonNull() {
+        var enc = withDefault(string(), "N/A");
+        assertEquals("hello", enc.encode("hello"));
+    }
+
+    @Test
+    void withDefaultSupplierEncodesDefaultWhenNull() {
+        java.util.function.Supplier<String> supplier = () -> "generated";
+        var enc = withDefault(string(), supplier);
+        assertEquals("generated", enc.encode(null));
+    }
+
+    @Test
+    void withDefaultSupplierEncodesValueWhenNonNull() {
+        java.util.function.Supplier<String> supplier = () -> "generated";
+        var enc = withDefault(string(), supplier);
+        assertEquals("world", enc.encode("world"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ObjectEncoders.withDefault(enc, defaultValue)` — encodes default when input is null
- Add `ObjectEncoders.withDefault(enc, Supplier)` — lazy variant
- Mirrors `Decoders.withDefault` on the decoder side

Closes #36

## Test plan

- [x] `withDefault` encodes default when null
- [x] `withDefault` encodes value when non-null
- [x] `withDefault` (Supplier) encodes default when null
- [x] `withDefault` (Supplier) encodes value when non-null
- [x] `mvn clean test -pl raoh` — 234 tests pass
- [x] `mvn javadoc:javadoc -pl raoh` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)