### PR TITLE
feat(encode): add discriminate() to MapEncoders for tagged-union encoding (#44)

### DIFF
--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -1374,3 +1374,29 @@ Encoder<Order, Map<String, Object>> ORDER_ENCODER = object(
         property("customer",  Order::customer,  nested(CUSTOMER_ENCODER)),
         property("items",     Order::items,     list(nested(ITEM_ENCODER)))
 );
+```
+
+## 33. エンコード — discriminate（タグ付きユニオン）
+
+sealed インターフェース（タグ付きユニオン）は `discriminate()` でエンコードします。値の実行時型でバリアントを選び、ディスクリミネーターのタグを出力に書き込みます。デコーダー側の `discriminate()`（第11節）の鏡像です。デコーダーが入力データからタグを読むのに対し、エンコーダーは値の型からタグを選びます。
+
+```java
+sealed interface Shape permits Circle, Rect {}
+record Circle(double radius) implements Shape {}
+record Rect(double width, double height) implements Shape {}
+
+Encoder<Circle, Map<String, Object>> CIRCLE_ENCODER =
+        object(property("radius", Circle::radius, double_()));
+Encoder<Rect, Map<String, Object>> RECT_ENCODER = object(
+        property("width",  Rect::width,  double_()),
+        property("height", Rect::height, double_()));
+
+Encoder<Shape, Map<String, Object>> SHAPE_ENCODER = discriminate("type",
+        variant(Circle.class, "circle", CIRCLE_ENCODER),
+        variant(Rect.class,   "rect",   RECT_ENCODER));
+
+SHAPE_ENCODER.encode(new Circle(2.0));
+// => {type=circle, radius=2.0}
+```
+
+各バリアントは `variant(型, タグ, エンコーダー)` で宣言します。タグは出力の先頭に注入され、コンビネータが権威を持つため、バリアントエンコーダー側はタグを書きません。ディスパッチは `getClass()` の完全一致で、permits がすべて record / final の sealed 階層に適します。エンコードは総関数なので、未登録の型を渡すと `IllegalArgumentException` を投げます（デコーダーが `not_allowed` エラーを返すのと非対称です）。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1379,3 +1379,29 @@ Encoder<Order, Map<String, Object>> ORDER_ENCODER = object(
         property("customer",  Order::customer,  nested(CUSTOMER_ENCODER)),
         property("items",     Order::items,     list(nested(ITEM_ENCODER)))
 );
+```
+
+## 33. Encoding — discriminate (tagged unions)
+
+Encode a sealed interface (tagged union) with `discriminate()`, which selects a variant by the value's runtime type and writes the discriminator tag into the output. It mirrors the decoder-side `discriminate()` (section 11): the decoder reads the tag from the input data, while the encoder chooses the tag from the value's type.
+
+```java
+sealed interface Shape permits Circle, Rect {}
+record Circle(double radius) implements Shape {}
+record Rect(double width, double height) implements Shape {}
+
+Encoder<Circle, Map<String, Object>> CIRCLE_ENCODER =
+        object(property("radius", Circle::radius, double_()));
+Encoder<Rect, Map<String, Object>> RECT_ENCODER = object(
+        property("width",  Rect::width,  double_()),
+        property("height", Rect::height, double_()));
+
+Encoder<Shape, Map<String, Object>> SHAPE_ENCODER = discriminate("type",
+        variant(Circle.class, "circle", CIRCLE_ENCODER),
+        variant(Rect.class,   "rect",   RECT_ENCODER));
+
+SHAPE_ENCODER.encode(new Circle(2.0));
+// => {type=circle, radius=2.0}
+```
+
+Declare each variant with `variant(type, tag, encoder)`. The tag is injected first and is authoritative, so variant encoders do not write it themselves. Dispatch is by exact `getClass()` match, which fits a sealed hierarchy whose permitted types are records or final classes. Since encoding is a total function, passing an unregistered type throws `IllegalArgumentException` (asymmetric with the decoder, which returns a `not_allowed` error).

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -2,6 +2,7 @@ package net.unit8.raoh.encode;
 
 import org.jspecify.annotations.Nullable;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -285,16 +286,23 @@ public final class MapEncoders {
      * @param fieldName the discriminator key written into the output map
      * @param variants  the variants, each pairing a concrete class with its tag and encoder
      * @return an encoder that dispatches on runtime class and injects the discriminator tag
-     * @throws IllegalArgumentException if two variants register the same class (detected here), or,
-     *         from the returned encoder, if it is given a value whose class has no registered variant
+     * @throws IllegalArgumentException if two variants register the same class or the same tag
+     *         (both detected here), or, from the returned encoder, if it is given a value whose
+     *         class has no registered variant
      */
     @SafeVarargs
     public static <T> Encoder<T, Map<String, @Nullable Object>> discriminate(
             String fieldName, Variant<? extends T>... variants) {
         var byClass = new LinkedHashMap<Class<?>, Variant<? extends T>>(variants.length * 2);
+        var seenTags = new HashSet<String>(variants.length * 2);
         for (var v : variants) {
             if (byClass.put(v.type(), v) != null) {
                 throw new IllegalArgumentException("duplicate variant for " + v.type().getName());
+            }
+            // Reject duplicate tags too: two classes sharing a tag would emit a non-unique
+            // discriminator that the tag-keyed decoder side cannot round-trip.
+            if (!seenTags.add(v.tag())) {
+                throw new IllegalArgumentException("duplicate variant tag '" + v.tag() + "'");
             }
         }
         return value -> {

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -215,4 +215,109 @@ public final class MapEncoders {
                 .map(elementEncoder::encode)
                 .toList();
     }
+
+    /**
+     * A single tagged variant of a discriminated (tagged-union) encoder: the concrete subtype,
+     * the discriminator tag written for it, and the encoder that produces its body.
+     *
+     * <p>Created via {@link #variant(Class, String, Encoder)} and consumed by
+     * {@link #discriminate(String, Variant[])}. The {@code type} is matched against
+     * {@link Object#getClass()} of the value being encoded, so it must be the value's exact
+     * runtime class (see {@link #discriminate(String, Variant[])} for the implications).
+     *
+     * @param <S>     the concrete subtype this variant encodes
+     * @param type    the exact runtime class dispatched on
+     * @param tag     the discriminator value written under the discriminator key
+     * @param encoder the encoder producing the variant body (must not itself write the tag)
+     */
+    public record Variant<S>(
+            Class<S> type,
+            String tag,
+            Encoder<S, Map<String, @Nullable Object>> encoder) {}
+
+    /**
+     * Creates a {@link Variant} binding a concrete subtype to its discriminator tag and encoder.
+     *
+     * <p>The type parameter {@code S} ties the class and the encoder together so a mismatched
+     * pair fails to compile. It deliberately does not mention the union supertype {@code T} of
+     * {@link #discriminate(String, Variant[])}: that keeps type inference working when several
+     * {@code variant(...)} calls of different subtypes are passed to the same {@code discriminate}.
+     *
+     * @param <S>     the concrete subtype this variant encodes
+     * @param type    the exact runtime class to dispatch on
+     * @param tag     the discriminator value to write for this subtype
+     * @param encoder the encoder producing the variant body
+     * @return a variant for use with {@link #discriminate(String, Variant[])}
+     */
+    public static <S> Variant<S> variant(
+            Class<S> type, String tag, Encoder<S, Map<String, @Nullable Object>> encoder) {
+        return new Variant<>(type, tag, encoder);
+    }
+
+    /**
+     * Creates an encoder for a tagged union (typically a {@code sealed} interface) that selects a
+     * variant encoder by the value's runtime class and writes the discriminator tag into the output.
+     *
+     * <p>This is the encode-side mirror of
+     * {@link net.unit8.raoh.decode.map.MapDecoders#discriminate(String, Map)
+     * MapDecoders.discriminate}. The two are asymmetric by nature: the decoder reads the tag from
+     * the input data to choose a variant, whereas this encoder chooses a variant from the value's
+     * concrete type and then writes the tag. The discriminator entry is injected here, so variant
+     * encoders must not write it themselves.
+     *
+     * <p>The tag is placed first in the resulting {@link LinkedHashMap} and is authoritative: if a
+     * variant encoder also emits the discriminator key, that entry is discarded in favour of the
+     * injected tag. The return type matches {@link #object(PropertyEncoder[])}, so the result can be
+     * embedded via {@link #nested(Encoder)} or used as a top-level encoder.
+     *
+     * <p><strong>Exact-class dispatch.</strong> Variants are matched against
+     * {@link Object#getClass()}, i.e. by exact runtime class, not {@code instanceof}. This fits a
+     * {@code sealed} hierarchy whose permitted types are {@code record}s or {@code final} classes.
+     * A value whose class is a subclass of a registered non-final variant type will not match.
+     *
+     * <p><strong>Never fails for well-formed definitions.</strong> Consistent with {@link Encoder}
+     * being a total function, a correct definition covering every permitted subtype never throws at
+     * encode time. The runtime {@link IllegalArgumentException} below is a guard against a
+     * definition that omits a subtype — a programming error, not a data error (unlike the decoder,
+     * which returns an error result for an unknown tag).
+     *
+     * @param <T>       the union (supertype) being encoded
+     * @param fieldName the discriminator key written into the output map
+     * @param variants  the variants, each pairing a concrete class with its tag and encoder
+     * @return an encoder that dispatches on runtime class and injects the discriminator tag
+     * @throws IllegalArgumentException if two variants register the same class (detected here), or,
+     *         from the returned encoder, if it is given a value whose class has no registered variant
+     */
+    @SafeVarargs
+    public static <T> Encoder<T, Map<String, @Nullable Object>> discriminate(
+            String fieldName, Variant<? extends T>... variants) {
+        var byClass = new LinkedHashMap<Class<?>, Variant<? extends T>>(variants.length * 2);
+        for (var v : variants) {
+            if (byClass.put(v.type(), v) != null) {
+                throw new IllegalArgumentException("duplicate variant for " + v.type().getName());
+            }
+        }
+        return value -> {
+            var v = byClass.get(value.getClass());
+            if (v == null) {
+                throw new IllegalArgumentException(
+                        "no encoder registered for " + value.getClass().getName()
+                        + "; known variants: "
+                        + byClass.keySet().stream().map(Class::getName).sorted().toList());
+            }
+            // value.getClass() == v.type() is verified above, so applying the variant encoder to
+            // this value is runtime-safe. Mirrors the unchecked cast in Decoders.discriminate.
+            @SuppressWarnings("unchecked")
+            var enc = (Encoder<T, Map<String, @Nullable Object>>) (Encoder<?, ?>) v.encoder();
+            var body = enc.encode(value);
+            var out = new LinkedHashMap<String, @Nullable Object>(body.size() + 2);
+            out.put(fieldName, v.tag());
+            body.forEach((k, val) -> {
+                if (!k.equals(fieldName)) {
+                    out.put(k, val);
+                }
+            });
+            return out;
+        };
+    }
 }

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -321,7 +321,10 @@ public final class MapEncoders {
             var out = new LinkedHashMap<String, @Nullable Object>(body.size() + 2);
             out.put(fieldName, v.tag());
             body.forEach((k, val) -> {
-                if (!k.equals(fieldName)) {
+                // fieldName is non-null; call equals on it so a variant that emits a null key
+                // (keys are non-null by contract, but the encoder is arbitrary) drops through
+                // as a normal entry instead of throwing.
+                if (!fieldName.equals(k)) {
                     out.put(k, val);
                 }
             });

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -195,6 +195,15 @@ class MapEncoderTest {
     }
 
     @Test
+    void discriminateThrowsForDuplicateTag() {
+        // Two distinct classes sharing one tag would emit a non-unique discriminator
+        // that the tag-keyed decoder side cannot round-trip.
+        assertThrows(IllegalArgumentException.class, () -> discriminate("type",
+                variant(Circle.class, "shape", CIRCLE_ENCODER),
+                variant(Rect.class,   "shape", RECT_ENCODER)));
+    }
+
+    @Test
     void discriminateTagIsAuthoritativeOverVariantOutput() {
         // A variant encoder that (incorrectly) also emits the discriminator key.
         Encoder<Circle, Map<String, @Nullable Object>> rogue = object(

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -204,6 +204,25 @@ class MapEncoderTest {
     }
 
     @Test
+    void discriminateToleratesNullKeyFromVariant() {
+        // Keys are non-null by contract, but a variant encoder is arbitrary. A null key
+        // must not NPE during tag injection; the null-keyed entry passes through.
+        Encoder<Circle, Map<String, @Nullable Object>> nullKey = c -> {
+            var m = new java.util.LinkedHashMap<String, @Nullable Object>();
+            m.put(null, "x");
+            m.put("radius", c.radius());
+            return m;
+        };
+        Encoder<Shape, Map<String, @Nullable Object>> enc =
+                discriminate("type", variant(Circle.class, "circle", nullKey));
+
+        var out = enc.encode(new Circle(1.0));
+        assertEquals("circle", out.get("type"));
+        assertEquals(1.0, out.get("radius"));
+        assertTrue(out.containsKey(null));
+    }
+
+    @Test
     void discriminateTagIsAuthoritativeOverVariantOutput() {
         // A variant encoder that (incorrectly) also emits the discriminator key.
         Encoder<Circle, Map<String, @Nullable Object>> rogue = object(

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import org.jspecify.annotations.Nullable;
 
+import net.unit8.raoh.decode.Decoder;
+import net.unit8.raoh.decode.ObjectDecoders;
+import net.unit8.raoh.decode.map.MapDecoders;
+
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 
 import static net.unit8.raoh.encode.MapEncoders.*;
@@ -120,5 +125,86 @@ class MapEncoderTest {
         java.util.function.Supplier<String> supplier = () -> "generated";
         var enc = object(propertyWithDefault("name", Row::name, string(), supplier));
         assertEquals("world", enc.encode(new Row("world")).get("name"));
+    }
+
+    // --- discriminate ---
+
+    sealed interface Shape permits Circle, Rect {}
+    record Circle(double radius) implements Shape {}
+    record Rect(double width, double height) implements Shape {}
+
+    static final Encoder<Circle, Map<String, @Nullable Object>> CIRCLE_ENCODER =
+            object(property("radius", Circle::radius, double_()));
+    static final Encoder<Rect, Map<String, @Nullable Object>> RECT_ENCODER = object(
+            property("width",  Rect::width,  double_()),
+            property("height", Rect::height, double_()));
+
+    static final Encoder<Shape, Map<String, @Nullable Object>> SHAPE_ENCODER = discriminate("type",
+            variant(Circle.class, "circle", CIRCLE_ENCODER),
+            variant(Rect.class,   "rect",   RECT_ENCODER));
+
+    @Test
+    void discriminateDispatchesAndInjectsTag() {
+        var circle = SHAPE_ENCODER.encode(new Circle(2.0));
+        assertEquals("circle", circle.get("type"));
+        assertEquals(2.0, circle.get("radius"));
+
+        var rect = SHAPE_ENCODER.encode(new Rect(3.0, 4.0));
+        assertEquals("rect", rect.get("type"));
+        assertEquals(3.0, rect.get("width"));
+        assertEquals(4.0, rect.get("height"));
+    }
+
+    @Test
+    void discriminatePlacesTagFirst() {
+        var keys = SHAPE_ENCODER.encode(new Circle(1.0)).keySet().stream().toList();
+        assertEquals("type", keys.getFirst());
+    }
+
+    @Test
+    void discriminateRoundTripsWithDecoder() {
+        Decoder<Map<String, Object>, Shape> dec = MapDecoders.discriminate("type", Map.of(
+                "circle", MapDecoders.field("radius", ObjectDecoders.decimal())
+                        .map(r -> new Circle(r.doubleValue())),
+                "rect", MapDecoders.combine(
+                                MapDecoders.field("width",  ObjectDecoders.decimal()),
+                                MapDecoders.field("height", ObjectDecoders.decimal()))
+                        .map((w, h) -> new Rect(w.doubleValue(), h.doubleValue()))));
+
+        for (Shape original : List.of(new Circle(2.0), new Rect(3.0, 4.0))) {
+            var encoded = SHAPE_ENCODER.encode(original);
+            // The encoder's output (Map<String, @Nullable Object>) feeds straight back into the decoder.
+            @SuppressWarnings("unchecked")
+            var asInput = (Map<String, Object>) (Map<String, ?>) encoded;
+            assertEquals(original, dec.decode(asInput).getOrThrow());
+        }
+    }
+
+    @Test
+    void discriminateThrowsForUnregisteredType() {
+        Encoder<Shape, Map<String, @Nullable Object>> enc =
+                discriminate("type", variant(Circle.class, "circle", CIRCLE_ENCODER));
+        assertThrows(IllegalArgumentException.class, () -> enc.encode(new Rect(1.0, 2.0)));
+    }
+
+    @Test
+    void discriminateThrowsForDuplicateVariant() {
+        assertThrows(IllegalArgumentException.class, () -> discriminate("type",
+                variant(Circle.class, "circle", CIRCLE_ENCODER),
+                variant(Circle.class, "disc",   CIRCLE_ENCODER)));
+    }
+
+    @Test
+    void discriminateTagIsAuthoritativeOverVariantOutput() {
+        // A variant encoder that (incorrectly) also emits the discriminator key.
+        Encoder<Circle, Map<String, @Nullable Object>> rogue = object(
+                property("type",   c -> "WRONG",   string()),
+                property("radius", Circle::radius, double_()));
+        Encoder<Shape, Map<String, @Nullable Object>> enc =
+                discriminate("type", variant(Circle.class, "circle", rogue));
+
+        var out = enc.encode(new Circle(1.0));
+        assertEquals("circle", out.get("type"));
+        assertEquals(1.0, out.get("radius"));
     }
 }


### PR DESCRIPTION
## Summary

Adds an encode-side `discriminate()` combinator to `MapEncoders`, mirroring the decoder-side `discriminate` that already exists across the core / map / json / jooq layers. Tagged-union (sealed interface) encoding no longer needs a hand-written `switch` plus a hard-coded tag property in every variant.

Closes #44.

## API

```java
// Declare each variant: concrete class + tag + body encoder.
Encoder<Shape, Map<String, @Nullable Object>> SHAPE_ENCODER = discriminate("type",
    variant(Circle.class, "circle", CIRCLE_ENCODER),
    variant(Rect.class,   "rect",   RECT_ENCODER));

SHAPE_ENCODER.encode(new Circle(2.0));   // => {type=circle, radius=2.0}
```

- `Variant<S>` (public record) + `variant(Class<S>, String, Encoder<S, Map<String, @Nullable Object>>)` + `@SafeVarargs discriminate(String, Variant<? extends T>...)`.
- The `variant` type parameter ties the class and encoder together and deliberately omits the union supertype `T`, so several `variant(...)` calls of different subtypes still infer under one `discriminate(...)`.

## Why Class-dispatch, not a tag function

Encode is asymmetric to decode: the decoder reads the tag from input **data**; the encoder must choose from the value's **type**. Dispatching on `value.getClass()` is the honest inverse and removes the caller's `switch` entirely — the exact pain point in #44. A `Function<T,String>` tag form would keep a (smaller) switch and split the variant list across two places.

## Behaviour decisions

- **Tag injected first, authoritative** — the discriminator is written at the head of the output `LinkedHashMap`; if a variant encoder also emits that key, the injected tag wins. Variants therefore drop their own `property("type", …)`.
- **Exact-class dispatch** — matches by `getClass()`, fitting a sealed hierarchy of records / final classes.
- **Total function** — consistent with `Encoder` never returning a `Result`. A correct definition never throws at encode time; an unregistered type throws `IllegalArgumentException` (guard against an incomplete definition, asymmetric with the decoder's `not_allowed` result). Duplicate variant classes throw at construction.
- **Return type matches `object(...)`** — composes via `nested(...)` or as a top-level encoder. No new `ErrorCodes`/`messages.properties` (no `Result` path), so no change to `MessageResolver` or the coverage test.

## Tests

Six tests added to `MapEncoderTest` (JUnit 5): dispatch + tag injection, tag-first ordering, **round-trip against the decoder-side `discriminate`**, unregistered-type throw, duplicate-variant throw, and tag-is-authoritative-over-variant-output.

## Verification

- `mvn test -pl raoh` — 240 tests pass (234 prior + 6).
- `mvn -Pnullcheck clean compile -pl raoh` — NullAway (JSpecifyMode=ERROR) clean, including the unchecked variant cast.
- `mvn javadoc:javadoc -pl raoh` — no Javadoc warnings.
- jetshell — the new tutorial snippet runs and prints `{type=circle, radius=2.0}` / `{type=rect, width=3.0, height=4.0}` as documented.

## Docs

Adds tutorial section 33 (EN + JA) with a verified example, and closes a pre-existing unterminated code fence at the end of both tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
