### PR TITLE
feat(decode): mirror nullableField() into JsonDecoders and JooqRecordDecoders (#53)

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -97,6 +97,43 @@ public final class JooqRecordDecoders {
     }
 
     /**
+     * Extracts a named field from a {@link org.jooq.Record} directly as a {@code @Nullable T}: an
+     * absent column or a present {@code null} value both decode to {@code null}, and any other value
+     * is decoded with {@code dec}.
+     *
+     * <p>This is the {@code @Nullable}-target sibling of {@link #optionalField} (which targets
+     * {@link Optional Optional&lt;T&gt;}) and {@link #optionalNullableField} (which targets
+     * {@link Presence Presence&lt;T&gt;}). Unlike {@code optionalNullableField}, it does <em>not</em>
+     * preserve the absent/present-null distinction — it collapses both to {@code null}. Use it to
+     * populate a plain {@code @Nullable} domain field or constructor argument without an intermediate
+     * {@code Optional} or {@code Presence}.
+     *
+     * @param <T>  the decoded value type
+     * @param name the column name
+     * @param dec  decoder for the raw value when present and non-null
+     * @return a decoder that produces the decoded value, or {@code null} when the column is absent or
+     *         its value is {@code null}
+     */
+    // Returns a JooqRecordDecoder<@Nullable T>. NullAway cannot verify the type-parameter nullness of
+    // the @Nullable T return, the same honest widening already suppressed in ObjectDecoders.nullable.
+    @SuppressWarnings("NullAway")
+    public static <T> JooqRecordDecoder<@Nullable T> nullableField(String name, Decoder<@Nullable Object, T> dec) {
+        return (in, path) -> {
+            var fieldPath = path.append(name);
+            // A null record or absent column is treated as absent (-> null), consistent with
+            // optionalField / optionalNullableField (field alone would reject it as a required error).
+            if (in == null || in.field(name) == null) {
+                return Result.<@Nullable T>ok(null);
+            }
+            var value = in.get(name);
+            if (value == null) {
+                return Result.<@Nullable T>ok(null);
+            }
+            return dec.decode(value, fieldPath);
+        };
+    }
+
+    /**
      * Applies another {@link JooqRecordDecoder} to the same {@link org.jooq.Record}.
      *
      * <p>This is the primary building block for mapping a flat JOIN result into a

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -242,6 +242,43 @@ class JooqDecoderTest {
     }
 
     // -------------------------------------------------------------------------
+    // nullableField — folds absent / present-null directly to @Nullable T
+    // -------------------------------------------------------------------------
+
+    @Test
+    void nullableFieldCollapsesAbsentAndPresentNull() {
+        var dec = nullableField("display_name", string());
+
+        // absent column -> null
+        var absent = dec.decode(record("name", "Bob"));
+        assertInstanceOf(Ok.class, absent);
+        assertNull(((Ok<String>) absent).value());
+
+        // present-null -> null
+        var presentNull = dec.decode(record("display_name", (Object) null));
+        assertInstanceOf(Ok.class, presentNull);
+        assertNull(((Ok<String>) presentNull).value());
+
+        // present value -> decoded value
+        var present = dec.decode(record("display_name", "Alice"));
+        assertInstanceOf(Ok.class, present);
+        assertEquals("Alice", ((Ok<String>) present).value());
+    }
+
+    @Test
+    void nullableFieldDecodesPresentValueThroughInnerDecoder() {
+        // The inner decoder still runs (and can fail) for a present, non-null value.
+        var dec = nullableField("display_name", string().nonBlank());
+
+        var ok = dec.decode(record("display_name", "abc"));
+        assertInstanceOf(Ok.class, ok);
+        assertEquals("abc", ((Ok<String>) ok).value());
+
+        var err = dec.decode(record("display_name", "  "));
+        assertInstanceOf(Err.class, err);
+    }
+
+    // -------------------------------------------------------------------------
     // Value object composition — Money from two columns
     // -------------------------------------------------------------------------
 

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -278,6 +278,17 @@ class JooqDecoderTest {
         assertInstanceOf(Err.class, err);
     }
 
+    @Test
+    void nullableFieldTreatsNullRecordAsNull() {
+        // A null record is tolerated as absent -> null, consistent with optionalField /
+        // optionalNullableField (field alone would reject it as a required error).
+        var dec = nullableField("display_name", string());
+        org.jooq.Record nullRecord = null;
+        var result = dec.decode(nullRecord);
+        assertInstanceOf(Ok.class, result);
+        assertNull(((Ok<String>) result).value());
+    }
+
     // -------------------------------------------------------------------------
     // Value object composition — Money from two columns
     // -------------------------------------------------------------------------

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -260,6 +260,45 @@ public final class JsonDecoders {
         };
     }
 
+    /**
+     * Creates a field decoder that lands directly on a {@code @Nullable T}: a missing key or a
+     * JSON {@code null} value both decode to {@code null}, and any other value is decoded with
+     * {@code dec}.
+     *
+     * <p>This is the {@code @Nullable}-target sibling of {@link #optionalField} (which targets
+     * {@link Optional Optional&lt;T&gt;}) and {@link #optionalNullableField} (which targets
+     * {@link Presence Presence&lt;T&gt;}). Unlike {@code optionalNullableField}, it does <em>not</em>
+     * preserve the absent/present-null distinction — it collapses both to {@code null}. Use it to
+     * populate a plain {@code @Nullable} domain field or constructor argument without an intermediate
+     * {@code Optional} or {@code Presence}.
+     *
+     * @param <T>  the decoded value type
+     * @param name the field name
+     * @param dec  the decoder for the field value when present and non-null
+     * @return a decoder that produces the decoded value, or {@code null} when the key is absent or its
+     *         value is JSON {@code null}
+     */
+    // Returns a Decoder<..., @Nullable T>. NullAway cannot verify the type-parameter nullness of the
+    // @Nullable T return, the same honest widening already suppressed in JsonDecoders.nullable.
+    @SuppressWarnings("NullAway")
+    public static <T> Decoder<JsonNode, @Nullable T> nullableField(String name, Decoder<JsonNode, T> dec) {
+        return (in, path) -> {
+            var fieldPath = path.append(name);
+            // A null / non-object input is treated as absent (-> null), consistent with optionalField /
+            // optionalNullableField (field alone would reject it as a required error).
+            if (in == null || !in.isObject()) {
+                return Result.<@Nullable T>ok(null);
+            }
+            var node = in.get(name);
+            // Collapse both a missing key and a JSON null to null; nullable(dec) alone would not,
+            // since it only folds NullNode and leaves a MissingNode to reach the inner decoder.
+            if (node == null || node.isMissingNode() || node.isNull()) {
+                return Result.<@Nullable T>ok(null);
+            }
+            return dec.decode(node, fieldPath);
+        };
+    }
+
     // --- list / map ---
 
     /**

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -281,6 +281,16 @@ class JsonDecoderTest {
     }
 
     @Test
+    void nullableFieldTreatsNullAndNonObjectInputAsNull() {
+        // A null or non-object parent is tolerated as absent -> null, consistent with
+        // optionalField / optionalNullableField (field alone would reject it as a required error).
+        var dec = nullableField("val", string());
+        assertNull(assertOk(dec.decode((JsonNode) null)));
+        assertNull(assertOk(dec.decode(parse("[]"))));
+        assertNull(assertOk(dec.decode(parse("\"scalar\""))));
+    }
+
+    @Test
     void presenceTriState() {
         var dec = optionalNullableField("email", string());
         var absent = assertOk(dec.decode(parse("{}")));

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -259,10 +259,25 @@ class JsonDecoderTest {
     }
 
     @Test
-    void nullableField() {
-        var dec = field("val", nullable(string()));
+    void nullableFieldCollapsesAbsentAndPresentNull() {
+        var dec = nullableField("val", string());
+
+        // absent key -> null
+        assertNull(assertOk(dec.decode(parse("{}"))));
+
+        // JSON null -> null
         assertNull(assertOk(dec.decode(parse("{\"val\":null}"))));
+
+        // present value -> decoded value
         assertEquals("x", assertOk(dec.decode(parse("{\"val\":\"x\"}"))));
+    }
+
+    @Test
+    void nullableFieldDecodesPresentValueThroughInnerDecoder() {
+        // The inner decoder still runs (and can fail) for a present, non-null value.
+        var dec = nullableField("name", string().nonBlank());
+        assertEquals("abc", assertOk(dec.decode(parse("{\"name\":\"abc\"}"))));
+        assertErr(dec.decode(parse("{\"name\":\"  \"}")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`nullableField()` — a field decoder landing directly on `@Nullable T` (absent or null → `null`, present → decoded value) — was added in #46 but only to `MapDecoders`. `field` / `optionalField` / `optionalNullableField` already exist in all three boundary layers, so `nullableField` was the sole asymmetry. This closes that gap.

- **`JsonDecoders.nullableField(String, Decoder<JsonNode, T>) -> Decoder<JsonNode, @Nullable T>`** — collapses a missing key **and** an explicit JSON `null` to `null`.
- **`JooqRecordDecoders.nullableField(String, Decoder<@Nullable Object, T>) -> JooqRecordDecoder<@Nullable T>`** — collapses an absent column **and** a present `null` to `null`.

Both mirror each layer's `optionalNullableField` absent/present-null handling, folded down to `@Nullable T`.

## Design note

The JSON version is written self-contained rather than as `field(name, nullable(dec))`. `nullable()` only folds a JSON `NullNode`; an absent key surfaces as a `MissingNode`, which `nullable` leaves untouched, so it would reach the inner decoder and error. The direct form treats missing / JSON-null / non-object input uniformly as `null`.

## Tests

- **jOOQ**: new tests covering absent column / present-null / present, plus inner-decoder pass-through and failure.
- **JSON**: the pre-existing `nullableField` test actually exercised the hand-rolled `field(name, nullable(...))` composition and omitted the absent-key case. Replaced with factory tests covering absent / present-null / present + inner-decoder failure.

## Verification

- `mvn -pl raoh-json,raoh-jooq -am test` → all green (json 70, jooq 18).
- `mvn javadoc:javadoc` → BUILD SUCCESS, no warnings (no `-Xdoclint:none`).

Closes #53. Refs #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)