### PR TITLE
fix(decode): reject zero divisor and inverted range at construction (#66)

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -95,6 +95,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @param min the minimum allowed value (inclusive)
      * @param max the maximum allowed value (inclusive)
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public DecimalDecoder<I> range(BigDecimal min, BigDecimal max) {
         return range(min, max, null);
@@ -107,8 +108,12 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @param max     the maximum allowed value (inclusive)
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public DecimalDecoder<I> range(BigDecimal min, BigDecimal max, @Nullable String message) {
+        if (min.compareTo(max) > 0) {
+            throw new IllegalArgumentException("min (%s) must not be greater than max (%s)".formatted(min, max));
+        }
         return chain((value, path) -> {
             if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
@@ -224,6 +229,7 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      *
      * @param n the required divisor
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not a multiple
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public DecimalDecoder<I> multipleOf(BigDecimal n) {
         return multipleOf(n, null);
@@ -235,8 +241,12 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
      * @param n       the required divisor
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not a multiple
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public DecimalDecoder<I> multipleOf(BigDecimal n, @Nullable String message) {
+        if (n.signum() == 0) {
+            throw new IllegalArgumentException("divisor must not be zero");
+        }
         return chain((value, path) -> {
             if (value.remainder(n).compareTo(BigDecimal.ZERO) != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
@@ -102,6 +102,7 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
      * @param min the minimum allowed value (inclusive)
      * @param max the maximum allowed value (inclusive)
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public DoubleDecoder<I> range(double min, double max) {
         return range(min, max, null);
@@ -114,8 +115,12 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
      * @param max     the maximum allowed value (inclusive)
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public DoubleDecoder<I> range(double min, double max, @Nullable String message) {
+        if (Double.compare(min, max) > 0) {
+            throw new IllegalArgumentException("min (%s) must not be greater than max (%s)".formatted(min, max));
+        }
         return chain((value, path) -> {
             if (Double.compare(value, min) < 0 || Double.compare(value, max) > 0) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
@@ -102,6 +102,7 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
      * @param min the minimum allowed value (inclusive)
      * @param max the maximum allowed value (inclusive)
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public FloatDecoder<I> range(float min, float max) {
         return range(min, max, null);
@@ -114,8 +115,12 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
      * @param max     the maximum allowed value (inclusive)
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public FloatDecoder<I> range(float min, float max, @Nullable String message) {
+        if (Float.compare(min, max) > 0) {
+            throw new IllegalArgumentException("min (%s) must not be greater than max (%s)".formatted(min, max));
+        }
         return chain((value, path) -> {
             if (Float.compare(value, min) < 0 || Float.compare(value, max) > 0) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -97,6 +97,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @param min the minimum allowed value (inclusive)
      * @param max the maximum allowed value (inclusive)
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public IntDecoder<I> range(int min, int max) {
         return range(min, max, null);
@@ -109,8 +110,12 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @param max     the maximum allowed value (inclusive)
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public IntDecoder<I> range(int min, int max, @Nullable String message) {
+        if (min > max) {
+            throw new IllegalArgumentException("min (%d) must not be greater than max (%d)".formatted(min, max));
+        }
         return chain((value, path) -> {
             if (value < min || value > max) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
@@ -245,6 +250,7 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      *
      * @param n the divisor
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public IntDecoder<I> multipleOf(int n) {
         return multipleOf(n, null);
@@ -256,8 +262,12 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
      * @param n       the divisor
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public IntDecoder<I> multipleOf(int n, @Nullable String message) {
+        if (n == 0) {
+            throw new IllegalArgumentException("divisor must not be zero");
+        }
         return chain((value, path) -> {
             if (value % n != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -97,6 +97,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @param min the minimum allowed value (inclusive)
      * @param max the maximum allowed value (inclusive)
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public LongDecoder<I> range(long min, long max) {
         return range(min, max, null);
@@ -109,8 +110,12 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @param max     the maximum allowed value (inclusive)
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#OUT_OF_RANGE} if outside
+     * @throws IllegalArgumentException if {@code min} is greater than {@code max}
      */
     public LongDecoder<I> range(long min, long max, @Nullable String message) {
+        if (min > max) {
+            throw new IllegalArgumentException("min (%d) must not be greater than max (%d)".formatted(min, max));
+        }
         return chain((value, path) -> {
             if (value < min || value > max) {
                 var meta = Map.<String, Object>of("min", min, "max", max, "actual", value);
@@ -245,6 +250,7 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      *
      * @param n the divisor
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public LongDecoder<I> multipleOf(long n) {
         return multipleOf(n, null);
@@ -256,8 +262,12 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
      * @param n       the divisor
      * @param message custom error message, or {@code null} for the default
      * @return a new decoder that fails with {@link ErrorCodes#NOT_MULTIPLE_OF} if not divisible
+     * @throws IllegalArgumentException if {@code n} is zero
      */
     public LongDecoder<I> multipleOf(long n, @Nullable String message) {
+        if (n == 0) {
+            throw new IllegalArgumentException("divisor must not be zero");
+        }
         return chain((value, path) -> {
             if (value % n != 0) {
                 var meta = Map.<String, Object>of("divisor", n, "actual", value);

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -596,6 +596,26 @@ class MapDecoderTest {
     }
 
     @Test
+    void multipleOfZeroThrowsAtConstruction() {
+        // A zero divisor is a schema-author error, rejected fast at construction rather than
+        // throwing ArithmeticException mid-decode (see #66).
+        assertThrows(IllegalArgumentException.class, () -> int_().multipleOf(0));
+        assertThrows(IllegalArgumentException.class, () -> long_().multipleOf(0L));
+        assertThrows(IllegalArgumentException.class, () -> decimal().multipleOf(BigDecimal.ZERO));
+        // A scale-zero but non-zero divisor (e.g. 0.00) must also be rejected.
+        assertThrows(IllegalArgumentException.class, () -> decimal().multipleOf(new BigDecimal("0.00")));
+    }
+
+    @Test
+    void rangeMinGreaterThanMaxThrowsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> int_().range(10, 0));
+        assertThrows(IllegalArgumentException.class, () -> long_().range(10L, 0L));
+        assertThrows(IllegalArgumentException.class, () -> decimal().range(new BigDecimal("10"), new BigDecimal("0")));
+        // Equal bounds are a valid (single-value) range, not an error.
+        assertEquals(5, assertOk(field("v", int_().range(5, 5)).decode(Map.of("v", 5))));
+    }
+
+    @Test
     void nestedObject() {
         var dec = combine(
                 field("name", string()),

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -611,8 +611,11 @@ class MapDecoderTest {
         assertThrows(IllegalArgumentException.class, () -> int_().range(10, 0));
         assertThrows(IllegalArgumentException.class, () -> long_().range(10L, 0L));
         assertThrows(IllegalArgumentException.class, () -> decimal().range(new BigDecimal("10"), new BigDecimal("0")));
+        assertThrows(IllegalArgumentException.class, () -> double_().range(10.0, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> float_().range(10f, 0f));
         // Equal bounds are a valid (single-value) range, not an error.
         assertEquals(5, assertOk(field("v", int_().range(5, 5)).decode(Map.of("v", 5))));
+        assertEquals(1.0, assertOk(field("v", double_().range(1.0, 1.0)).decode(Map.of("v", 1.0))));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #66. Two construction-time validation gaps in the numeric decoders, both surfaced during the #54 review.

### `multipleOf(0)` — the #66 bug

`multipleOf` had no zero-divisor guard, so `multipleOf(0)` threw an unchecked `ArithmeticException` **mid-decode** (`value % 0` for int/long, `BigDecimal.remainder(ZERO)` for decimal). Because `Result.flatMap` does not wrap exceptions (`case Ok -> f.apply(...)`), it escaped the `Result` error channel entirely.

Reproduced before the fix:

```
int   multipleOf(0):   THREW ArithmeticException: / by zero
decimal multipleOf(0): THREW ArithmeticException: Division by zero
```

A zero divisor is a **schema-author error, not a data error**, so it is now rejected fast at construction with `IllegalArgumentException` — consistent with the existing precedent `TemporalDecoder.between` (throws on `from > to`) and `ListDecoder` (throws on empty elements). After the fix the same calls throw `IllegalArgumentException: divisor must not be zero` at wiring time, before any decode.

### `range(min, max)` inverted bounds — adjacent gap

`range(min, max)` never validated its bounds, so an inverted range like `range(10, 0)` silently rejected **every** value with no indication of the misconfiguration. It now throws `IllegalArgumentException` at construction too, matching `TemporalDecoder.between`. Equal bounds (`range(5, 5)`) remain a valid single-value range.

### Scope

Both guards apply to `IntDecoder`, `LongDecoder`, and `DecimalDecoder`. The Decimal zero-divisor check uses `signum()`, so a scale-zero divisor like `0.00` is also rejected. `@throws IllegalArgumentException` is documented on both overloads of each affected method.

## Tests

Added to `MapDecoderTest`:
- `multipleOfZeroThrowsAtConstruction` — int / long / decimal, plus the `0.00` scale-zero case.
- `rangeMinGreaterThanMaxThrowsAtConstruction` — int / long / decimal, plus a `range(5, 5)` equal-bounds sanity check.

## Verification

- `mvn test` (all modules) → BUILD SUCCESS (MapDecoderTest 96 → 98).
- `mvn -Pnullcheck compile` (NullAway gate) → BUILD SUCCESS.
- `mvn javadoc:javadoc` → BUILD SUCCESS, no warnings.
- End-to-end repro confirms `IllegalArgumentException` at construction replaces the mid-decode `ArithmeticException`.

Closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)