### PR TITLE
ci: add GitHub Actions workflow (build/test + NullAway gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build & Test (JDK 25)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 25
@@ -27,7 +27,7 @@ jobs:
 
   nullcheck:
     name: NullAway null-analysis gate (JDK 25)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Test (JDK 25)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Build and test
+        run: mvn -B --no-transfer-progress verify
+
+  nullcheck:
+    name: NullAway null-analysis gate (JDK 25)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      # The @NullMarked modules (raoh, raoh-json, raoh-jooq) declare a `nullcheck`
+      # profile that runs NullAway via Error Prone. It requires exactly JDK 25.
+      - name: NullAway check
+        run: mvn -B --no-transfer-progress -Pnullcheck compile


### PR DESCRIPTION
## Summary

Raoh had **no CI**: the ~280 JUnit tests and the NullAway null-analysis gate were only ever run locally, so nothing verified them automatically on push or PR. This is the largest quality gap on the road to a 1.0 release.

This adds `.github/workflows/ci.yml`, triggered on push and PR to `develop` and `main`, with two jobs on Temurin **JDK 25**:

- **build** — `mvn verify` across all six modules (compiles + runs the full test suite).
- **nullcheck** — `mvn -Pnullcheck compile`, enforcing the `@NullMarked` contract on `raoh`, `raoh-json`, and `raoh-jooq` via NullAway/Error Prone. This profile requires exactly JDK 25 (Error Prone crashes on JDK 26), which the job pins.

Both commands were run against the current `develop` tree locally and pass (`BUILD SUCCESS`).

## Out of scope (follow-up)

Release/deploy automation (tag → `mvn deploy -Prelease` → Maven Central) is intentionally **not** included here: it needs the GPG signing key and Central credentials configured as repository secrets, plus a decision on whether to auto-publish on tag given `autoPublish=true`. That will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)