### PR TITLE
docs(jooq): document the jOOQ Result decode idiom; lock subtype-list traverse (#45)

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/package-info.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/package-info.java
@@ -1,7 +1,40 @@
 /**
  * Decoders for {@link org.jooq.Record} input.
  *
+ * <p>{@link net.unit8.raoh.jooq.JooqRecordDecoders} builds decoders that turn a single
+ * {@link org.jooq.Record} (one row) into a domain object. To decode the result of a query, apply
+ * such a decoder to the rows the caller has already fetched — raoh does not run the query itself.
+ *
+ * <p><strong>Single row.</strong> Apply the decoder directly to a fetched record:
+ *
+ * <pre>{@code
+ * Result<Problem> one = PROBLEM_DECODER.decode(
+ *         ctx.selectFrom(PROBLEMS).where(ID.eq(id)).fetchOne());
+ *
+ * // Zero-or-one row: keep the "no row" case as Optional, the decode outcome as Result
+ * Optional<Result<Problem>> maybe = ctx.selectFrom(PROBLEMS).where(ID.eq(id))
+ *         .fetchOptional().map(PROBLEM_DECODER::decode);
+ * }</pre>
+ *
+ * <p><strong>Many rows.</strong> {@code ResultQuery.fetch()} returns an
+ * {@link org.jooq.Result} (which is a {@link java.util.List} of records), so
+ * {@link net.unit8.raoh.Result#traverse(java.util.List, java.util.function.BiFunction)} decodes
+ * every row, accumulating each row's errors under an indexed path ({@code /0/col}, {@code /1/col}):
+ *
+ * <pre>{@code
+ * Result<List<Problem>> problems =
+ *         Result.traverse(ctx.selectFrom(PROBLEMS).fetch(), PROBLEM_DECODER::decode);
+ * }</pre>
+ *
+ * <p>{@code traverse} infers its element type from the arguments, so a
+ * {@code Result<SomeGeneratedRecord>} (a list of a subtype of {@code Record}) decodes cleanly with a
+ * {@code Decoder<Record, T>} — no copy or cast is needed. Choose how to surface a failure on the
+ * returned {@link net.unit8.raoh.Result}: {@link net.unit8.raoh.Result#getOrThrow()} to throw, or
+ * {@link net.unit8.raoh.Result#orElseThrow(java.util.function.Function)} to map the issues to a
+ * domain exception.
+ *
  * @see net.unit8.raoh.jooq.JooqRecordDecoders
+ * @see net.unit8.raoh.Result#traverse(java.util.List, java.util.function.BiFunction)
  */
 @NullMarked
 package net.unit8.raoh.jooq;

--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/package-info.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/package-info.java
@@ -5,11 +5,13 @@
  * {@link org.jooq.Record} (one row) into a domain object. To decode the result of a query, apply
  * such a decoder to the rows the caller has already fetched — raoh does not run the query itself.
  *
- * <p><strong>Single row.</strong> Apply the decoder directly to a fetched record:
+ * <p><strong>Single row.</strong> Apply the decoder directly to a fetched record. Use
+ * {@code fetchSingle()} when exactly one row is expected ({@code fetchOne()} instead returns
+ * {@code null} for no row, which would make "no row" look like a decode failure):
  *
  * <pre>{@code
  * Result<Problem> one = PROBLEM_DECODER.decode(
- *         ctx.selectFrom(PROBLEMS).where(ID.eq(id)).fetchOne());
+ *         ctx.selectFrom(PROBLEMS).where(ID.eq(id)).fetchSingle());
  *
  * // Zero-or-one row: keep the "no row" case as Optional, the decode outcome as Result
  * Optional<Result<Problem>> maybe = ctx.selectFrom(PROBLEMS).where(ID.eq(id))
@@ -26,9 +28,9 @@
  *         Result.traverse(ctx.selectFrom(PROBLEMS).fetch(), PROBLEM_DECODER::decode);
  * }</pre>
  *
