### PR TITLE
Fix: 0.5.0 release audit — Javadoc completion and example version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Value decoders:
 - `StringDecoder`
 - `IntDecoder`
 - `LongDecoder`
+- `DoubleDecoder`
+- `FloatDecoder`
 - `BoolDecoder`
 - `DecimalDecoder`
 
@@ -238,6 +240,10 @@ Collection/value-container decoders:
 
 - `ListDecoder`
 - `RecordDecoder`
+
+Other:
+
+- `ObjectDecoders.bytes()` — decodes `byte[]` (for JDBC binary columns such as BYTEA/VARBINARY)
 
 ### String Capabilities
 
@@ -288,7 +294,7 @@ Temporal decoders (`iso8601()`, `date()`, `time()`, `localDateTime()`, `offsetDa
 
 ### Numeric Capabilities
 
-`IntDecoder` and `LongDecoder` support:
+`IntDecoder`, `LongDecoder`, `DoubleDecoder`, and `FloatDecoder` support:
 
 - `min(...)`
 - `max(...)`
@@ -297,7 +303,7 @@ Temporal decoders (`iso8601()`, `date()`, `time()`, `localDateTime()`, `offsetDa
 - `negative()`
 - `nonNegative()`
 - `nonPositive()`
-- `multipleOf(...)`
+- `multipleOf(...)` (integer/long only — not available for double/float)
 - `oneOf(...)`
 
 `DecimalDecoder` supports:
@@ -678,6 +684,34 @@ combine(
 ```java
 string().email().decode(node)
 ```
+
+## Encoders
+
+The `net.unit8.raoh.encode` package provides the mirror image of decoders: converting domain objects to `Map<String, Object>` for JDBC binding or JSON serialization.
+
+```java
+import static net.unit8.raoh.encode.MapEncoders.*;
+import static net.unit8.raoh.encode.ObjectEncoders.*;
+
+Encoder<Item, Map<String, Object>> ITEM_ENCODER = object(
+        property("id",    Item::id,    long_().contramap(ItemId::value)),
+        property("name",  Item::name,  string()),
+        property("price", Item::price, decimal())
+);
+
+Map<String, Object> row = ITEM_ENCODER.encode(item);
+```
+
+### Built-in Encoders
+
+`ObjectEncoders` provides: `string()`, `int_()`, `long_()`, `double_()`, `float_()`, `bool()`, `decimal()`, `date()`, `time()`, `dateTime()`, `iso8601()`, `offsetDateTime()`, `enumOf()`.
+
+Null handling:
+
+- `nullable(enc)` — passes `null` through as-is
+- `withDefault(enc, defaultValue)` — encodes a default value when the input is `null`
+
+`MapEncoders` provides: `property()`, `object()`, `nested()`, `list()`.
 
 ## Comparisons
 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -7,8 +7,8 @@ If you know Zod, the closest equivalents are:
 | Zod | Raoh |
 | --- | --- |
 | `z.string()` | `string()` |
-| `z.number().int()` | `int_()` |
-| `z.number()` | `decimal()` |
+| `z.number().int()` | `int_()` / `long_()` |
+| `z.number()` | `double_()` / `float_()` / `decimal()` |
 | `z.boolean()` | `bool()` |
 | `z.enum([...])` | `enumOf(MyEnum.class)` |
 | `z.literal("x")` | `literal("x")` |

--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -1219,3 +1219,64 @@ switch (dec.decode(input)) {
 ```
 
 パターンマッチを使わない場合は `_1`, `_2`, ... `_8` でアクセスできます。
+
+---
+
+## 30. エンコード — ドメインオブジェクトから Map へ
+
+Raoh はデコーダーの逆操作として、ドメインオブジェクトを `Map<String, Object>` に変換するエンコーダーも提供しています。JDBC バインディングや JSON シリアライズに使えます。
+
+```java
+import static net.unit8.raoh.encode.MapEncoders.*;
+import static net.unit8.raoh.encode.ObjectEncoders.*;
+
+record ItemId(long value) {}
+record Item(ItemId id, String name, BigDecimal price) {}
+
+Encoder<Item, Map<String, Object>> ITEM_ENCODER = object(
+        property("id",    Item::id,    long_().contramap(ItemId::value)),
+        property("name",  Item::name,  string()),
+        property("price", Item::price, decimal())
+);
+
+Map<String, Object> row = ITEM_ENCODER.encode(new Item(new ItemId(42L), "Widget", new BigDecimal("9.99")));
+// {id=42, name=Widget, price=9.99}
+```
+
+エンコーダー API はデコーダーと対称になっています：
+
+| デコーダー | エンコーダー |
+| --- | --- |
+| `field("name", string())` | `property("name", T::name, string())` |
+| `combine(...).map(T::new)` | `object(property(...), ...)` |
+| `nested(subDecoder)` | `nested(subEncoder)` |
+| `list(elementDecoder)` | `list(elementEncoder)` |
+| `nullable(dec)` | `nullable(enc)` |
+| `withDefault(dec, v)` | `withDefault(enc, v)` |
+
+## 31. エンコード — nullable と withDefault
+
+出力で null をそのまま通したい場合は `nullable(enc)` を使います：
+
+```java
+property("description", Item::description, nullable(string()))
+// null → 出力でも null
+```
+
+null をデフォルト値に置き換えたい場合は `withDefault(enc, defaultValue)` を使います：
+
+```java
+property("tags", Article::tags, withDefault(list(nested(TAG_ENCODER)), List.of()))
+// null → 出力では []
+```
+
+## 32. エンコード — ネストしたオブジェクト
+
+`nested()` で構造化エンコーダーを親に埋め込み、`list()` でコレクションをエンコードします：
+
+```java
+Encoder<Order, Map<String, Object>> ORDER_ENCODER = object(
+        property("id",        Order::id,        long_()),
+        property("customer",  Order::customer,  nested(CUSTOMER_ENCODER)),
+        property("items",     Order::items,     list(nested(ITEM_ENCODER)))
+);

--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -66,6 +66,15 @@ bool().decode(true)
 
 decimal().decode(19.99)
 // ==> Ok[19.99]
+
+double_().decode(3.14)
+// ==> Ok[3.14]
+
+float_().decode(2.5f)
+// ==> Ok[2.5]
+
+bytes().decode(new byte[]{1, 2, 3})
+// ==> Ok[[1, 2, 3]]
 ```
 
 各メソッドは `Decoder<Object, T>` を返します。期待する型でなければ `type_mismatch` エラーになります。
@@ -102,6 +111,21 @@ string().uuid().decode("550e8400-e29b-41d4-a716-446655440000")
 // ==> Ok[550e8400-e29b-41d4-a716-446655440000]
 ```
 
+### URI / URL バリデーション
+
+```java
+string().uri().decode("file:///tmp/data.csv")
+// ==> Ok[file:///tmp/data.csv]
+
+string().url().decode("https://example.com/api")
+// ==> Ok[https://example.com/api]
+
+string().url().decode("ftp://example.com")
+// ==> Err[/: not a valid URL]
+```
+
+`uri()` は任意のスキームを受け入れ、`java.net.URI` を返します。`url()` はより厳格で、`http` または `https` スキーム、空でないホスト、最大 2048 文字を要求します。どちらも終端メソッドで、`String` ではなく `URI` を返します。
+
 ### 数値の制約
 
 ```java
@@ -126,6 +150,21 @@ string().date().decode("2025-06-15")
 
 string().iso8601().decode("2025-06-15T10:30:00Z")
 // ==> Ok[2025-06-15T10:30:00Z]
+
+date().after(LocalDate.of(2020, 1, 1)).decode(LocalDate.of(2025, 6, 15))
+// ==> Ok[2025-06-15]
+
+date().before(LocalDate.of(2030, 1, 1)).decode(LocalDate.of(2035, 1, 1))
+// ==> Err[/: must be before 2030-01-01]
+
+date().between(LocalDate.of(2020, 1, 1), LocalDate.of(2030, 12, 31)).decode(LocalDate.of(2025, 6, 15))
+// ==> Ok[2025-06-15]
+
+iso8601().past().decode(Instant.now().minusSeconds(3600))
+// ==> Ok[...]
+
+iso8601().future().decode(Instant.now().minusSeconds(3600))
+// ==> Err[/: must be in the future]
 ```
 
 ### 文字列からの型変換（coerce）
@@ -440,6 +479,19 @@ orderItemsDec.decode(Map.of("items", List.of(
 // ==> Err[/items/1/productId: is required, /items/1/quantity: must be positive]
 ```
 
+`nonempty()` 以外のリスト制約:
+
+```java
+field("tags", list(string()).minSize(1).maxSize(10)).decode(Map.of("tags", List.of("a", "b")))
+// ==> Ok[[a, b]]
+
+field("tags", list(string()).unique()).decode(Map.of("tags", List.of("a", "b", "a")))
+// ==> Err[/tags: contains duplicates: [a]]
+
+field("codes", list(string()).fixedSize(3)).decode(Map.of("codes", List.of("X", "Y")))
+// ==> Err[/codes: size must be exactly 3]
+```
+
 ---
 
 ## 8. マップのデコード
@@ -557,6 +609,36 @@ contactDec.decode(Map.of("kind", "fax", "value", "123"))
 ```
 
 すべての候補がマッチしなかった場合、`no variant matched` エラーが返ります。
+
+### discriminate — フィールド値によるディスパッチ
+
+ディスクリミネーターフィールド名が固定の場合、`discriminate()` は `oneOf()` よりクリーンな代替手段です:
+
+```java
+sealed interface Shape {}
+record Circle(double radius) implements Shape {}
+record Rect(double width, double height) implements Shape {}
+
+var shapeDec = discriminate("type", Map.of(
+        "circle", combine(
+                field("type", literal("circle")),
+                field("radius", double_().positive())
+        ).map((t, r) -> (Shape) new Circle(r)),
+        "rect", combine(
+                field("type", literal("rect")),
+                field("width", double_().positive()),
+                field("height", double_().positive())
+        ).map((t, w, h) -> (Shape) new Rect(w, h))
+));
+
+shapeDec.decode(Map.of("type", "circle", "radius", 5.0))
+// ==> Ok[Circle[radius=5.0]]
+
+shapeDec.decode(Map.of("type", "rect", "width", 3.0, "height", 4.0))
+// ==> Ok[Rect[width=3.0, height=4.0]]
+```
+
+`discriminate()` はフィールド値を先に読み取り、一致するデコーダーにディスパッチします。`oneOf()` のようにすべての候補を試すわけではないため、より効率的でエラーメッセージも明確です。
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1217,3 +1217,64 @@ switch (dec.decode(input)) {
 ```
 
 Tuple elements are accessed as `_1`, `_2`, ... `_8` when not using pattern matching.
+
+---
+
+## 30. Encoding — domain objects to Map
+
+Raoh also provides encoders that perform the reverse operation: converting domain objects into `Map<String, Object>` for JDBC binding, JSON serialization, or other boundary output.
+
+```java
+import static net.unit8.raoh.encode.MapEncoders.*;
+import static net.unit8.raoh.encode.ObjectEncoders.*;
+
+record ItemId(long value) {}
+record Item(ItemId id, String name, BigDecimal price) {}
+
+Encoder<Item, Map<String, Object>> ITEM_ENCODER = object(
+        property("id",    Item::id,    long_().contramap(ItemId::value)),
+        property("name",  Item::name,  string()),
+        property("price", Item::price, decimal())
+);
+
+Map<String, Object> row = ITEM_ENCODER.encode(new Item(new ItemId(42L), "Widget", new BigDecimal("9.99")));
+// {id=42, name=Widget, price=9.99}
+```
+
+The encoder API mirrors the decoder side:
+
+| Decoder | Encoder |
+| --- | --- |
+| `field("name", string())` | `property("name", T::name, string())` |
+| `combine(...).map(T::new)` | `object(property(...), ...)` |
+| `nested(subDecoder)` | `nested(subEncoder)` |
+| `list(elementDecoder)` | `list(elementEncoder)` |
+| `nullable(dec)` | `nullable(enc)` |
+| `withDefault(dec, v)` | `withDefault(enc, v)` |
+
+## 31. Encoding — nullable and withDefault
+
+Use `nullable(enc)` when null should pass through as null in the output:
+
+```java
+property("description", Item::description, nullable(string()))
+// null → null in output
+```
+
+Use `withDefault(enc, defaultValue)` when null should be replaced with a default:
+
+```java
+property("tags", Article::tags, withDefault(list(nested(TAG_ENCODER)), List.of()))
+// null → [] in output
+```
+
+## 32. Encoding — nested objects
+
+Use `nested()` to embed structured encoders inside a parent, and `list()` to encode collections:
+
+```java
+Encoder<Order, Map<String, Object>> ORDER_ENCODER = object(
+        property("id",        Order::id,        long_()),
+        property("customer",  Order::customer,  nested(CUSTOMER_ENCODER)),
+        property("items",     Order::items,     list(nested(ITEM_ENCODER)))
+);

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -67,6 +67,15 @@ bool().decode(true)
 
 decimal().decode(19.99)
 // ==> Ok[19.99]
+
+double_().decode(3.14)
+// ==> Ok[3.14]
+
+float_().decode(2.5f)
+// ==> Ok[2.5]
+
+bytes().decode(new byte[]{1, 2, 3})
+// ==> Ok[[1, 2, 3]]
 ```
 
 Each method returns a `Decoder<Object, T>`. If the value is not the expected type, a `type_mismatch` error is returned.
@@ -103,6 +112,21 @@ string().uuid().decode("550e8400-e29b-41d4-a716-446655440000")
 // ==> Ok[550e8400-e29b-41d4-a716-446655440000]
 ```
 
+### URI / URL validation
+
+```java
+string().uri().decode("file:///tmp/data.csv")
+// ==> Ok[file:///tmp/data.csv]
+
+string().url().decode("https://example.com/api")
+// ==> Ok[https://example.com/api]
+
+string().url().decode("ftp://example.com")
+// ==> Err[/: not a valid URL]
+```
+
+`uri()` accepts any scheme and returns a `java.net.URI`. `url()` is stricter: it requires `http` or `https`, a non-empty host, and a maximum length of 2048. Both are terminal methods — they produce `URI`, not `String`.
+
 ### Numeric constraints
 
 ```java
@@ -127,6 +151,21 @@ string().date().decode("2025-06-15")
 
 string().iso8601().decode("2025-06-15T10:30:00Z")
 // ==> Ok[2025-06-15T10:30:00Z]
+
+date().after(LocalDate.of(2020, 1, 1)).decode(LocalDate.of(2025, 6, 15))
+// ==> Ok[2025-06-15]
+
+date().before(LocalDate.of(2030, 1, 1)).decode(LocalDate.of(2035, 1, 1))
+// ==> Err[/: must be before 2030-01-01]
+
+date().between(LocalDate.of(2020, 1, 1), LocalDate.of(2030, 12, 31)).decode(LocalDate.of(2025, 6, 15))
+// ==> Ok[2025-06-15]
+
+iso8601().past().decode(Instant.now().minusSeconds(3600))
+// ==> Ok[...]
+
+iso8601().future().decode(Instant.now().minusSeconds(3600))
+// ==> Err[/: must be in the future]
 ```
 
 ### String-to-type conversions (coerce)
@@ -438,6 +477,19 @@ orderItemsDec.decode(Map.of("items", List.of(
 // ==> Err[/items/1/productId: is required, /items/1/quantity: must be positive]
 ```
 
+List constraints beyond `nonempty()`:
+
+```java
+field("tags", list(string()).minSize(1).maxSize(10)).decode(Map.of("tags", List.of("a", "b")))
+// ==> Ok[[a, b]]
+
+field("tags", list(string()).unique()).decode(Map.of("tags", List.of("a", "b", "a")))
+// ==> Err[/tags: contains duplicates: [a]]
+
+field("codes", list(string()).fixedSize(3)).decode(Map.of("codes", List.of("X", "Y")))
+// ==> Err[/codes: size must be exactly 3]
+```
+
 ---
 
 ## 8. Decoding maps
@@ -555,6 +607,36 @@ contactDec.decode(Map.of("kind", "fax", "value", "123"))
 ```
 
 When no candidate matches, a `no variant matched` error is returned.
+
+### discriminate — dispatch by field value
+
+When the discriminator field name is fixed, `discriminate()` provides a cleaner alternative to `oneOf()`:
+
+```java
+sealed interface Shape {}
+record Circle(double radius) implements Shape {}
+record Rect(double width, double height) implements Shape {}
+
+var shapeDec = discriminate("type", Map.of(
+        "circle", combine(
+                field("type", literal("circle")),
+                field("radius", double_().positive())
+        ).map((t, r) -> (Shape) new Circle(r)),
+        "rect", combine(
+                field("type", literal("rect")),
+                field("width", double_().positive()),
+                field("height", double_().positive())
+        ).map((t, w, h) -> (Shape) new Rect(w, h))
+));
+
+shapeDec.decode(Map.of("type", "circle", "radius", 5.0))
+// ==> Ok[Circle[radius=5.0]]
+
+shapeDec.decode(Map.of("type", "rect", "width", 3.0, "height", 4.0))
+// ==> Ok[Rect[width=3.0, height=4.0]]
+```
+
+`discriminate()` reads the field value first and dispatches to the matching decoder — it does not try all candidates like `oneOf()`. This is more efficient and produces clearer error messages.
 
 ---
 

--- a/examples/schema-versioning/pom.xml
+++ b/examples/schema-versioning/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>25</java.version>
-        <raoh.version>0.4.1</raoh.version>
+        <raoh.version>0.5.0-SNAPSHOT</raoh.version>
     </properties>
 
     <dependencies>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>25</java.version>
-        <raoh.version>0.4.1</raoh.version>
+        <raoh.version>0.5.0-SNAPSHOT</raoh.version>
     </properties>
 
     <dependencies>

--- a/raoh/src/main/java/net/unit8/raoh/decode/Decoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/Decoders.java
@@ -44,40 +44,173 @@ public final class Decoders {
         return new Combiner2<>(da, db);
     }
 
+    /**
+     * Combines 3 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C> Combiner3<I, A, B, C> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc) {
         return new Combiner3<>(da, db, dc);
     }
 
+    /**
+     * Combines 4 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D> Combiner4<I, A, B, C, D> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd) {
         return new Combiner4<>(da, db, dc, dd);
     }
 
+    /**
+     * Combines 5 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E> Combiner5<I, A, B, C, D, E> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de) {
         return new Combiner5<>(da, db, dc, dd, de);
     }
 
+    /**
+     * Combines 6 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F> Combiner6<I, A, B, C, D, E, F> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df) {
         return new Combiner6<>(da, db, dc, dd, de, df);
     }
 
+    /**
+     * Combines 7 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G> Combiner7<I, A, B, C, D, E, F, G> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg) {
         return new Combiner7<>(da, db, dc, dd, de, df, dg);
     }
 
+    /**
+     * Combines 8 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H> Combiner8<I, A, B, C, D, E, F, G, H> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh) {
         return new Combiner8<>(da, db, dc, dd, de, df, dg, dh);
     }
 
+    /**
+     * Combines 9 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J> Combiner9<I, A, B, C, D, E, F, G, H, J> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -85,6 +218,33 @@ public final class Decoders {
         return new Combiner9<>(da, db, dc, dd, de, df, dg, dh, dj);
     }
 
+    /**
+     * Combines 10 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K> Combiner10<I, A, B, C, D, E, F, G, H, J, K> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -92,6 +252,35 @@ public final class Decoders {
         return new Combiner10<>(da, db, dc, dd, de, df, dg, dh, dj, dk);
     }
 
+    /**
+     * Combines 11 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L> Combiner11<I, A, B, C, D, E, F, G, H, J, K, L> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -99,6 +288,37 @@ public final class Decoders {
         return new Combiner11<>(da, db, dc, dd, de, df, dg, dh, dj, dk, dl);
     }
 
+    /**
+     * Combines 12 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L, M> Combiner12<I, A, B, C, D, E, F, G, H, J, K, L, M> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -106,6 +326,39 @@ public final class Decoders {
         return new Combiner12<>(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm);
     }
 
+    /**
+     * Combines 13 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L, M, N> Combiner13<I, A, B, C, D, E, F, G, H, J, K, L, M, N> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -114,6 +367,41 @@ public final class Decoders {
         return new Combiner13<>(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn);
     }
 
+    /**
+     * Combines 14 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L, M, N, O> Combiner14<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -122,6 +410,43 @@ public final class Decoders {
         return new Combiner14<>(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_);
     }
 
+    /**
+     * Combines 15 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param <P> the fifteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @param dp  the fifteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P> Combiner15<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,
@@ -130,6 +455,45 @@ public final class Decoders {
         return new Combiner15<>(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_, dp);
     }
 
+    /**
+     * Combines 16 decoders into an applicative builder.
+     *
+     * @param <I> the input type
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param <P> the fifteenth decoder's output type
+     * @param <Q> the sixteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @param dp  the fifteenth decoder
+     * @param dq  the sixteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q> Combiner16<I, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q> combine(
             Decoder<I, A> da, Decoder<I, B> db, Decoder<I, C> dc, Decoder<I, D> dd,
             Decoder<I, E> de, Decoder<I, F> df, Decoder<I, G> dg, Decoder<I, H> dh,

--- a/raoh/src/main/java/net/unit8/raoh/decode/FieldDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/FieldDecoder.java
@@ -13,6 +13,10 @@ package net.unit8.raoh.decode;
  */
 public interface FieldDecoder<I, T> extends Decoder<I, T> {
 
-    /** Returns the field name this decoder is bound to. */
+    /**
+     * Returns the field name this decoder is bound to.
+     *
+     * @return the field name
+     */
     String fieldName();
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -17,6 +17,11 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
 
     private final Decoder<I, BigDecimal> inner;
 
+    /**
+     * Creates a new decimal decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
     public DecimalDecoder(Decoder<I, BigDecimal> inner) {
         this.inner = inner;
     }
@@ -26,6 +31,12 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         return inner.decode(in, path);
     }
 
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n the minimum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
     public DecimalDecoder<I> min(BigDecimal n) {
         return chain((value, path) -> {
             if (value.compareTo(n) < 0) {
@@ -36,6 +47,12 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
     public DecimalDecoder<I> max(BigDecimal n) {
         return chain((value, path) -> {
             if (value.compareTo(n) > 0) {
@@ -46,6 +63,11 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
     public DecimalDecoder<I> positive() {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) <= 0) {
@@ -56,6 +78,11 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
     public DecimalDecoder<I> negative() {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) >= 0) {
@@ -66,6 +93,11 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
     public DecimalDecoder<I> nonNegative() {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) < 0) {
@@ -76,6 +108,11 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
     public DecimalDecoder<I> nonPositive() {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) > 0) {
@@ -86,6 +123,12 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n the required divisor
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not a multiple
+     */
     public DecimalDecoder<I> multipleOf(BigDecimal n) {
         return chain((value, path) -> {
             if (value.remainder(n).compareTo(BigDecimal.ZERO) != 0) {
@@ -97,6 +140,12 @@ public class DecimalDecoder<I> implements Decoder<I, BigDecimal> {
         });
     }
 
+    /**
+     * Restricts the number of decimal places.
+     *
+     * @param s the maximum allowed scale (number of decimal places)
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SCALE} if the scale exceeds {@code s}
+     */
     public DecimalDecoder<I> scale(int s) {
         return chain((value, path) -> {
             if (value.scale() > s) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -19,6 +19,11 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
 
     private final Decoder<I, Integer> inner;
 
+    /**
+     * Creates a new integer decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
     public IntDecoder(Decoder<I, Integer> inner) {
         this.inner = inner;
     }
@@ -28,10 +33,23 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         return inner.decode(in, path);
     }
 
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n the minimum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
     public IntDecoder<I> min(int n) {
         return min(n, null);
     }
 
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n       the minimum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
     public IntDecoder<I> min(int n, String message) {
         return chain((value, path) -> {
             if (value < n) {
@@ -44,10 +62,23 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
     public IntDecoder<I> max(int n) {
         return max(n, null);
     }
 
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n       the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
     public IntDecoder<I> max(int n, String message) {
         return chain((value, path) -> {
             if (value > n) {
@@ -60,10 +91,25 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
     public IntDecoder<I> range(int min, int max) {
         return range(min, max, null);
     }
 
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min     the minimum allowed value (inclusive)
+     * @param max     the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
     public IntDecoder<I> range(int min, int max, String message) {
         return chain((value, path) -> {
             if (value < min || value > max) {
@@ -76,6 +122,11 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
     public IntDecoder<I> positive() {
         return chain((value, path) -> {
             if (value <= 0) {
@@ -86,6 +137,11 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
     public IntDecoder<I> negative() {
         return chain((value, path) -> {
             if (value >= 0) {
@@ -96,6 +152,11 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
     public IntDecoder<I> nonNegative() {
         return chain((value, path) -> {
             if (value < 0) {
@@ -106,6 +167,11 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
     public IntDecoder<I> nonPositive() {
         return chain((value, path) -> {
             if (value > 0) {
@@ -135,6 +201,12 @@ public class IntDecoder<I> implements Decoder<I, Integer> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n the divisor
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     */
     public IntDecoder<I> multipleOf(int n) {
         return chain((value, path) -> {
             if (value % n != 0) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
@@ -24,6 +24,11 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
 
     private final Decoder<I, List<T>> inner;
 
+    /**
+     * Creates a new list decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
     public ListDecoder(Decoder<I, List<T>> inner) {
         this.inner = inner;
     }
@@ -33,6 +38,11 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
         return inner.decode(in, path);
     }
 
+    /**
+     * Requires the list to be non-empty.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the list is empty
+     */
     public ListDecoder<I, T> nonempty() {
         return chain((value, path) -> {
             if (value.isEmpty()) {
@@ -43,6 +53,12 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
         });
     }
 
+    /**
+     * Restricts the list to have at least {@code n} elements.
+     *
+     * @param n the minimum number of elements (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if below
+     */
     public ListDecoder<I, T> minSize(int n) {
         return chain((value, path) -> {
             if (value.size() < n) {
@@ -54,6 +70,12 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
         });
     }
 
+    /**
+     * Restricts the list to have at most {@code n} elements.
+     *
+     * @param n the maximum number of elements (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if above
+     */
     public ListDecoder<I, T> maxSize(int n) {
         return chain((value, path) -> {
             if (value.size() > n) {
@@ -65,6 +87,12 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
         });
     }
 
+    /**
+     * Restricts the list to have exactly {@code n} elements.
+     *
+     * @param n the required number of elements
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the size differs
+     */
     public ListDecoder<I, T> fixedSize(int n) {
         return chain((value, path) -> {
             if (value.size() != n) {
@@ -150,6 +178,11 @@ public class ListDecoder<I, T> implements Decoder<I, List<T>> {
         });
     }
 
+    /**
+     * Converts the decoded list to a {@link Set}, preserving insertion order.
+     *
+     * @return a decoder that produces an unmodifiable {@link Set} from the list elements
+     */
     public Decoder<I, Set<T>> toSet() {
         return (in, path) -> this.decode(in, path).map(list -> Set.copyOf(new LinkedHashSet<>(list)));
     }

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -19,6 +19,11 @@ public class LongDecoder<I> implements Decoder<I, Long> {
 
     private final Decoder<I, Long> inner;
 
+    /**
+     * Creates a new long decoder wrapping the given inner decoder.
+     *
+     * @param inner the inner decoder that performs the actual decoding
+     */
     public LongDecoder(Decoder<I, Long> inner) {
         this.inner = inner;
     }
@@ -28,10 +33,23 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         return inner.decode(in, path);
     }
 
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n the minimum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
     public LongDecoder<I> min(long n) {
         return min(n, null);
     }
 
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n       the minimum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
     public LongDecoder<I> min(long n, String message) {
         return chain((value, path) -> {
             if (value < n) {
@@ -44,10 +62,23 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
     public LongDecoder<I> max(long n) {
         return max(n, null);
     }
 
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n       the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
     public LongDecoder<I> max(long n, String message) {
         return chain((value, path) -> {
             if (value > n) {
@@ -60,10 +91,25 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
     public LongDecoder<I> range(long min, long max) {
         return range(min, max, null);
     }
 
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min     the minimum allowed value (inclusive)
+     * @param max     the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
     public LongDecoder<I> range(long min, long max, String message) {
         return chain((value, path) -> {
             if (value < min || value > max) {
@@ -76,6 +122,11 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
     public LongDecoder<I> positive() {
         return chain((value, path) -> {
             if (value <= 0) {
@@ -85,6 +136,11 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
     public LongDecoder<I> negative() {
         return chain((value, path) -> {
             if (value >= 0) {
@@ -94,6 +150,11 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
     public LongDecoder<I> nonNegative() {
         return chain((value, path) -> {
             if (value < 0) {
@@ -103,6 +164,11 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
     public LongDecoder<I> nonPositive() {
         return chain((value, path) -> {
             if (value > 0) {
@@ -131,6 +197,12 @@ public class LongDecoder<I> implements Decoder<I, Long> {
         });
     }
 
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n the divisor
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     */
     public LongDecoder<I> multipleOf(long n) {
         return chain((value, path) -> {
             if (value % n != 0) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
@@ -17,6 +17,11 @@ public class RecordDecoder<I, V> implements Decoder<I, Map<String, V>> {
 
     private final Decoder<I, Map<String, V>> inner;
 
+    /**
+     * Creates a new {@link RecordDecoder} wrapping the given decoder.
+     *
+     * @param inner the underlying decoder that produces a map value
+     */
     public RecordDecoder(Decoder<I, Map<String, V>> inner) {
         this.inner = inner;
     }
@@ -26,6 +31,11 @@ public class RecordDecoder<I, V> implements Decoder<I, Map<String, V>> {
         return inner.decode(in, path);
     }
 
+    /**
+     * Requires the record to have at least one entry.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map is empty
+     */
     public RecordDecoder<I, V> nonempty() {
         return chain((value, path) -> {
             if (value.isEmpty()) {
@@ -36,6 +46,12 @@ public class RecordDecoder<I, V> implements Decoder<I, Map<String, V>> {
         });
     }
 
+    /**
+     * Requires the record to have at least {@code n} entries.
+     *
+     * @param n the minimum number of entries
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map has fewer entries
+     */
     public RecordDecoder<I, V> minSize(int n) {
         return chain((value, path) -> {
             if (value.size() < n) {
@@ -47,6 +63,12 @@ public class RecordDecoder<I, V> implements Decoder<I, Map<String, V>> {
         });
     }
 
+    /**
+     * Requires the record to have at most {@code n} entries.
+     *
+     * @param n the maximum number of entries
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if the map has more entries
+     */
     public RecordDecoder<I, V> maxSize(int n) {
         return chain((value, path) -> {
             if (value.size() > n) {
@@ -58,6 +80,12 @@ public class RecordDecoder<I, V> implements Decoder<I, Map<String, V>> {
         });
     }
 
+    /**
+     * Requires the record to have exactly {@code n} entries.
+     *
+     * @param n the required number of entries
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the map size differs
+     */
     public RecordDecoder<I, V> fixedSize(int n) {
         return chain((value, path) -> {
             if (value.size() != n) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -50,11 +50,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
     private final Decoder<I, String> inner;
     private final Decoder<I, String> base;
 
+    /**
+     * Creates a new {@link StringDecoder} wrapping the given decoder.
+     *
+     * @param inner the underlying decoder that produces a string value
+     */
     public StringDecoder(Decoder<I, String> inner) {
         this.inner = inner;
         this.base = null;
     }
 
+    /**
+     * Creates a new {@link StringDecoder} wrapping the given decoder, retaining a base decoder
+     * for use by {@link #allowBlank()}.
+     *
+     * @param inner the underlying decoder that produces a string value
+     * @param base  the original decoder before {@link #nonBlank()} was applied, or {@code null}
+     */
     public StringDecoder(Decoder<I, String> inner, Decoder<I, String> base) {
         this.inner = inner;
         this.base = base;
@@ -106,6 +118,7 @@ public class StringDecoder<I> implements Decoder<I, String> {
     /**
      * Removes a previously-applied {@link #nonBlank()} constraint, restoring blank-string acceptance.
      *
+     * @return a new decoder that accepts blank strings
      * @throws IllegalStateException if this decoder was not created via {@code net.unit8.raoh.json.JsonDecoders#string()}
      *         or {@link net.unit8.raoh.decode.ObjectDecoders#string()} (i.e., no base decoder is available to restore)
      */
@@ -118,10 +131,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         return new StringDecoder<>(base);
     }
 
+    /**
+     * Restricts the string to be at least {@code n} characters long.
+     *
+     * @param n the minimum length
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SHORT} if shorter
+     */
     public StringDecoder<I> minLength(int n) {
         return minLength(n, null);
     }
 
+    /**
+     * Restricts the string to be at least {@code n} characters long.
+     *
+     * @param n       the minimum length
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SHORT} if shorter
+     */
     public StringDecoder<I> minLength(int n, String message) {
         return chain((value, path) -> {
             if (value.length() < n) {
@@ -134,10 +160,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Restricts the string to be at most {@code n} characters long.
+     *
+     * @param n the maximum length
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_LONG} if longer
+     */
     public StringDecoder<I> maxLength(int n) {
         return maxLength(n, null);
     }
 
+    /**
+     * Restricts the string to be at most {@code n} characters long.
+     *
+     * @param n       the maximum length
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_LONG} if longer
+     */
     public StringDecoder<I> maxLength(int n, String message) {
         return chain((value, path) -> {
             if (value.length() > n) {
@@ -150,10 +189,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Restricts the string to be exactly {@code n} characters long.
+     *
+     * @param n the required length
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_LENGTH} if the length differs
+     */
     public StringDecoder<I> fixedLength(int n) {
         return fixedLength(n, null);
     }
 
+    /**
+     * Restricts the string to be exactly {@code n} characters long.
+     *
+     * @param n       the required length
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_LENGTH} if the length differs
+     */
     public StringDecoder<I> fixedLength(int n, String message) {
         return chain((value, path) -> {
             if (value.length() != n) {
@@ -185,14 +237,35 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Validates the string against the given regular expression pattern.
+     *
+     * @param p the pattern to match against
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value does not match
+     */
     public StringDecoder<I> pattern(Pattern p) {
         return pattern(p, ErrorCodes.INVALID_FORMAT, null);
     }
 
+    /**
+     * Validates the string against the given regular expression pattern with a custom error code.
+     *
+     * @param p    the pattern to match against
+     * @param code the error code to use on failure
+     * @return a new decoder that fails with the specified error code if the value does not match
+     */
     public StringDecoder<I> pattern(Pattern p, String code) {
         return pattern(p, code, null);
     }
 
+    /**
+     * Validates the string against the given regular expression pattern with a custom error code and message.
+     *
+     * @param p       the pattern to match against
+     * @param code    the error code to use on failure
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with the specified error code if the value does not match
+     */
     public StringDecoder<I> pattern(Pattern p, String code, String message) {
         return chain((value, path) -> {
             if (!p.matcher(value).matches()) {
@@ -205,10 +278,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Requires the string to start with the given prefix.
+     *
+     * @param prefix the required prefix
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the prefix is absent
+     */
     public StringDecoder<I> startsWith(String prefix) {
         return startsWith(prefix, null);
     }
 
+    /**
+     * Requires the string to start with the given prefix.
+     *
+     * @param prefix  the required prefix
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the prefix is absent
+     */
     public StringDecoder<I> startsWith(String prefix, String message) {
         return chain((value, path) -> {
             if (!value.startsWith(prefix)) {
@@ -221,10 +307,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Requires the string to end with the given suffix.
+     *
+     * @param suffix the required suffix
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the suffix is absent
+     */
     public StringDecoder<I> endsWith(String suffix) {
         return endsWith(suffix, null);
     }
 
+    /**
+     * Requires the string to end with the given suffix.
+     *
+     * @param suffix  the required suffix
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the suffix is absent
+     */
     public StringDecoder<I> endsWith(String suffix, String message) {
         return chain((value, path) -> {
             if (!value.endsWith(suffix)) {
@@ -237,10 +336,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Requires the string to contain the given substring.
+     *
+     * @param substring the required substring
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the substring is absent
+     */
     public StringDecoder<I> includes(String substring) {
         return includes(substring, null);
     }
 
+    /**
+     * Requires the string to contain the given substring.
+     *
+     * @param substring the required substring
+     * @param message   custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the substring is absent
+     */
     public StringDecoder<I> includes(String substring, String message) {
         return chain((value, path) -> {
             if (!value.contains(substring)) {
@@ -255,10 +367,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
 
     // --- Preset constraints ---
 
+    /**
+     * Validates that the string is a well-formed email address.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid email
+     */
     public StringDecoder<I> email() {
         return email(null);
     }
 
+    /**
+     * Validates that the string is a well-formed email address.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid email
+     */
     public StringDecoder<I> email(String message) {
         return chain((value, path) -> {
             if (value.length() > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.matcher(value).matches()) {
@@ -322,10 +445,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Validates that the string is a valid IPv4 address.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IPv4 address
+     */
     public StringDecoder<I> ipv4() {
         return ipv4(null);
     }
 
+    /**
+     * Validates that the string is a valid IPv4 address.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IPv4 address
+     */
     public StringDecoder<I> ipv4(String message) {
         return chain((value, path) -> {
             if (value.length() > MAX_IP_LENGTH || !IPV4_PATTERN.matcher(value).matches()) {
@@ -337,13 +471,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Validates that the string is a valid IPv6 address.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IPv6 address
+     */
     public StringDecoder<I> ipv6() {
         return ipv6(null);
     }
 
     /**
-     * Validates that the value is a valid IPv6 address.
+     * Validates that the string is a valid IPv6 address.
      * Uses {@link InetAddress#getByName} to avoid ReDoS from complex regex backtracking.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IPv6 address
      */
     public StringDecoder<I> ipv6(String message) {
         return chain((value, path) -> {
@@ -356,10 +498,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Validates that the string is a valid IP address (IPv4 or IPv6).
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IP address
+     */
     public StringDecoder<I> ip() {
         return ip(null);
     }
 
+    /**
+     * Validates that the string is a valid IP address (IPv4 or IPv6).
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid IP address
+     */
     public StringDecoder<I> ip(String message) {
         return chain((value, path) -> {
             if (value.length() > MAX_IP_LENGTH
@@ -385,10 +538,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
         }
     }
 
+    /**
+     * Validates that the string is a valid CUID.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid CUID
+     */
     public StringDecoder<I> cuid() {
         return cuid(null);
     }
 
+    /**
+     * Validates that the string is a valid CUID.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid CUID
+     */
     public StringDecoder<I> cuid(String message) {
         return chain((value, path) -> {
             if (!CUID_PATTERN.matcher(value).matches()) {
@@ -400,10 +564,21 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Validates that the string is a valid ULID.
+     *
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid ULID
+     */
     public StringDecoder<I> ulid() {
         return ulid(null);
     }
 
+    /**
+     * Validates that the string is a valid ULID.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_FORMAT} if the value is not a valid ULID
+     */
     public StringDecoder<I> ulid(String message) {
         return chain((value, path) -> {
             if (!ULID_PATTERN.matcher(value).matches()) {
@@ -417,24 +592,50 @@ public class StringDecoder<I> implements Decoder<I, String> {
 
     // --- Transforms ---
 
+    /**
+     * Trims leading and trailing whitespace from the decoded string.
+     *
+     * @return a new decoder that applies {@link String#trim()} to the value
+     */
     public StringDecoder<I> trim() {
         return new StringDecoder<>((in, path) -> this.decode(in, path).map(String::trim));
     }
 
+    /**
+     * Converts the decoded string to lower case.
+     *
+     * @return a new decoder that applies {@link String#toLowerCase()} to the value
+     */
     public StringDecoder<I> toLowerCase() {
         return new StringDecoder<>((in, path) -> this.decode(in, path).map(String::toLowerCase));
     }
 
+    /**
+     * Converts the decoded string to upper case.
+     *
+     * @return a new decoder that applies {@link String#toUpperCase()} to the value
+     */
     public StringDecoder<I> toUpperCase() {
         return new StringDecoder<>((in, path) -> this.decode(in, path).map(String::toUpperCase));
     }
 
     // --- Type conversions ---
 
+    /**
+     * Parses the string as a {@link UUID}.
+     *
+     * @return a decoder producing {@link UUID} from validated UUID strings
+     */
     public Decoder<I, UUID> uuid() {
         return uuid(null);
     }
 
+    /**
+     * Parses the string as a {@link UUID}.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a decoder producing {@link UUID} from validated UUID strings
+     */
     public Decoder<I, UUID> uuid(String message) {
         return (in, path) -> this.decode(in, path).flatMap(value -> {
             try {
@@ -447,10 +648,23 @@ public class StringDecoder<I> implements Decoder<I, String> {
         });
     }
 
+    /**
+     * Parses the string as a {@link URI}.
+     *
+     * <p>Unlike {@link #url()}, this accepts any valid URI regardless of scheme.
+     *
+     * @return a decoder producing {@link URI} from validated URI strings
+     */
     public Decoder<I, URI> uri() {
         return uri(null);
     }
 
+    /**
+     * Parses the string as a {@link URI}.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a decoder producing {@link URI} from validated URI strings
+     */
     public Decoder<I, URI> uri(String message) {
         return (in, path) -> this.decode(in, path).flatMap(value -> {
             try {

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function10.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function10.java
@@ -1,6 +1,36 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 10 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function10<A, B, C, D, E, F, G, H, J, K, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function11.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function11.java
@@ -1,6 +1,38 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 11 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function11<A, B, C, D, E, F, G, H, J, K, L, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function12.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function12.java
@@ -1,6 +1,40 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 12 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <M> the type of the twelfth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function12<A, B, C, D, E, F, G, H, J, K, L, M, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @param m the twelfth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l, M m);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function13.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function13.java
@@ -1,6 +1,42 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 13 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <M> the type of the twelfth argument
+ * @param <N> the type of the thirteenth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function13<A, B, C, D, E, F, G, H, J, K, L, M, N, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @param m the twelfth argument
+     * @param n the thirteenth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l, M m, N n);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function14.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function14.java
@@ -1,6 +1,44 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 14 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <M> the type of the twelfth argument
+ * @param <N> the type of the thirteenth argument
+ * @param <O> the type of the fourteenth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function14<A, B, C, D, E, F, G, H, J, K, L, M, N, O, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @param m the twelfth argument
+     * @param n the thirteenth argument
+     * @param o the fourteenth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l, M m, N n, O o);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function15.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function15.java
@@ -1,6 +1,46 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 15 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <M> the type of the twelfth argument
+ * @param <N> the type of the thirteenth argument
+ * @param <O> the type of the fourteenth argument
+ * @param <P> the type of the fifteenth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function15<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @param m the twelfth argument
+     * @param n the thirteenth argument
+     * @param o the fourteenth argument
+     * @param p the fifteenth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l, M m, N n, O o, P p);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function16.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function16.java
@@ -1,6 +1,48 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 16 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <K> the type of the tenth argument
+ * @param <L> the type of the eleventh argument
+ * @param <M> the type of the twelfth argument
+ * @param <N> the type of the thirteenth argument
+ * @param <O> the type of the fourteenth argument
+ * @param <P> the type of the fifteenth argument
+ * @param <Q> the type of the sixteenth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function16<A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @param k the tenth argument
+     * @param l the eleventh argument
+     * @param m the twelfth argument
+     * @param n the thirteenth argument
+     * @param o the fourteenth argument
+     * @param p the fifteenth argument
+     * @param q the sixteenth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j, K k, L l, M m, N n, O o, P p, Q q);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function3.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function3.java
@@ -1,6 +1,22 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 3 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function3<A, B, C, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @return the result
+     */
     R apply(A a, B b, C c);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function4.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function4.java
@@ -1,6 +1,24 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 4 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function4<A, B, C, D, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function5.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function5.java
@@ -1,6 +1,26 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 5 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function5<A, B, C, D, E, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function6.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function6.java
@@ -1,6 +1,28 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 6 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function6<A, B, C, D, E, F, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function7.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function7.java
@@ -1,6 +1,30 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 7 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function7<A, B, C, D, E, F, G, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function8.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function8.java
@@ -1,6 +1,32 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 8 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function8<A, B, C, D, E, F, G, H, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function9.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/combinator/Function9.java
@@ -1,6 +1,34 @@
 package net.unit8.raoh.decode.combinator;
 
+/**
+ * A function that accepts 9 arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <E> the type of the fifth argument
+ * @param <F> the type of the sixth argument
+ * @param <G> the type of the seventh argument
+ * @param <H> the type of the eighth argument
+ * @param <J> the type of the ninth argument
+ * @param <R> the type of the result
+ */
 @FunctionalInterface
 public interface Function9<A, B, C, D, E, F, G, H, J, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first argument
+     * @param b the second argument
+     * @param c the third argument
+     * @param d the fourth argument
+     * @param e the fifth argument
+     * @param f the sixth argument
+     * @param g the seventh argument
+     * @param h the eighth argument
+     * @param j the ninth argument
+     * @return the result
+     */
     R apply(A a, B b, C c, D d, E e, F f, G g, H h, J j);
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
@@ -231,14 +231,42 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc);
     }
 
-    /** 4-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 4 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D> Combiner4<Map<String, Object>, A, B, C, D> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd) {
         return Decoders.combine(da, db, dc, dd);
     }
 
-    /** 5-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 5 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E> Combiner5<Map<String, Object>, A, B, C, D, E> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -246,7 +274,24 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de);
     }
 
-    /** 6-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 6 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F> Combiner6<Map<String, Object>, A, B, C, D, E, F> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -254,7 +299,26 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df);
     }
 
-    /** 7-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 7 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G> Combiner7<Map<String, Object>, A, B, C, D, E, F, G> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -263,7 +327,28 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg);
     }
 
-    /** 8-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 8 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H> Combiner8<Map<String, Object>, A, B, C, D, E, F, G, H> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -272,7 +357,30 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh);
     }
 
-    /** 9-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 9 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J> Combiner9<Map<String, Object>, A, B, C, D, E, F, G, H, J> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -282,7 +390,32 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj);
     }
 
-    /** 10-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 10 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K> Combiner10<Map<String, Object>, A, B, C, D, E, F, G, H, J, K> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -292,7 +425,34 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk);
     }
 
-    /** 11-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 11 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L> Combiner11<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -303,7 +463,36 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl);
     }
 
-    /** 12-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 12 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L, M> Combiner12<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L, M> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -314,7 +503,38 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm);
     }
 
-    /** 13-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 13 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L, M, N> Combiner13<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L, M, N> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -326,7 +546,40 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn);
     }
 
-    /** 14-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 14 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L, M, N, O> Combiner14<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L, M, N, O> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -338,7 +591,42 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_);
     }
 
-    /** 15-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 15 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param <P> the fifteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @param dp  the fifteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L, M, N, O, P> Combiner15<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,
@@ -351,7 +639,44 @@ public final class MapDecoders {
         return Decoders.combine(da, db, dc, dd, de, df, dg, dh, dj, dk, dl, dm, dn, do_, dp);
     }
 
-    /** 16-arity variant of {@link #combine(Decoder, Decoder)}. @return a combiner */
+    /**
+     * Combines 16 map-field decoders into an applicative builder.
+     *
+     * @param <A> the first decoder's output type
+     * @param <B> the second decoder's output type
+     * @param <C> the third decoder's output type
+     * @param <D> the fourth decoder's output type
+     * @param <E> the fifth decoder's output type
+     * @param <F> the sixth decoder's output type
+     * @param <G> the seventh decoder's output type
+     * @param <H> the eighth decoder's output type
+     * @param <J> the ninth decoder's output type
+     * @param <K> the tenth decoder's output type
+     * @param <L> the eleventh decoder's output type
+     * @param <M> the twelfth decoder's output type
+     * @param <N> the thirteenth decoder's output type
+     * @param <O> the fourteenth decoder's output type
+     * @param <P> the fifteenth decoder's output type
+     * @param <Q> the sixteenth decoder's output type
+     * @param da  the first decoder
+     * @param db  the second decoder
+     * @param dc  the third decoder
+     * @param dd  the fourth decoder
+     * @param de  the fifth decoder
+     * @param df  the sixth decoder
+     * @param dg  the seventh decoder
+     * @param dh  the eighth decoder
+     * @param dj  the ninth decoder
+     * @param dk  the tenth decoder
+     * @param dl  the eleventh decoder
+     * @param dm  the twelfth decoder
+     * @param dn  the thirteenth decoder
+     * @param do_ the fourteenth decoder
+     * @param dp  the fifteenth decoder
+     * @param dq  the sixteenth decoder
+     * @return a combiner that can be applied with a function
+     * @see #combine(Decoder, Decoder)
+     */
     public static <A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q> Combiner16<Map<String, Object>, A, B, C, D, E, F, G, H, J, K, L, M, N, O, P, Q> combine(
             Decoder<Map<String, Object>, A> da, Decoder<Map<String, Object>, B> db,
             Decoder<Map<String, Object>, C> dc, Decoder<Map<String, Object>, D> dd,

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -45,6 +45,7 @@ FILES=(
     "$ROOT/raoh-gsh-weaver/pom.xml"
     "$ROOT/raoh-gsh-maven-plugin/pom.xml"
     "$ROOT/examples/spring/pom.xml"
+    "$ROOT/examples/schema-versioning/pom.xml"
 )
 
 for f in "${FILES[@]}"; do
@@ -53,6 +54,17 @@ for f in "${FILES[@]}"; do
         echo "  updated: $f"
     else
         echo "  WARNING: not found: $f" >&2
+    fi
+done
+
+# Also update <raoh.version> in example poms (may differ from parent version)
+EXAMPLE_POMS=(
+    "$ROOT/examples/spring/pom.xml"
+    "$ROOT/examples/schema-versioning/pom.xml"
+)
+for f in "${EXAMPLE_POMS[@]}"; do
+    if [[ -f "$f" ]]; then
+        sed -i '' "s|<raoh.version>.*</raoh.version>|<raoh.version>${NEW_VERSION}</raoh.version>|g" "$f"
     fi
 done
 


### PR DESCRIPTION
## Summary

0.5.0 リリース前の総点検で検出した問題を修正:

- All 100 Javadoc warnings eliminated (doclint=all)
- Example pom.xml versions updated from 0.4.1 to 0.5.0-SNAPSHOT

### Javadoc added to (25 files):
- `IntDecoder`, `LongDecoder`, `DecimalDecoder` — all constraint methods
- `StringDecoder` — all constraint/transform/conversion methods
- `ListDecoder`, `RecordDecoder` — constructors and constraint methods
- `FieldDecoder` — `@return` tag
- `Function3`–`Function16` — interface and method Javadoc
- `Decoders`, `MapDecoders` — all combine() overloads with `@param`/`@return`

### Security/performance audit results (no issues found):
- ReDoS: all regex patterns safe, IPv6/URL use non-regex validation
- Thread safety: no mutable static state
- Algorithms: all O(n), no O(n²)
- decode/encode symmetry: complete
- 0.4.x remnants: none

## Test plan

- [x] `mvn clean test` — all 7 modules BUILD SUCCESS
- [x] `mvn clean javadoc:javadoc -pl raoh -Prelease` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)