### PR TITLE
docs(readme): fix Jackson 3 import and add Maven coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,14 @@ If you are coming from a validator-oriented library, the main difference in feel
 
 ## Installation
 
-Raoh is distributed under the `net.unit8.raoh` group ID on Maven Central. Add the
+Raoh is published to Maven Central under the `net.unit8.raoh` group ID. Add the
 core module, plus whichever boundary module matches your input source. Define the
-version once as a property — replace the value below with the latest shown on the
-Maven Central badge above.
+version once as a property — use the latest shown on the Maven Central badge above.
 
 ```xml
 <properties>
-    <!-- Replace with the latest version from the Maven Central badge above -->
-    <raoh.version>1.0.0</raoh.version>
+    <!-- Use the latest version from the Maven Central badge above -->
+    <raoh.version>0.5.0</raoh.version>
 </properties>
 
 <dependencies>

--- a/README.md
+++ b/README.md
@@ -35,31 +35,39 @@ If you are coming from a validator-oriented library, the main difference in feel
 
 ## Installation
 
-Raoh is published to Maven Central under the `net.unit8.raoh` group. Add the core
-module, plus whichever boundary module matches your input source. For the version,
-use the latest shown on the Maven Central badge above.
+Raoh is distributed under the `net.unit8.raoh` group ID on Maven Central. Add the
+core module, plus whichever boundary module matches your input source. Define the
+version once as a property — replace the value below with the latest shown on the
+Maven Central badge above.
 
 ```xml
-<!-- Core: decoders, encoders, error model -->
-<dependency>
-    <groupId>net.unit8.raoh</groupId>
-    <artifactId>raoh</artifactId>
-    <version>${raoh.version}</version>
-</dependency>
+<properties>
+    <!-- Replace with the latest version from the Maven Central badge above -->
+    <raoh.version>1.0.0</raoh.version>
+</properties>
 
-<!-- Optional: decode Jackson JsonNode (pulls in Jackson 3) -->
-<dependency>
-    <groupId>net.unit8.raoh</groupId>
-    <artifactId>raoh-json</artifactId>
-    <version>${raoh.version}</version>
-</dependency>
+<dependencies>
+    <!-- Core: decoders, encoders, error model -->
+    <dependency>
+        <groupId>net.unit8.raoh</groupId>
+        <artifactId>raoh</artifactId>
+        <version>${raoh.version}</version>
+    </dependency>
 
-<!-- Optional: decode jOOQ Record (jOOQ is a provided dependency) -->
-<dependency>
-    <groupId>net.unit8.raoh</groupId>
-    <artifactId>raoh-jooq</artifactId>
-    <version>${raoh.version}</version>
-</dependency>
+    <!-- Optional: decode Jackson JsonNode (pulls in Jackson 3) -->
+    <dependency>
+        <groupId>net.unit8.raoh</groupId>
+        <artifactId>raoh-json</artifactId>
+        <version>${raoh.version}</version>
+    </dependency>
+
+    <!-- Optional: decode jOOQ Record (jOOQ is a provided dependency) -->
+    <dependency>
+        <groupId>net.unit8.raoh</groupId>
+        <artifactId>raoh-jooq</artifactId>
+        <version>${raoh.version}</version>
+    </dependency>
+</dependencies>
 ```
 
 ## Building from source

--- a/README.md
+++ b/README.md
@@ -32,9 +32,40 @@ If you are coming from a validator-oriented library, the main difference in feel
 ## Requirements
 
 - Java 25
-- Maven
 
-Build and run tests:
+## Installation
+
+Raoh is published to Maven Central under the `net.unit8.raoh` group. Add the core
+module, plus whichever boundary module matches your input source. For the version,
+use the latest shown on the Maven Central badge above.
+
+```xml
+<!-- Core: decoders, encoders, error model -->
+<dependency>
+    <groupId>net.unit8.raoh</groupId>
+    <artifactId>raoh</artifactId>
+    <version>${raoh.version}</version>
+</dependency>
+
+<!-- Optional: decode Jackson JsonNode (pulls in Jackson 3) -->
+<dependency>
+    <groupId>net.unit8.raoh</groupId>
+    <artifactId>raoh-json</artifactId>
+    <version>${raoh.version}</version>
+</dependency>
+
+<!-- Optional: decode jOOQ Record (jOOQ is a provided dependency) -->
+<dependency>
+    <groupId>net.unit8.raoh</groupId>
+    <artifactId>raoh-jooq</artifactId>
+    <version>${raoh.version}</version>
+</dependency>
+```
+
+## Building from source
+
+- Java 25
+- Maven
 
 ```bash
 mvn clean test
@@ -139,7 +170,7 @@ That means the "happy path" looks like object construction, while the failure pa
 ### Decode JSON into a domain object
 
 ```java
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import net.unit8.raoh.json.JsonDecoder;
 
@@ -389,7 +420,7 @@ The following example shows the common Raoh shape:
 - run domain-specific rules afterwards
 
 ```java
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.math.BigDecimal;
 


### PR DESCRIPTION
## Summary

Two README gaps that trip up a first-time user, both found while assessing 1.0 readiness.

- **Quick Start didn't compile.** It imported `com.fasterxml.jackson.databind.JsonNode` (Jackson 2), but `raoh-json` is built on **Jackson 3** — the real class is `tools.jackson.databind.JsonNode` (`JsonDecoders.java:24`). Fixed both occurrences.
- **No install instructions.** The README had a Maven Central badge but no copy-pasteable `<dependency>` block, so consumers had no way to know the coordinates. Added an **Installation** section for `raoh`, `raoh-json`, and `raoh-jooq`. The version is defined once via a `<raoh.version>` property (with the latest shown on the badge); the current release is 0.5.0. Moved the build-from-source steps into their own section.

## Notes

- raoh **is** published to Maven Central (0.1.0–0.5.0, latest release 0.5.0). An earlier revision of this PR wrongly said it wasn't — that came from a stale search.maven.org query and has been corrected.
- Verified no other `com.fasterxml` references remain in `README.md` or `docs/`.
- The jOOQ dependency note reflects its `provided` scope; the Jackson note reflects that `raoh-json` pulls Jackson 3 transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)