### PR TITLE
feat(decode): DecimalDecoder parity + message overloads across numeric decoders (#54)

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/Result.java
+++ b/raoh/src/main/java/net/unit8/raoh/Result.java
@@ -229,6 +229,29 @@ public sealed interface Result<T extends @Nullable Object> permits Ok, Err {
     }
 
     /**
+     * Creates a failed result, using {@code message} as a custom (resolve-proof) message when it is
+     * non-null and falling back to {@code defaultMessage} otherwise.
+     *
+     * <p>This unifies the common "a caller-supplied message overrides the built-in default" branch:
+     * a non-null {@code message} routes through {@link #failCustom} (so {@link MessageResolver} will
+     * not overwrite it), while {@code null} routes through {@link #fail} with the default message.
+     *
+     * @param <T>            the value type
+     * @param path           the path where the error occurred
+     * @param code           the error code
+     * @param message        the caller-supplied custom message, or {@code null} to use the default
+     * @param defaultMessage the built-in fallback message used when {@code message} is {@code null}
+     * @param meta           additional metadata
+     * @return an {@link Err} result carrying either the custom or the default message
+     */
+    static <T extends @Nullable Object> Result<T> failWith(
+            Path path, String code, @Nullable String message, String defaultMessage, Map<String, Object> meta) {
+        return message != null
+                ? failCustom(path, code, message, meta)
+                : fail(path, code, defaultMessage, meta);
+    }
+
+    /**
      * Combines two independent results, accumulating errors from both if either fails.
      *
      * <p>Unlike {@link #flatMap}, both {@code ra} and {@code rb} are evaluated regardless of

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -54,9 +54,8 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(n) < 0) {
                 var meta = Map.<String, Object>of("min", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %s".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at least %s".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -83,9 +82,8 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(n) > 0) {
                 var meta = Map.<String, Object>of("max", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %s".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at most %s".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -114,10 +112,8 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE,
-                                "must be between %s and %s".formatted(min, max), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be between %s and %s".formatted(min, max), meta);
             }
             return Result.ok(value);
         });
@@ -142,9 +138,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) <= 0) {
                 var meta = Map.<String, Object>of("min", BigDecimal.ZERO, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -169,9 +163,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) >= 0) {
                 var meta = Map.<String, Object>of("max", BigDecimal.ZERO, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -196,9 +188,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) < 0) {
                 var meta = Map.<String, Object>of("min", BigDecimal.ZERO, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -223,9 +213,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) > 0) {
                 var meta = Map.<String, Object>of("max", BigDecimal.ZERO, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -252,10 +240,8 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.remainder(n).compareTo(BigDecimal.ZERO) != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
-                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                                "must be a multiple of %s".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.NOT_MULTIPLE_OF, message,
+                        "must be a multiple of %s".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -282,10 +268,8 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
         return chain((value, path) -> {
             if (value.scale() > s) {
                 var meta = Map.<String, Object>of("maxScale", s, "actualScale", value.scale());
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.INVALID_SCALE, message, meta)
-                        : Result.fail(path, ErrorCodes.INVALID_SCALE,
-                                "too many decimal places (max %d)".formatted(s), meta);
+                return Result.failWith(path, ErrorCodes.INVALID_SCALE, message,
+                        "too many decimal places (max %d)".formatted(s), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -40,10 +40,23 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
      */
     public DecimalDecoder<I> min(BigDecimal n) {
+        return min(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at least {@code n}.
+     *
+     * @param n       the minimum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if below
+     */
+    public DecimalDecoder<I> min(BigDecimal n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(n) < 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %s".formatted(n),
-                        Map.of("min", n, "actual", value));
+                var meta = Map.<String, Object>of("min", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %s".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -56,10 +69,55 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
      */
     public DecimalDecoder<I> max(BigDecimal n) {
+        return max(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be at most {@code n}.
+     *
+     * @param n       the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if above
+     */
+    public DecimalDecoder<I> max(BigDecimal n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(n) > 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %s".formatted(n),
-                        Map.of("max", n, "actual", value));
+                var meta = Map.<String, Object>of("max", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %s".formatted(n), meta);
+            }
+            return Result.ok(value);
+        });
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min the minimum allowed value (inclusive)
+     * @param max the maximum allowed value (inclusive)
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public DecimalDecoder<I> range(BigDecimal min, BigDecimal max) {
+        return range(min, max, null);
+    }
+
+    /**
+     * Restricts the decoded value to be within the given range (inclusive).
+     *
+     * @param min     the minimum allowed value (inclusive)
+     * @param max     the maximum allowed value (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     */
+    public DecimalDecoder<I> range(BigDecimal min, BigDecimal max, @Nullable String message) {
+        return chain((value, path) -> {
+            if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
+                var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE,
+                                "must be between %s and %s".formatted(min, max), meta);
             }
             return Result.ok(value);
         });
@@ -71,10 +129,22 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
      */
     public DecimalDecoder<I> positive() {
+        return positive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
+    public DecimalDecoder<I> positive(@Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) <= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive",
-                        Map.of("min", BigDecimal.ZERO, "actual", value));
+                var meta = Map.<String, Object>of("min", BigDecimal.ZERO, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -86,10 +156,22 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
      */
     public DecimalDecoder<I> negative() {
+        return negative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
+    public DecimalDecoder<I> negative(@Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) >= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative",
-                        Map.of("max", BigDecimal.ZERO, "actual", value));
+                var meta = Map.<String, Object>of("max", BigDecimal.ZERO, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -101,10 +183,22 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
      */
     public DecimalDecoder<I> nonNegative() {
+        return nonNegative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
+    public DecimalDecoder<I> nonNegative(@Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) < 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative",
-                        Map.of("min", BigDecimal.ZERO, "actual", value));
+                var meta = Map.<String, Object>of("min", BigDecimal.ZERO, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -116,10 +210,22 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
      */
     public DecimalDecoder<I> nonPositive() {
+        return nonPositive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
+    public DecimalDecoder<I> nonPositive(@Nullable String message) {
         return chain((value, path) -> {
             if (value.compareTo(BigDecimal.ZERO) > 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive",
-                        Map.of("max", BigDecimal.ZERO, "actual", value));
+                var meta = Map.<String, Object>of("max", BigDecimal.ZERO, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -132,11 +238,24 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not a multiple
      */
     public DecimalDecoder<I> multipleOf(BigDecimal n) {
+        return multipleOf(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n       the required divisor
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not a multiple
+     */
+    public DecimalDecoder<I> multipleOf(BigDecimal n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.remainder(n).compareTo(BigDecimal.ZERO) != 0) {
-                return Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                        "must be a multiple of %s".formatted(n),
-                        Map.of("divisor", n, "actual", value));
+                var meta = Map.<String, Object>of("divisor", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
+                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
+                                "must be a multiple of %s".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -149,11 +268,24 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @return a new decoder that fails with {@link ErrorCodes#INVALID_SCALE} if the scale exceeds {@code s}
      */
     public DecimalDecoder<I> scale(int s) {
+        return scale(s, null);
+    }
+
+    /**
+     * Restricts the number of decimal places.
+     *
+     * @param s       the maximum allowed scale (number of decimal places)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SCALE} if the scale exceeds {@code s}
+     */
+    public DecimalDecoder<I> scale(int s, @Nullable String message) {
         return chain((value, path) -> {
             if (value.scale() > s) {
-                return Result.fail(path, ErrorCodes.INVALID_SCALE,
-                        "too many decimal places (max %d)".formatted(s),
-                        Map.of("maxScale", s, "actualScale", value.scale()));
+                var meta = Map.<String, Object>of("maxScale", s, "actualScale", value.scale());
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.INVALID_SCALE, message, meta)
+                        : Result.fail(path, ErrorCodes.INVALID_SCALE,
+                                "too many decimal places (max %d)".formatted(s), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -130,10 +130,22 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
      */
     public IntDecoder<I> positive() {
+        return positive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
+    public IntDecoder<I> positive(@Nullable String message) {
         return chain((value, path) -> {
             if (value <= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive",
-                        Map.of("min", 1, "actual", value));
+                var meta = Map.<String, Object>of("min", 1, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -145,10 +157,22 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
      */
     public IntDecoder<I> negative() {
+        return negative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
+    public IntDecoder<I> negative(@Nullable String message) {
         return chain((value, path) -> {
             if (value >= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative",
-                        Map.of("max", -1, "actual", value));
+                var meta = Map.<String, Object>of("max", -1, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -160,10 +184,22 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
      */
     public IntDecoder<I> nonNegative() {
+        return nonNegative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
+    public IntDecoder<I> nonNegative(@Nullable String message) {
         return chain((value, path) -> {
             if (value < 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative",
-                        Map.of("min", 0, "actual", value));
+                var meta = Map.<String, Object>of("min", 0, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -175,10 +211,22 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
      */
     public IntDecoder<I> nonPositive() {
+        return nonPositive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
+    public IntDecoder<I> nonPositive(@Nullable String message) {
         return chain((value, path) -> {
             if (value > 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive",
-                        Map.of("max", 0, "actual", value));
+                var meta = Map.<String, Object>of("max", 0, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -210,11 +258,24 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
      */
     public IntDecoder<I> multipleOf(int n) {
+        return multipleOf(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n       the divisor
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     */
+    public IntDecoder<I> multipleOf(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value % n != 0) {
-                return Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                        "must be a multiple of %d".formatted(n),
-                        Map.of("divisor", n, "actual", value));
+                var meta = Map.<String, Object>of("divisor", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
+                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
+                                "must be a multiple of %d".formatted(n), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -56,9 +56,8 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value < n) {
                 var meta = Map.<String, Object>of("min", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at least %d".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -85,9 +84,8 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value > n) {
                 var meta = Map.<String, Object>of("max", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at most %d".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -116,9 +114,8 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value < min || value > max) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be between %d and %d".formatted(min, max), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be between %d and %d".formatted(min, max), meta);
             }
             return Result.ok(value);
         });
@@ -143,9 +140,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value <= 0) {
                 var meta = Map.<String, Object>of("min", 1, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -170,9 +165,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value >= 0) {
                 var meta = Map.<String, Object>of("max", -1, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -197,9 +190,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value < 0) {
                 var meta = Map.<String, Object>of("min", 0, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -224,9 +215,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value > 0) {
                 var meta = Map.<String, Object>of("max", 0, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -272,10 +261,8 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
         return chain((value, path) -> {
             if (value % n != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
-                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                                "must be a multiple of %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.NOT_MULTIPLE_OF, message,
+                        "must be a multiple of %d".formatted(n), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -130,9 +130,22 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
      */
     public LongDecoder<I> positive() {
+        return positive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not positive
+     */
+    public LongDecoder<I> positive(@Nullable String message) {
         return chain((value, path) -> {
             if (value <= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", Map.of("min", 1L, "actual", value));
+                var meta = Map.<String, Object>of("min", 1L, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -144,9 +157,22 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
      */
     public LongDecoder<I> negative() {
+        return negative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be strictly negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if not negative
+     */
+    public LongDecoder<I> negative(@Nullable String message) {
         return chain((value, path) -> {
             if (value >= 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", Map.of("max", -1L, "actual", value));
+                var meta = Map.<String, Object>of("max", -1L, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -158,9 +184,22 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
      */
     public LongDecoder<I> nonNegative() {
+        return nonNegative(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or positive.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if negative
+     */
+    public LongDecoder<I> nonNegative(@Nullable String message) {
         return chain((value, path) -> {
             if (value < 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", Map.of("min", 0L, "actual", value));
+                var meta = Map.<String, Object>of("min", 0L, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -172,9 +211,22 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
      */
     public LongDecoder<I> nonPositive() {
+        return nonPositive(null);
+    }
+
+    /**
+     * Restricts the decoded value to be zero or negative.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if positive
+     */
+    public LongDecoder<I> nonPositive(@Nullable String message) {
         return chain((value, path) -> {
             if (value > 0) {
-                return Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", Map.of("max", 0L, "actual", value));
+                var meta = Map.<String, Object>of("max", 0L, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
+                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -206,11 +258,24 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
      */
     public LongDecoder<I> multipleOf(long n) {
+        return multipleOf(n, null);
+    }
+
+    /**
+     * Restricts the decoded value to be a multiple of {@code n}.
+     *
+     * @param n       the divisor
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     */
+    public LongDecoder<I> multipleOf(long n, @Nullable String message) {
         return chain((value, path) -> {
             if (value % n != 0) {
-                return Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                        "must be a multiple of %d".formatted(n),
-                        Map.of("divisor", n, "actual", value));
+                var meta = Map.<String, Object>of("divisor", n, "actual", value);
+                return message != null
+                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
+                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
+                                "must be a multiple of %d".formatted(n), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -56,9 +56,8 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value < n) {
                 var meta = Map.<String, Object>of("min", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at least %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at least %d".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -85,9 +84,8 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value > n) {
                 var meta = Map.<String, Object>of("max", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be at most %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be at most %d".formatted(n), meta);
             }
             return Result.ok(value);
         });
@@ -116,9 +114,8 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value < min || value > max) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be between %d and %d".formatted(min, max), meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message,
+                        "must be between %d and %d".formatted(min, max), meta);
             }
             return Result.ok(value);
         });
@@ -143,9 +140,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value <= 0) {
                 var meta = Map.<String, Object>of("min", 1L, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be positive", meta);
             }
             return Result.ok(value);
         });
@@ -170,9 +165,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value >= 0) {
                 var meta = Map.<String, Object>of("max", -1L, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be negative", meta);
             }
             return Result.ok(value);
         });
@@ -197,9 +190,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value < 0) {
                 var meta = Map.<String, Object>of("min", 0L, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-negative", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-negative", meta);
             }
             return Result.ok(value);
         });
@@ -224,9 +215,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value > 0) {
                 var meta = Map.<String, Object>of("max", 0L, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.OUT_OF_RANGE, message, meta)
-                        : Result.fail(path, ErrorCodes.OUT_OF_RANGE, "must be non-positive", meta);
+                return Result.failWith(path, ErrorCodes.OUT_OF_RANGE, message, "must be non-positive", meta);
             }
             return Result.ok(value);
         });
@@ -272,10 +261,8 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
         return chain((value, path) -> {
             if (value % n != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);
-                return message != null
-                        ? Result.failCustom(path, ErrorCodes.NOT_MULTIPLE_OF, message, meta)
-                        : Result.fail(path, ErrorCodes.NOT_MULTIPLE_OF,
-                                "must be a multiple of %d".formatted(n), meta);
+                return Result.failWith(path, ErrorCodes.NOT_MULTIPLE_OF, message,
+                        "must be a multiple of %d".formatted(n), meta);
             }
             return Result.ok(value);
         });

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -576,6 +576,17 @@ class MapDecoderTest {
     }
 
     @Test
+    void customMessageSurvivesResolve() {
+        // failCustom must mark the message as custom so Issues.resolve() keeps it verbatim
+        // (rather than overwriting it with the error-code template) for the newly-added overloads.
+        assertResolvesTo(field("v", decimal().positive("正の数で")).decode(Map.of("v", -1)), "正の数で");
+        assertResolvesTo(field("v", decimal().multipleOf(new BigDecimal("3"), "3の倍数で")).decode(Map.of("v", 4)), "3の倍数で");
+        assertResolvesTo(field("v", decimal().scale(2, "小数2桁まで")).decode(Map.of("v", 1.234)), "小数2桁まで");
+        assertResolvesTo(field("v", int_().multipleOf(3, "3の倍数で")).decode(Map.of("v", 4)), "3の倍数で");
+        assertResolvesTo(field("v", long_().nonNegative("0以上で")).decode(Map.of("v", -1L)), "0以上で");
+    }
+
+    @Test
     void nullMessageFallsBackToDefault() {
         // Passing null (or using the no-message overload) yields the built-in default message.
         assertErrMessage(field("v", decimal().positive(null)).decode(Map.of("v", -1)), "must be positive");
@@ -1124,6 +1135,17 @@ class MapDecoderTest {
         switch (result) {
             case Ok(_) -> fail("Expected Err, got Ok: " + result);
             case Err(var issues) -> assertEquals(expectedMessage, issues.asList().getFirst().message());
+        }
+    }
+
+    /** Asserts the result is an Err whose first issue still carries the given message after resolve(). */
+    static void assertResolvesTo(Result<?> result, String expectedMessage) {
+        switch (result) {
+            case Ok(_) -> fail("Expected Err, got Ok: " + result);
+            case Err(var issues) -> {
+                var resolved = issues.resolve(MessageResolver.DEFAULT);
+                assertEquals(expectedMessage, resolved.asList().getFirst().message());
+            }
         }
     }
 }

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -524,6 +524,67 @@ class MapDecoderTest {
     }
 
     @Test
+    void decimalRange() {
+        var dec = field("price", decimal().range(new BigDecimal("0"), new BigDecimal("100")));
+        assertEquals(0, new BigDecimal("50").compareTo(assertOk(dec.decode(Map.of("price", 50)))));
+        assertEquals(0, new BigDecimal("0").compareTo(assertOk(dec.decode(Map.of("price", 0)))));  // inclusive lower
+        assertEquals(0, new BigDecimal("100").compareTo(assertOk(dec.decode(Map.of("price", 100)))));  // inclusive upper
+        assertErr(dec.decode(Map.of("price", 150)));
+        assertErr(dec.decode(Map.of("price", -1)));
+    }
+
+    @Test
+    void decimalConstraintCustomMessages() {
+        // Each numeric constraint's message overload stores the custom message as the pre-resolved Issue.message().
+        assertErrMessage(field("v", decimal().range(new BigDecimal("0"), new BigDecimal("10"), "0〜10で"))
+                .decode(Map.of("v", 20)), "0〜10で");
+        assertErrMessage(field("v", decimal().min(new BigDecimal("5"), "5以上で"))
+                .decode(Map.of("v", 1)), "5以上で");
+        assertErrMessage(field("v", decimal().max(new BigDecimal("5"), "5以下で"))
+                .decode(Map.of("v", 9)), "5以下で");
+        assertErrMessage(field("v", decimal().positive("正の数で"))
+                .decode(Map.of("v", -1)), "正の数で");
+        assertErrMessage(field("v", decimal().negative("負の数で"))
+                .decode(Map.of("v", 1)), "負の数で");
+        assertErrMessage(field("v", decimal().nonNegative("0以上で"))
+                .decode(Map.of("v", -1)), "0以上で");
+        assertErrMessage(field("v", decimal().nonPositive("0以下で"))
+                .decode(Map.of("v", 1)), "0以下で");
+        assertErrMessage(field("v", decimal().multipleOf(new BigDecimal("3"), "3の倍数で"))
+                .decode(Map.of("v", 4)), "3の倍数で");
+        assertErrMessage(field("v", decimal().scale(2, "小数2桁まで"))
+                .decode(Map.of("v", 1.234)), "小数2桁まで");
+    }
+
+    @Test
+    void intConstraintCustomMessages() {
+        // Newly-added message overloads on the non-range integer constraints.
+        assertErrMessage(field("v", int_().positive("正の数で")).decode(Map.of("v", -1)), "正の数で");
+        assertErrMessage(field("v", int_().negative("負の数で")).decode(Map.of("v", 1)), "負の数で");
+        assertErrMessage(field("v", int_().nonNegative("0以上で")).decode(Map.of("v", -1)), "0以上で");
+        assertErrMessage(field("v", int_().nonPositive("0以下で")).decode(Map.of("v", 1)), "0以下で");
+        assertErrMessage(field("v", int_().multipleOf(3, "3の倍数で")).decode(Map.of("v", 4)), "3の倍数で");
+    }
+
+    @Test
+    void longConstraintCustomMessages() {
+        assertErrMessage(field("v", long_().positive("正の数で")).decode(Map.of("v", -1L)), "正の数で");
+        assertErrMessage(field("v", long_().negative("負の数で")).decode(Map.of("v", 1L)), "負の数で");
+        assertErrMessage(field("v", long_().nonNegative("0以上で")).decode(Map.of("v", -1L)), "0以上で");
+        assertErrMessage(field("v", long_().nonPositive("0以下で")).decode(Map.of("v", 1L)), "0以下で");
+        assertErrMessage(field("v", long_().multipleOf(3L, "3の倍数で")).decode(Map.of("v", 4L)), "3の倍数で");
+    }
+
+    @Test
+    void nullMessageFallsBackToDefault() {
+        // Passing null (or using the no-message overload) yields the built-in default message.
+        assertErrMessage(field("v", decimal().positive(null)).decode(Map.of("v", -1)), "must be positive");
+        assertErrMessage(field("v", int_().multipleOf(3)).decode(Map.of("v", 4)), "must be a multiple of 3");
+        assertErrMessage(field("v", decimal().range(new BigDecimal("0"), new BigDecimal("10")))
+                .decode(Map.of("v", 20)), "must be between 0 and 10");
+    }
+
+    @Test
     void nestedObject() {
         var dec = combine(
                 field("name", string()),
@@ -1055,6 +1116,14 @@ class MapDecoderTest {
     static void assertErr(Result<?> result) {
         if (result instanceof Ok<?>) {
             fail("Expected Err, got Ok: " + result);
+        }
+    }
+
+    /** Asserts the result is an Err whose first issue carries the given pre-resolved message. */
+    static void assertErrMessage(Result<?> result, String expectedMessage) {
+        switch (result) {
+            case Ok(_) -> fail("Expected Err, got Ok: " + result);
+            case Err(var issues) -> assertEquals(expectedMessage, issues.asList().getFirst().message());
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #54. Two related gaps in the numeric decoders, closed symmetrically:

1. **`DecimalDecoder` lagged its integer siblings** — no `range()`, and no custom-message overloads at all (`IntDecoder`/`LongDecoder` had them on `min`/`max`/`range` since the initial commit).
2. **The integer decoders only had message overloads on `min`/`max`/`range`** — not on `positive`/`negative`/`nonNegative`/`nonPositive`/`multipleOf`.

### Changes

- **`DecimalDecoder`**: add `range(min, max)` + `range(min, max, message)`, and a `@Nullable String message` overload on every constraint (`min`, `max`, `positive`, `negative`, `nonNegative`, `nonPositive`, `multipleOf`, `scale`).
- **`IntDecoder` / `LongDecoder`**: add the missing message overloads on `positive`, `negative`, `nonNegative`, `nonPositive`, `multipleOf`, so all three decoders expose the same message-overload surface.

All overloads follow the established `min`/`max` pattern: a non-null message is stored via `Result.failCustom` as the pre-resolved `Issue.message()`; `null` falls back to the built-in default via `Result.fail`. **No new error codes**, so `messages.properties` / `MessageResolver.DEFAULT` are unchanged.

### Scope decision (discussed on the issue)

The issue's AC over-reached: it said to add message overloads "mirroring the integer decoders", but the integer decoders lacked overloads on the non-range constraints. Rather than create a reverse asymmetry, this PR brings **all three** decoders up to the same surface.

`oneOf` is **intentionally left off `DecimalDecoder`**: `BigDecimal` equality is scale-sensitive (`2.0 != 2.00`), and there's no identified use case for an allow-list of decimals.

## Tests

Added to `MapDecoderTest` (90 → 95):
- `decimalRange` — inclusive bounds, below/above rejection.
- `decimalConstraintCustomMessages` / `intConstraintCustomMessages` / `longConstraintCustomMessages` — custom message stored as `Issue.message()` across each constraint.
- `nullMessageFallsBackToDefault` — the `null` / no-message path yields the built-in default.

## Verification

- `mvn test` (all modules) → BUILD SUCCESS.
- `mvn -Pnullcheck compile` (NullAway gate) → BUILD SUCCESS.
- `mvn javadoc:javadoc` → BUILD SUCCESS, no warnings (no `-Xdoclint:none`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)