- * <p>{@code traverse} infers its element type from the arguments, so a
- * {@code Result<SomeGeneratedRecord>} (a list of a subtype of {@code Record}) decodes cleanly with a
- * {@code Decoder<Record, T>} — no copy or cast is needed. Choose how to surface a failure on the
+ * <p>{@code traverse} infers its element type from the arguments, so an
+ * {@code org.jooq.Result<SomeGeneratedRecord>} (a list of a subtype of {@code org.jooq.Record})
+ * decodes cleanly with a {@code Decoder<org.jooq.Record, T>} — no copy or cast is needed. Choose how to surface a failure on the
  * returned {@link net.unit8.raoh.Result}: {@link net.unit8.raoh.Result#getOrThrow()} to throw, or
  * {@link net.unit8.raoh.Result#orElseThrow(java.util.function.Function)} to map the issues to a
  * domain exception.

--- a/raoh/src/test/java/net/unit8/raoh/decode/combinator/TraverseTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/combinator/TraverseTest.java
@@ -96,6 +96,25 @@ class TraverseTest {
         assertEquals(2, issues.size());
     }
 
+    /**
+     * A decoder over a supertype must apply to a list of a subtype without any copy or cast.
+     * {@code Result.traverse}'s element type {@code I} is inferred from the arguments, so a
+     * {@code List<String>} decodes fine with a {@code Decoder<CharSequence, ...>}. This mirrors
+     * the raoh-jooq idiom {@code Result.traverse(query.fetch(), dec::decode)} where
+     * {@code query.fetch()} is an {@code org.jooq.Result<SomeRecordSubtype>} (a {@code List} of a
+     * subtype of {@code org.jooq.Record}) and {@code dec} is a {@code Decoder<org.jooq.Record, T>}.
+     * If this stops compiling, the jOOQ list-decode idiom has regressed.
+     */
+    @Test
+    void traverseAcceptsSubtypeElementList() {
+        Decoder<CharSequence, Integer> lengthDecoder = (in, path) -> Result.ok(in.length());
+        List<String> subtypeList = List.of("a", "bb", "ccc");
+
+        var result = Result.traverse(subtypeList, lengthDecoder::decode);
+        assertInstanceOf(Ok.class, result);
+        assertEquals(List.of(1, 2, 3), result.getOrThrow());
+    }
+
     @Test
     void decoderListConvenience() {
         Decoder<List<String>, List<Integer>> listDecoder = INT_DECODER.list();


### PR DESCRIPTION
## Summary

Investigating #45 showed the feature needs **no new API**. Applying a decoder to a jOOQ query result is already expressible with the core `Result.traverse` runner; this PR documents the idiom and adds a regression test. Closes #45.

## Why no code

`Result.traverse(List<I>, BiFunction<? super I, ...>)` infers its element type `I` from the arguments — it is **not** pinned. So a `Result<SomeGeneratedRecord>` (which is a `List` of a subtype of `org.jooq.Record`) decodes cleanly with a `Decoder<org.jooq.Record, T>`:

```java
Result<List<Problem>> problems =
        Result.traverse(ctx.selectFrom(PROBLEMS).fetch(), PROBLEM_DECODER::decode);
```

This accumulates each row's errors under an indexed path (`/0/col`, `/1/col`) and returns `Result<List<T>>` — the caller chooses `.getOrThrow()` or `.orElseThrow(...)`. Single-row is `dec.decode(query.fetchOne())`; zero-or-one is `query.fetchOptional().map(dec::decode)`.

The only thing that does **not** accept a subtype list is `dec.list().decode(...)` (its input type is pinned to `List<Record>`), but `traverse` is the correct eager runner for this and works today. This matches how Elm (`decodeValue (list dec)`) and Yavi (`liftList` + `validate`) keep list handling as a combinator plus a generic runner rather than a fused eager helper — so no jooq-specific bridge is added.

## Changes

- **`raoh-jooq` package-info** — documents the single-row / optional / many-row decode idioms at the module's front door.
- **`TraverseTest`** — a regression test that fails to compile if `Result.traverse` ever stops accepting a subtype-element list (`Decoder<CharSequence, Integer>` over a `List<String>`, mirroring `Decoder<Record, T>` over `List<GeneratedRecord>`).

## Verification

- `mvn test -pl raoh` — 243 tests pass (+1).
- `mvn javadoc:javadoc -pl raoh-jooq -am` — no warnings (all `{@link}` resolve).
- `mvn -Pnullcheck clean compile -pl raoh-jooq -am` — NullAway (JSpecifyMode=ERROR) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
