### PR TITLE
test(decode): add direct unit tests for builtin decoders (#55)

### DIFF
--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/BoolDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/BoolDecoderTest.java
@@ -1,0 +1,70 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.ObjectDecoders.bool;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link BoolDecoder}, covering the {@code isTrue()} and
+ * {@code isFalse()} value constraints and their {@link ErrorCodes#INVALID_VALUE} failures.
+ */
+class BoolDecoderTest {
+
+    // --- isTrue ---
+
+    @Test
+    void isTrueAcceptsTrue() {
+        assertTrue(decodeOk(bool().isTrue(), true));
+    }
+
+    @Test
+    void isTrueRejectsFalse() {
+        var issue = decodeErr(bool().isTrue(), false);
+        assertEquals(ErrorCodes.INVALID_VALUE, issue.code());
+        assertEquals("must be true", issue.message());
+        assertEquals(true, issue.meta().get("expected"));
+        assertEquals(false, issue.meta().get("actual"));
+    }
+
+    @Test
+    void isTrueUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(bool().isTrue("you must accept the terms"), false);
+        assertEquals(ErrorCodes.INVALID_VALUE, issue.code());
+        assertEquals("you must accept the terms", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- isFalse ---
+
+    @Test
+    void isFalseAcceptsFalse() {
+        assertFalse(decodeOk(bool().isFalse(), false));
+    }
+
+    @Test
+    void isFalseRejectsTrue() {
+        var issue = decodeErr(bool().isFalse(), true);
+        assertEquals(ErrorCodes.INVALID_VALUE, issue.code());
+        assertEquals("must be false", issue.message());
+        assertEquals(false, issue.meta().get("expected"));
+        assertEquals(true, issue.meta().get("actual"));
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(bool(), null).code());
+    }
+
+    @Test
+    void rejectsNonBooleanAsTypeMismatch() {
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(bool(), "true").code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/BuiltinTestSupport.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/BuiltinTestSupport.java
@@ -1,0 +1,52 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.Err;
+import net.unit8.raoh.Issue;
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Path;
+import net.unit8.raoh.Result;
+import net.unit8.raoh.decode.Decoder;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Test-only helpers for exercising builtin decoders directly at the root path,
+ * independent of the {@code Map}/JSON boundary.
+ */
+final class BuiltinTestSupport {
+
+    private BuiltinTestSupport() {}
+
+    /**
+     * Decodes {@code input} at {@link Path#ROOT} and returns the decoded value,
+     * throwing an {@link AssertionError} if the decoder failed.
+     *
+     * @param <T>     the decoded value type
+     * @param decoder the decoder under test
+     * @param input   the raw input value
+     * @return the successfully decoded value
+     */
+    static <T extends @Nullable Object> T decodeOk(Decoder<@Nullable Object, T> decoder, @Nullable Object input) {
+        Result<T> result = decoder.decode(input, Path.ROOT);
+        if (result instanceof Ok<T> ok) {
+            return ok.value();
+        }
+        throw new AssertionError("expected Ok but got: " + result);
+    }
+
+    /**
+     * Decodes {@code input} at {@link Path#ROOT} and returns the first {@link Issue},
+     * throwing an {@link AssertionError} if the decoder succeeded.
+     *
+     * @param decoder the decoder under test
+     * @param input   the raw input value
+     * @return the first issue reported by the decoder
+     */
+    static Issue decodeErr(Decoder<@Nullable Object, ?> decoder, @Nullable Object input) {
+        Result<?> result = decoder.decode(input, Path.ROOT);
+        if (result instanceof Err<?> err) {
+            return err.issues().asList().getFirst();
+        }
+        throw new AssertionError("expected Err but got: " + result);
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/DecimalDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/DecimalDecoderTest.java
@@ -1,0 +1,138 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static net.unit8.raoh.decode.ObjectDecoders.decimal;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link DecimalDecoder}, covering the {@link BigDecimal}
+ * numeric constraints plus the decimal-specific {@code scale()} constraint.
+ */
+class DecimalDecoderTest {
+
+    private static BigDecimal bd(String s) {
+        return new BigDecimal(s);
+    }
+
+    // --- min / max ---
+
+    @Test
+    void minAcceptsBoundaryValue() {
+        assertEquals(bd("1.5"), decodeOk(decimal().min(bd("1.5")), bd("1.5")));
+    }
+
+    @Test
+    void minRejectsBelowBoundary() {
+        var issue = decodeErr(decimal().min(bd("1.5")), bd("1.4"));
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at least 1.5", issue.message());
+        assertEquals(bd("1.5"), issue.meta().get("min"));
+    }
+
+    @Test
+    void maxRejectsAboveBoundary() {
+        var issue = decodeErr(decimal().max(bd("1.5")), bd("1.6"));
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at most 1.5", issue.message());
+    }
+
+    @Test
+    void minUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(decimal().min(bd("1.5"), "too small"), bd("1.0"));
+        assertEquals("too small", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- range ---
+
+    @Test
+    void rangeAcceptsBothBoundaries() {
+        assertEquals(bd("1"), decodeOk(decimal().range(bd("1"), bd("10")), bd("1")));
+        assertEquals(bd("10"), decodeOk(decimal().range(bd("1"), bd("10")), bd("10")));
+    }
+
+    @Test
+    void rangeRejectsOutside() {
+        var issue = decodeErr(decimal().range(bd("1"), bd("10")), bd("11"));
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be between 1 and 10", issue.message());
+    }
+
+    @Test
+    void rangeRejectsInvertedBoundsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> decimal().range(bd("10"), bd("1")));
+    }
+
+    // --- sign constraints ---
+
+    @Test
+    void positiveAcceptsPositiveRejectsZero() {
+        assertEquals(bd("0.1"), decodeOk(decimal().positive(), bd("0.1")));
+        assertEquals("must be positive", decodeErr(decimal().positive(), bd("0")).message());
+    }
+
+    @Test
+    void negativeAcceptsNegativeRejectsZero() {
+        assertEquals(bd("-0.1"), decodeOk(decimal().negative(), bd("-0.1")));
+        assertEquals("must be negative", decodeErr(decimal().negative(), bd("0")).message());
+    }
+
+    @Test
+    void nonNegativeAcceptsZeroRejectsNegative() {
+        assertEquals(bd("0"), decodeOk(decimal().nonNegative(), bd("0")));
+        assertEquals("must be non-negative", decodeErr(decimal().nonNegative(), bd("-0.1")).message());
+    }
+
+    @Test
+    void nonPositiveAcceptsZeroRejectsPositive() {
+        assertEquals(bd("0"), decodeOk(decimal().nonPositive(), bd("0")));
+        assertEquals("must be non-positive", decodeErr(decimal().nonPositive(), bd("0.1")).message());
+    }
+
+    // --- multipleOf ---
+
+    @Test
+    void multipleOfAcceptsMultipleRejectsNonMultiple() {
+        assertEquals(bd("1.5"), decodeOk(decimal().multipleOf(bd("0.5")), bd("1.5")));
+        var issue = decodeErr(decimal().multipleOf(bd("0.5")), bd("1.7"));
+        assertEquals(ErrorCodes.NOT_MULTIPLE_OF, issue.code());
+        assertEquals("must be a multiple of 0.5", issue.message());
+        assertEquals(bd("0.5"), issue.meta().get("divisor"));
+    }
+
+    @Test
+    void multipleOfRejectsZeroDivisorAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> decimal().multipleOf(BigDecimal.ZERO));
+    }
+
+    // --- scale ---
+
+    @Test
+    void scaleAcceptsWithinLimit() {
+        assertEquals(bd("1.23"), decodeOk(decimal().scale(2), bd("1.23")));
+    }
+
+    @Test
+    void scaleRejectsTooManyFractionalDigits() {
+        var issue = decodeErr(decimal().scale(2), bd("1.234"));
+        assertEquals(ErrorCodes.INVALID_SCALE, issue.code());
+        assertEquals("too many decimal places (max 2)", issue.message());
+        assertEquals(2, issue.meta().get("maxScale"));
+        assertEquals(3, issue.meta().get("actualScale"));
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(decimal(), null).code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
@@ -1,0 +1,117 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.ObjectDecoders.double_;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link DoubleDecoder}. Comparisons use
+ * {@link Double#compare(double, double)}, so {@code NaN} is treated as greater than
+ * every other value; the range test guards that behaviour.
+ */
+class DoubleDecoderTest {
+
+    // --- min / max ---
+
+    @Test
+    void minAcceptsBoundaryValue() {
+        assertEquals(1.5, decodeOk(double_().min(1.5), 1.5));
+    }
+
+    @Test
+    void minRejectsBelowBoundary() {
+        var issue = decodeErr(double_().min(1.5), 1.4);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at least 1.5", issue.message());
+        assertEquals(1.5, issue.meta().get("min"));
+    }
+
+    @Test
+    void maxRejectsAboveBoundary() {
+        var issue = decodeErr(double_().max(1.5), 1.6);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at most 1.5", issue.message());
+    }
+
+    @Test
+    void minUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(double_().min(1.5, "too small"), 1.0);
+        assertEquals("too small", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- range ---
+
+    @Test
+    void rangeAcceptsBothBoundaries() {
+        assertEquals(1.0, decodeOk(double_().range(1.0, 10.0), 1.0));
+        assertEquals(10.0, decodeOk(double_().range(1.0, 10.0), 10.0));
+    }
+
+    @Test
+    void rangeRejectsOutside() {
+        var issue = decodeErr(double_().range(1.0, 10.0), 10.5);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be between 1.0 and 10.0", issue.message());
+    }
+
+    @Test
+    void rangeRejectsNaN() {
+        var issue = decodeErr(double_().range(0.0, 10.0), Double.NaN);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+    }
+
+    @Test
+    void rangeRejectsInvertedBoundsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> double_().range(10.0, 1.0));
+    }
+
+    // --- sign constraints ---
+
+    @Test
+    void positiveAcceptsPositiveRejectsZero() {
+        assertEquals(0.1, decodeOk(double_().positive(), 0.1));
+        assertEquals("must be positive", decodeErr(double_().positive(), 0.0).message());
+    }
+
+    @Test
+    void negativeAcceptsNegativeRejectsZero() {
+        assertEquals(-0.1, decodeOk(double_().negative(), -0.1));
+        assertEquals("must be negative", decodeErr(double_().negative(), 0.0).message());
+    }
+
+    @Test
+    void nonNegativeAcceptsZeroRejectsNegative() {
+        assertEquals(0.0, decodeOk(double_().nonNegative(), 0.0));
+        assertEquals("must be non-negative", decodeErr(double_().nonNegative(), -0.1).message());
+    }
+
+    @Test
+    void nonPositiveAcceptsZeroRejectsPositive() {
+        assertEquals(0.0, decodeOk(double_().nonPositive(), 0.0));
+        assertEquals("must be non-positive", decodeErr(double_().nonPositive(), 0.1).message());
+    }
+
+    // --- oneOf ---
+
+    @Test
+    void oneOfAcceptsMemberRejectsNonMember() {
+        assertEquals(2.0, decodeOk(double_().oneOf(1.0, 2.0, 3.0), 2.0));
+        var issue = decodeErr(double_().oneOf(3.0, 1.0, 2.0), 4.0);
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("must be one of [1.0, 2.0, 3.0]", issue.message());
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(double_(), null).code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
@@ -11,9 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Direct unit tests for {@link DoubleDecoder}. Comparisons use
+ * Direct unit tests for {@link DoubleDecoder}. The decoder's range checks use
  * {@link Double#compare(double, double)}, so {@code NaN} is treated as greater than
- * every other value; the range test guards that behaviour.
+ * every other value; the {@code rangeRejectsNaN} test guards that behaviour.
  */
 class DoubleDecoderTest {
 

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
@@ -1,0 +1,116 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.ObjectDecoders.float_;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link FloatDecoder}, mirroring {@link DoubleDecoderTest} for the
+ * {@code float} type. Comparisons use {@link Float#compare(float, float)}.
+ */
+class FloatDecoderTest {
+
+    // --- min / max ---
+
+    @Test
+    void minAcceptsBoundaryValue() {
+        assertEquals(1.5f, decodeOk(float_().min(1.5f), 1.5f));
+    }
+
+    @Test
+    void minRejectsBelowBoundary() {
+        var issue = decodeErr(float_().min(1.5f), 1.4f);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at least 1.5", issue.message());
+        assertEquals(1.5f, issue.meta().get("min"));
+    }
+
+    @Test
+    void maxRejectsAboveBoundary() {
+        var issue = decodeErr(float_().max(1.5f), 1.6f);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at most 1.5", issue.message());
+    }
+
+    @Test
+    void minUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(float_().min(1.5f, "too small"), 1.0f);
+        assertEquals("too small", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- range ---
+
+    @Test
+    void rangeAcceptsBothBoundaries() {
+        assertEquals(1.0f, decodeOk(float_().range(1.0f, 10.0f), 1.0f));
+        assertEquals(10.0f, decodeOk(float_().range(1.0f, 10.0f), 10.0f));
+    }
+
+    @Test
+    void rangeRejectsOutside() {
+        var issue = decodeErr(float_().range(1.0f, 10.0f), 10.5f);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be between 1.0 and 10.0", issue.message());
+    }
+
+    @Test
+    void rangeRejectsNaN() {
+        var issue = decodeErr(float_().range(0.0f, 10.0f), Float.NaN);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+    }
+
+    @Test
+    void rangeRejectsInvertedBoundsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> float_().range(10.0f, 1.0f));
+    }
+
+    // --- sign constraints ---
+
+    @Test
+    void positiveAcceptsPositiveRejectsZero() {
+        assertEquals(0.1f, decodeOk(float_().positive(), 0.1f));
+        assertEquals("must be positive", decodeErr(float_().positive(), 0.0f).message());
+    }
+
+    @Test
+    void negativeAcceptsNegativeRejectsZero() {
+        assertEquals(-0.1f, decodeOk(float_().negative(), -0.1f));
+        assertEquals("must be negative", decodeErr(float_().negative(), 0.0f).message());
+    }
+
+    @Test
+    void nonNegativeAcceptsZeroRejectsNegative() {
+        assertEquals(0.0f, decodeOk(float_().nonNegative(), 0.0f));
+        assertEquals("must be non-negative", decodeErr(float_().nonNegative(), -0.1f).message());
+    }
+
+    @Test
+    void nonPositiveAcceptsZeroRejectsPositive() {
+        assertEquals(0.0f, decodeOk(float_().nonPositive(), 0.0f));
+        assertEquals("must be non-positive", decodeErr(float_().nonPositive(), 0.1f).message());
+    }
+
+    // --- oneOf ---
+
+    @Test
+    void oneOfAcceptsMemberRejectsNonMember() {
+        assertEquals(2.0f, decodeOk(float_().oneOf(1.0f, 2.0f, 3.0f), 2.0f));
+        var issue = decodeErr(float_().oneOf(3.0f, 1.0f, 2.0f), 4.0f);
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("must be one of [1.0, 2.0, 3.0]", issue.message());
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(float_(), null).code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Direct unit tests for {@link FloatDecoder}, mirroring {@link DoubleDecoderTest} for the
- * {@code float} type. Comparisons use {@link Float#compare(float, float)}.
+ * {@code float} type. The decoder's range checks use {@link Float#compare(float, float)}.
  */
 class FloatDecoderTest {
 

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/IntDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/IntDecoderTest.java
@@ -1,0 +1,163 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.ObjectDecoders.int_;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link IntDecoder}, exercising each numeric constraint's
+ * success and failure paths independent of the {@code Map} boundary. Failure paths
+ * assert both the {@link ErrorCodes} value and the self-contained fallback message.
+ */
+class IntDecoderTest {
+
+    // --- min ---
+
+    @Test
+    void minAcceptsBoundaryValue() {
+        assertEquals(5, decodeOk(int_().min(5), 5));
+    }
+
+    @Test
+    void minRejectsBelowBoundary() {
+        var issue = decodeErr(int_().min(5), 4);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at least 5", issue.message());
+        assertEquals(5, issue.meta().get("min"));
+        assertEquals(4, issue.meta().get("actual"));
+    }
+
+    @Test
+    void minUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(int_().min(5, "too small"), 4);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("too small", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- max ---
+
+    @Test
+    void maxAcceptsBoundaryValue() {
+        assertEquals(5, decodeOk(int_().max(5), 5));
+    }
+
+    @Test
+    void maxRejectsAboveBoundary() {
+        var issue = decodeErr(int_().max(5), 6);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at most 5", issue.message());
+        assertEquals(5, issue.meta().get("max"));
+    }
+
+    // --- range ---
+
+    @Test
+    void rangeAcceptsBothBoundaries() {
+        assertEquals(1, decodeOk(int_().range(1, 10), 1));
+        assertEquals(10, decodeOk(int_().range(1, 10), 10));
+    }
+
+    @Test
+    void rangeRejectsBelowAndAbove() {
+        var below = decodeErr(int_().range(1, 10), 0);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, below.code());
+        assertEquals("must be between 1 and 10", below.message());
+        assertEquals(1, below.meta().get("min"));
+        assertEquals(10, below.meta().get("max"));
+
+        var above = decodeErr(int_().range(1, 10), 11);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, above.code());
+    }
+
+    @Test
+    void rangeRejectsInvertedBoundsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> int_().range(10, 1));
+    }
+
+    // --- sign constraints ---
+
+    @Test
+    void positiveAcceptsOneRejectsZero() {
+        assertEquals(1, decodeOk(int_().positive(), 1));
+        var issue = decodeErr(int_().positive(), 0);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be positive", issue.message());
+    }
+
+    @Test
+    void negativeAcceptsMinusOneRejectsZero() {
+        assertEquals(-1, decodeOk(int_().negative(), -1));
+        var issue = decodeErr(int_().negative(), 0);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be negative", issue.message());
+    }
+
+    @Test
+    void nonNegativeAcceptsZeroRejectsMinusOne() {
+        assertEquals(0, decodeOk(int_().nonNegative(), 0));
+        var issue = decodeErr(int_().nonNegative(), -1);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be non-negative", issue.message());
+    }
+
+    @Test
+    void nonPositiveAcceptsZeroRejectsOne() {
+        assertEquals(0, decodeOk(int_().nonPositive(), 0));
+        var issue = decodeErr(int_().nonPositive(), 1);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be non-positive", issue.message());
+    }
+
+    // --- oneOf ---
+
+    @Test
+    void oneOfAcceptsMemberOfSet() {
+        assertEquals(2, decodeOk(int_().oneOf(1, 2, 3), 2));
+    }
+
+    @Test
+    void oneOfRejectsNonMemberWithSortedAllowedList() {
+        var issue = decodeErr(int_().oneOf(3, 1, 2), 4);
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("must be one of [1, 2, 3]", issue.message());
+    }
+
+    // --- multipleOf ---
+
+    @Test
+    void multipleOfAcceptsMultiple() {
+        assertEquals(15, decodeOk(int_().multipleOf(5), 15));
+    }
+
+    @Test
+    void multipleOfRejectsNonMultiple() {
+        var issue = decodeErr(int_().multipleOf(5), 14);
+        assertEquals(ErrorCodes.NOT_MULTIPLE_OF, issue.code());
+        assertEquals("must be a multiple of 5", issue.message());
+        assertEquals(5, issue.meta().get("divisor"));
+    }
+
+    @Test
+    void multipleOfRejectsZeroDivisorAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> int_().multipleOf(0));
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(int_(), null).code());
+    }
+
+    @Test
+    void rejectsNonNumericAsTypeMismatch() {
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(int_(), "42").code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
@@ -1,0 +1,117 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static net.unit8.raoh.decode.ObjectDecoders.int_;
+import static net.unit8.raoh.decode.ObjectDecoders.list;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Direct unit tests for {@link ListDecoder}, covering the size, content, and uniqueness
+ * constraints plus the {@code toSet()} conversion. The element decoder is a plain
+ * {@code int_()} so the tests focus on list-level behaviour.
+ */
+class ListDecoderTest {
+
+    // --- size constraints ---
+
+    @Test
+    void nonemptyAcceptsNonEmptyRejectsEmpty() {
+        assertEquals(List.of(1), decodeOk(list(int_()).nonempty(), List.of(1)));
+        var issue = decodeErr(list(int_()).nonempty(), List.of());
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("must not be empty", issue.message());
+    }
+
+    @Test
+    void minSizeAcceptsBoundaryRejectsBelow() {
+        assertEquals(List.of(1, 2), decodeOk(list(int_()).minSize(2), List.of(1, 2)));
+        var issue = decodeErr(list(int_()).minSize(2), List.of(1));
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("must have at least 2 elements", issue.message());
+        assertEquals(2, issue.meta().get("min"));
+        assertEquals(1, issue.meta().get("actual"));
+    }
+
+    @Test
+    void maxSizeAcceptsBoundaryRejectsAbove() {
+        assertEquals(List.of(1, 2), decodeOk(list(int_()).maxSize(2), List.of(1, 2)));
+        var issue = decodeErr(list(int_()).maxSize(2), List.of(1, 2, 3));
+        assertEquals(ErrorCodes.TOO_BIG, issue.code());
+        assertEquals("must have at most 2 elements", issue.message());
+    }
+
+    @Test
+    void fixedSizeAcceptsExactRejectsDifferent() {
+        assertEquals(List.of(1, 2), decodeOk(list(int_()).fixedSize(2), List.of(1, 2)));
+        var issue = decodeErr(list(int_()).fixedSize(2), List.of(1, 2, 3));
+        assertEquals(ErrorCodes.INVALID_SIZE, issue.code());
+        assertEquals("must have exactly 2 elements", issue.message());
+    }
+
+    // --- content constraints ---
+
+    @Test
+    void containsAcceptsPresentRejectsAbsent() {
+        assertEquals(List.of(1, 2, 3), decodeOk(list(int_()).contains(2), List.of(1, 2, 3)));
+        var issue = decodeErr(list(int_()).contains(2), List.of(1, 3));
+        assertEquals(ErrorCodes.MISSING_ELEMENT, issue.code());
+        assertEquals("must contain 2", issue.message());
+        assertEquals(2, issue.meta().get("expected"));
+    }
+
+    @Test
+    void containsRejectsNullElementAtConstruction() {
+        assertThrows(NullPointerException.class, () -> list(int_()).contains(null));
+    }
+
+    @Test
+    void containsAllAcceptsAllPresentRejectsMissing() {
+        assertEquals(List.of(1, 2, 3), decodeOk(list(int_()).containsAll(2, 3), List.of(1, 2, 3)));
+        var issue = decodeErr(list(int_()).containsAll(2, 3), List.of(1, 2));
+        assertEquals(ErrorCodes.MISSING_ELEMENTS, issue.code());
+        assertEquals("must contain all of [2, 3] (missing: [3])", issue.message());
+        assertEquals(List.of(2, 3), issue.meta().get("expected"));
+        assertEquals(List.of(3), issue.meta().get("missing"));
+    }
+
+    @Test
+    void containsAllRejectsEmptyArgsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> list(int_()).containsAll());
+    }
+
+    @Test
+    void uniqueAcceptsDistinctRejectsDuplicates() {
+        assertEquals(List.of(1, 2, 3), decodeOk(list(int_()).unique(), List.of(1, 2, 3)));
+        var issue = decodeErr(list(int_()).unique(), List.of(1, 1, 2));
+        assertEquals(ErrorCodes.DUPLICATE_ELEMENT, issue.code());
+        assertEquals("must not contain duplicates: [1]", issue.message());
+        assertEquals(List.of(1), issue.meta().get("duplicates"));
+    }
+
+    // --- conversion ---
+
+    @Test
+    void toSetDeduplicatesElements() {
+        assertEquals(Set.of(1, 2, 3), decodeOk(list(int_()).toSet(), List.of(1, 2, 2, 3)));
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(list(int_()), null).code());
+    }
+
+    @Test
+    void rejectsNonListAsTypeMismatch() {
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(list(int_()), "not a list").code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/LongDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/LongDecoderTest.java
@@ -1,0 +1,125 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.ObjectDecoders.long_;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link LongDecoder}, mirroring {@link IntDecoderTest} for the
+ * {@code long} type. Failure paths assert both the error code and the fallback message.
+ */
+class LongDecoderTest {
+
+    // --- min / max ---
+
+    @Test
+    void minAcceptsBoundaryValue() {
+        assertEquals(5L, decodeOk(long_().min(5), 5L));
+    }
+
+    @Test
+    void minRejectsBelowBoundary() {
+        var issue = decodeErr(long_().min(5), 4L);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at least 5", issue.message());
+        assertEquals(5L, issue.meta().get("min"));
+    }
+
+    @Test
+    void maxRejectsAboveBoundary() {
+        var issue = decodeErr(long_().max(5), 6L);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be at most 5", issue.message());
+    }
+
+    @Test
+    void minUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(long_().min(5, "too small"), 4L);
+        assertEquals("too small", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- range ---
+
+    @Test
+    void rangeAcceptsBothBoundaries() {
+        assertEquals(1L, decodeOk(long_().range(1, 10), 1L));
+        assertEquals(10L, decodeOk(long_().range(1, 10), 10L));
+    }
+
+    @Test
+    void rangeRejectsOutside() {
+        var issue = decodeErr(long_().range(1, 10), 11L);
+        assertEquals(ErrorCodes.OUT_OF_RANGE, issue.code());
+        assertEquals("must be between 1 and 10", issue.message());
+    }
+
+    @Test
+    void rangeRejectsInvertedBoundsAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> long_().range(10, 1));
+    }
+
+    // --- sign constraints ---
+
+    @Test
+    void positiveAcceptsOneRejectsZero() {
+        assertEquals(1L, decodeOk(long_().positive(), 1L));
+        assertEquals("must be positive", decodeErr(long_().positive(), 0L).message());
+    }
+
+    @Test
+    void negativeAcceptsMinusOneRejectsZero() {
+        assertEquals(-1L, decodeOk(long_().negative(), -1L));
+        assertEquals("must be negative", decodeErr(long_().negative(), 0L).message());
+    }
+
+    @Test
+    void nonNegativeAcceptsZeroRejectsMinusOne() {
+        assertEquals(0L, decodeOk(long_().nonNegative(), 0L));
+        assertEquals("must be non-negative", decodeErr(long_().nonNegative(), -1L).message());
+    }
+
+    @Test
+    void nonPositiveAcceptsZeroRejectsOne() {
+        assertEquals(0L, decodeOk(long_().nonPositive(), 0L));
+        assertEquals("must be non-positive", decodeErr(long_().nonPositive(), 1L).message());
+    }
+
+    // --- oneOf ---
+
+    @Test
+    void oneOfAcceptsMemberRejectsNonMember() {
+        assertEquals(2L, decodeOk(long_().oneOf(1L, 2L, 3L), 2L));
+        var issue = decodeErr(long_().oneOf(3L, 1L, 2L), 4L);
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("must be one of [1, 2, 3]", issue.message());
+    }
+
+    // --- multipleOf ---
+
+    @Test
+    void multipleOfAcceptsMultipleRejectsNonMultiple() {
+        assertEquals(15L, decodeOk(long_().multipleOf(5), 15L));
+        var issue = decodeErr(long_().multipleOf(5), 14L);
+        assertEquals(ErrorCodes.NOT_MULTIPLE_OF, issue.code());
+        assertEquals("must be a multiple of 5", issue.message());
+    }
+
+    @Test
+    void multipleOfRejectsZeroDivisorAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> long_().multipleOf(0));
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(long_(), null).code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/RecordDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/RecordDecoderTest.java
@@ -1,0 +1,65 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static net.unit8.raoh.decode.ObjectDecoders.int_;
+import static net.unit8.raoh.decode.ObjectDecoders.map;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Direct unit tests for {@link RecordDecoder}, covering the entry-count constraints.
+ * The value decoder is a plain {@code int_()} so the tests focus on record-level behaviour.
+ */
+class RecordDecoderTest {
+
+    @Test
+    void nonemptyAcceptsNonEmptyRejectsEmpty() {
+        assertEquals(Map.of("a", 1), decodeOk(map(int_()).nonempty(), Map.of("a", 1)));
+        var issue = decodeErr(map(int_()).nonempty(), Map.of());
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("must not be empty", issue.message());
+    }
+
+    @Test
+    void minSizeAcceptsBoundaryRejectsBelow() {
+        assertEquals(Map.of("a", 1, "b", 2), decodeOk(map(int_()).minSize(2), Map.of("a", 1, "b", 2)));
+        var issue = decodeErr(map(int_()).minSize(2), Map.of("a", 1));
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("must have at least 2 entries", issue.message());
+        assertEquals(2, issue.meta().get("min"));
+        assertEquals(1, issue.meta().get("actual"));
+    }
+
+    @Test
+    void maxSizeAcceptsBoundaryRejectsAbove() {
+        assertEquals(Map.of("a", 1, "b", 2), decodeOk(map(int_()).maxSize(2), Map.of("a", 1, "b", 2)));
+        var issue = decodeErr(map(int_()).maxSize(2), Map.of("a", 1, "b", 2, "c", 3));
+        assertEquals(ErrorCodes.TOO_BIG, issue.code());
+        assertEquals("must have at most 2 entries", issue.message());
+    }
+
+    @Test
+    void fixedSizeAcceptsExactRejectsDifferent() {
+        assertEquals(Map.of("a", 1, "b", 2), decodeOk(map(int_()).fixedSize(2), Map.of("a", 1, "b", 2)));
+        var issue = decodeErr(map(int_()).fixedSize(2), Map.of("a", 1, "b", 2, "c", 3));
+        assertEquals(ErrorCodes.INVALID_SIZE, issue.code());
+        assertEquals("must have exactly 2 entries", issue.message());
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(map(int_()), null).code());
+    }
+
+    @Test
+    void rejectsNonMapAsTypeMismatch() {
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(map(int_()), "not a map").code());
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -156,9 +156,44 @@ class StringDecoderTest {
     }
 
     @Test
+    void emailRejectsTooLongValue() {
+        // Matches the email pattern but exceeds the 254-character maximum, so only the
+        // length guard rejects it — exercising that branch independently of the pattern.
+        var tooLong = "a".repeat(64) + "@" + "b".repeat(250) + ".co";
+        var issue = decodeErr(string().email(), tooLong);
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid email", issue.message());
+    }
+
+    @Test
     void urlAcceptsHttpsRejectsNonHttpScheme() {
         assertEquals(URI.create("https://example.com"), decodeOk(string().url(), "https://example.com"));
         var issue = decodeErr(string().url(), "ftp://example.com");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URL", issue.message());
+    }
+
+    @Test
+    void urlRejectsTooLongValue() {
+        // Exceeds the 2048-character maximum, exercising the length guard branch of url().
+        var tooLong = "https://example.com/" + "a".repeat(2048);
+        var issue = decodeErr(string().url(), tooLong);
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URL", issue.message());
+    }
+
+    @Test
+    void urlRejectsMalformedValue() {
+        // The embedded space makes URI.create throw, exercising the parse-failure branch of url().
+        var issue = decodeErr(string().url(), "http://exa mple.com");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URL", issue.message());
+    }
+
+    @Test
+    void urlRejectsMissingHost() {
+        // Valid http scheme but empty host, exercising the host==null/empty branch of url().
+        var issue = decodeErr(string().url(), "http://");
         assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
         assertEquals("not a valid URL", issue.message());
     }

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -1,0 +1,288 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static net.unit8.raoh.decode.ObjectDecoders.allowBlankString;
+import static net.unit8.raoh.decode.ObjectDecoders.string;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit tests for {@link StringDecoder}, covering length/format constraints,
+ * preset validators, transforms, and type conversions. Failure paths assert both the
+ * error code and the self-contained fallback message.
+ */
+class StringDecoderTest {
+
+    // --- nonBlank / allowBlank ---
+
+    @Test
+    void nonBlankAcceptsNonBlankRejectsWhitespace() {
+        assertEquals("hi", decodeOk(string().nonBlank(), "hi"));
+        var issue = decodeErr(string().nonBlank(), "   ");
+        assertEquals(ErrorCodes.BLANK, issue.code());
+        assertEquals("must not be blank", issue.message());
+    }
+
+    @Test
+    void allowBlankReturnsBlankAcceptingDecoder() {
+        // string() retains a base decoder, so allowBlank() is permitted and yields a decoder
+        // that accepts blank input. Note: allowBlank() must be called directly on string();
+        // any chained constraint (e.g. nonBlank()) drops the base via chain().
+        assertEquals("  ", decodeOk(string().allowBlank(), "  "));
+    }
+
+    @Test
+    void allowBlankThrowsWhenNoBaseRetained() {
+        // allowBlankString() uses the single-argument constructor, so no base decoder is retained.
+        assertThrows(IllegalStateException.class, () -> allowBlankString().allowBlank());
+    }
+
+    // --- length constraints ---
+
+    @Test
+    void minLengthAcceptsBoundaryRejectsShorter() {
+        assertEquals("abc", decodeOk(string().minLength(3), "abc"));
+        var issue = decodeErr(string().minLength(3), "ab");
+        assertEquals(ErrorCodes.TOO_SHORT, issue.code());
+        assertEquals("must be at least 3 characters", issue.message());
+        assertEquals(3, issue.meta().get("min"));
+        assertEquals(2, issue.meta().get("actual"));
+    }
+
+    @Test
+    void maxLengthAcceptsBoundaryRejectsLonger() {
+        assertEquals("abc", decodeOk(string().maxLength(3), "abc"));
+        var issue = decodeErr(string().maxLength(3), "abcd");
+        assertEquals(ErrorCodes.TOO_LONG, issue.code());
+        assertEquals("must be at most 3 characters", issue.message());
+    }
+
+    @Test
+    void maxLengthUsesCustomMessageWhenProvided() {
+        var issue = decodeErr(string().maxLength(3, "too long"), "abcd");
+        assertEquals("too long", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    @Test
+    void fixedLengthAcceptsExactRejectsDifferent() {
+        assertEquals("abc", decodeOk(string().fixedLength(3), "abc"));
+        var issue = decodeErr(string().fixedLength(3), "ab");
+        assertEquals(ErrorCodes.INVALID_LENGTH, issue.code());
+        assertEquals("must be exactly 3 characters", issue.message());
+    }
+
+    // --- oneOf ---
+
+    @Test
+    void oneOfAcceptsMemberRejectsNonMember() {
+        assertEquals("a", decodeOk(string().oneOf("a", "b"), "a"));
+        var issue = decodeErr(string().oneOf("b", "a"), "c");
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("must be one of [a, b]", issue.message());
+    }
+
+    // --- pattern ---
+
+    @Test
+    void patternAcceptsMatchRejectsMismatch() {
+        var p = Pattern.compile("\\d+");
+        assertEquals("123", decodeOk(string().pattern(p), "123"));
+        var issue = decodeErr(string().pattern(p), "12a");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("invalid format", issue.message());
+        assertEquals("\\d+", issue.meta().get("pattern"));
+    }
+
+    @Test
+    void patternUsesCustomCode() {
+        var issue = decodeErr(string().pattern(Pattern.compile("\\d+"), "must_be_digits"), "x");
+        assertEquals("must_be_digits", issue.code());
+    }
+
+    @Test
+    void patternUsesCustomCodeAndMessage() {
+        var issue = decodeErr(string().pattern(Pattern.compile("\\d+"), "must_be_digits", "digits only"), "x");
+        assertEquals("must_be_digits", issue.code());
+        assertEquals("digits only", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    // --- substring constraints ---
+
+    @Test
+    void startsWithAcceptsPrefixRejectsOther() {
+        assertEquals("foobar", decodeOk(string().startsWith("foo"), "foobar"));
+        var issue = decodeErr(string().startsWith("foo"), "barfoo");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("must start with \"foo\"", issue.message());
+        assertEquals("foo", issue.meta().get("prefix"));
+    }
+
+    @Test
+    void endsWithAcceptsSuffixRejectsOther() {
+        assertEquals("foobar", decodeOk(string().endsWith("bar"), "foobar"));
+        var issue = decodeErr(string().endsWith("bar"), "barfoo");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("must end with \"bar\"", issue.message());
+    }
+
+    @Test
+    void includesAcceptsSubstringRejectsOther() {
+        assertEquals("amidb", decodeOk(string().includes("mid"), "amidb"));
+        var issue = decodeErr(string().includes("mid"), "abc");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("must include \"mid\"", issue.message());
+    }
+
+    // --- preset validators ---
+
+    @Test
+    void emailAcceptsValidRejectsInvalid() {
+        assertEquals("a@b.co", decodeOk(string().email(), "a@b.co"));
+        var issue = decodeErr(string().email(), "not-an-email");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid email", issue.message());
+    }
+
+    @Test
+    void urlAcceptsHttpsRejectsNonHttpScheme() {
+        assertEquals(URI.create("https://example.com"), decodeOk(string().url(), "https://example.com"));
+        var issue = decodeErr(string().url(), "ftp://example.com");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URL", issue.message());
+    }
+
+    @Test
+    void ipv4AcceptsValidRejectsInvalid() {
+        assertEquals("192.168.0.1", decodeOk(string().ipv4(), "192.168.0.1"));
+        var issue = decodeErr(string().ipv4(), "999.1.1.1");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid IPv4 address", issue.message());
+    }
+
+    @Test
+    void ipv6AcceptsValidRejectsInvalid() {
+        assertEquals("::1", decodeOk(string().ipv6(), "::1"));
+        var issue = decodeErr(string().ipv6(), "not-an-ip");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid IPv6 address", issue.message());
+    }
+
+    @Test
+    void ipAcceptsIpv4AndIpv6RejectsOther() {
+        assertEquals("10.0.0.1", decodeOk(string().ip(), "10.0.0.1"));
+        assertEquals("::1", decodeOk(string().ip(), "::1"));
+        var issue = decodeErr(string().ip(), "nope");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid IP address", issue.message());
+    }
+
+    @Test
+    void cuidAcceptsValidRejectsInvalid() {
+        assertEquals("cjld2cyuq0000t3rmniod1foy", decodeOk(string().cuid(), "cjld2cyuq0000t3rmniod1foy"));
+        var issue = decodeErr(string().cuid(), "not-a-cuid");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid CUID", issue.message());
+    }
+
+    @Test
+    void ulidAcceptsValidRejectsInvalid() {
+        assertEquals("01ARZ3NDEKTSV4RRFFQ69G5FAV", decodeOk(string().ulid(), "01ARZ3NDEKTSV4RRFFQ69G5FAV"));
+        var issue = decodeErr(string().ulid(), "not-a-ulid");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid ULID", issue.message());
+    }
+
+    // --- transforms ---
+
+    @Test
+    void trimRemovesSurroundingWhitespace() {
+        assertEquals("hi", decodeOk(string().trim(), "  hi  "));
+    }
+
+    @Test
+    void toLowerCaseLowercasesValue() {
+        assertEquals("abc", decodeOk(string().toLowerCase(), "ABC"));
+    }
+
+    @Test
+    void toUpperCaseUppercasesValue() {
+        assertEquals("ABC", decodeOk(string().toUpperCase(), "abc"));
+    }
+
+    // --- type conversions ---
+
+    @Test
+    void uuidParsesValidRejectsInvalid() {
+        var uuid = "550e8400-e29b-41d4-a716-446655440000";
+        assertEquals(UUID.fromString(uuid), decodeOk(string().uuid(), uuid));
+        var issue = decodeErr(string().uuid(), "not-a-uuid");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid UUID", issue.message());
+    }
+
+    @Test
+    void uriParsesValidRejectsInvalid() {
+        assertEquals(URI.create("urn:isbn:0451450523"), decodeOk(string().uri(), "urn:isbn:0451450523"));
+        var issue = decodeErr(string().uri(), "http://exa mple.com");
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URI", issue.message());
+    }
+
+    @Test
+    void toIntParsesAndSupportsFurtherConstraints() {
+        assertEquals(42, decodeOk(string().toInt(), "42"));
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(string().toInt().positive(), "-5").code());
+        var issue = decodeErr(string().toInt(), "x");
+        assertEquals(ErrorCodes.TYPE_MISMATCH, issue.code());
+        assertEquals("expected integer", issue.message());
+    }
+
+    @Test
+    void toLongParsesRejectsInvalid() {
+        assertEquals(42L, decodeOk(string().toLong(), "42"));
+        var issue = decodeErr(string().toLong(), "x");
+        assertEquals(ErrorCodes.TYPE_MISMATCH, issue.code());
+        assertEquals("expected long", issue.message());
+    }
+
+    @Test
+    void toDecimalParsesRejectsInvalid() {
+        assertEquals(new BigDecimal("1.5"), decodeOk(string().toDecimal(), "1.5"));
+        var issue = decodeErr(string().toDecimal(), "x");
+        assertEquals(ErrorCodes.TYPE_MISMATCH, issue.code());
+        assertEquals("expected decimal", issue.message());
+    }
+
+    @Test
+    void toBoolParsesCommonFormsRejectsOther() {
+        assertEquals(true, decodeOk(string().toBool(), "yes"));
+        assertEquals(false, decodeOk(string().toBool(), "off"));
+        var issue = decodeErr(string().toBool(), "maybe");
+        assertEquals(ErrorCodes.TYPE_MISMATCH, issue.code());
+        assertEquals("expected boolean", issue.message());
+    }
+
+    // --- base decoder behaviour ---
+
+    @Test
+    void rejectsNullAsRequired() {
+        assertEquals(ErrorCodes.REQUIRED, decodeErr(string(), null).code());
+    }
+
+    @Test
+    void rejectsNonStringAsTypeMismatch() {
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(string(), 42).code());
+    }
+}


### PR DESCRIPTION
Closes #55.

## Summary

Adds a focused unit test class per builtin refinement decoder in the core module. Until now these decoders were only exercised transitively through `MapDecoderTest`, leaving several constraints (e.g. `includes`, `startsWith`, `ipv4/ipv6`, `cuid`, `ulid`, `isFalse`, list/record size constraints) and many error codes (`OUT_OF_RANGE`, `NOT_MULTIPLE_OF`, `INVALID_SCALE`, `INVALID_VALUE`, `INVALID_FORMAT`, `INVALID_LENGTH`, `TOO_LONG/SHORT`, `TOO_BIG/SMALL`, `INVALID_SIZE`) without any direct assertion.

Each test decodes raw input at the root path via `ObjectDecoders`, so the decoders are tested independently of the `Map` boundary. For every constraint:

- the success path (including boundary values) is asserted, and
- the failure path asserts both the `ErrorCodes` value **and** the self-contained fallback message (with the parameter value embedded), directly guarding the constraint → `ErrorCodes` contract.

Construction-time guards added in #66 (inverted range, zero divisor, empty `containsAll`, null `contains`) are covered as well.

## Test classes

`IntDecoderTest`, `LongDecoderTest`, `DoubleDecoderTest`, `FloatDecoderTest`, `DecimalDecoderTest`, `BoolDecoderTest`, `StringDecoderTest`, `ListDecoderTest`, `RecordDecoderTest`, plus a package-private `BuiltinTestSupport` helper (`decodeOk` / `decodeErr`).

135 new tests; full core suite passes (388 tests, 0 failures).

## Follow-up finding (not addressed here)

Writing `StringDecoderTest` surfaced a Javadoc/implementation mismatch: `StringDecoder.allowBlank()` is documented as "removes a previously-applied `nonBlank()` constraint", but `chain()` builds the next decoder via the single-argument constructor, which drops the retained `base`. So `string().nonBlank().allowBlank()` throws `IllegalStateException` instead of restoring blank acceptance — `allowBlank()` only works when called directly on `string()`. The tests assert the actual current behavior; the Javadoc mismatch is left for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)