### PR TITLE
refactor(decode): remove vestigial allowBlank() and fix toSet() ordering (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ Other:
 `StringDecoder` supports:
 
 - `nonBlank()`
-- `allowBlank()`
 - `minLength(...)`
 - `maxLength(...)`
 - `fixedLength(...)`

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -55,8 +55,7 @@ public final class JsonDecoders {
      * @return a decoder that extracts a string value from a JSON node
      */
     public static StringDecoder<JsonNode> string() {
-        Decoder<JsonNode, String> base = allowBlankBase();
-        return new StringDecoder<>(base, base);
+        return new StringDecoder<>(allowBlankBase());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
@@ -54,8 +54,8 @@ public final class ObjectDecoders {
      * <p>Returns {@code required} if the value is {@code null},
      * and {@code type_mismatch} if the value is not a {@link String}.
      * Blank strings are accepted by default; chain {@link net.unit8.raoh.decode.builtin.StringDecoder#nonBlank() nonBlank()}
-     * to reject them, or use {@link #allowBlankString()} when you explicitly want to allow blanks
-     * and suppress the {@link net.unit8.raoh.decode.builtin.StringDecoder#nonBlank() nonBlank()} default.
+     * to reject them. Constraints are additive — there is no opt-out combinator to remove a
+     * previously-applied constraint.
      *
      * @return a string decoder for {@code Object} input
      */
@@ -64,8 +64,7 @@ public final class ObjectDecoders {
     // the types are identical, so this is a checker generics limitation, not a nullness hole.
     @SuppressWarnings("NullAway")
     public static StringDecoder<@Nullable Object> string() {
-        Decoder<@Nullable Object, String> base = allowBlankBase();
-        return new StringDecoder<@Nullable Object>(base, base);
+        return new StringDecoder<@Nullable Object>(allowBlankBase());
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
@@ -186,7 +186,8 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a decoder that produces an unmodifiable {@link Set} from the list elements
      */
     public Decoder<I, Set<T>> toSet() {
-        return (in, path) -> this.decode(in, path).map(list -> Set.copyOf(new LinkedHashSet<>(list)));
+        return (in, path) -> this.decode(in, path)
+                .map(list -> Collections.unmodifiableSet(new LinkedHashSet<>(list)));
     }
 
     private ListDecoder<I, T> chain(Decoder<List<T>, List<T>> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -50,7 +50,6 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
             "^[0-9A-HJKMNP-TV-Z]{26}$");
 
     private final Decoder<I, String> inner;
-    private final @Nullable Decoder<I, String> base;
 
     /**
      * Creates a new {@link StringDecoder} wrapping the given decoder.
@@ -59,19 +58,6 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      */
     public StringDecoder(Decoder<I, String> inner) {
         this.inner = inner;
-        this.base = null;
-    }
-
-    /**
-     * Creates a new {@link StringDecoder} wrapping the given decoder, retaining a base decoder
-     * for use by {@link #allowBlank()}.
-     *
-     * @param inner the underlying decoder that produces a string value
-     * @param base  the original decoder before {@link #nonBlank()} was applied, or {@code null}
-     */
-    public StringDecoder(Decoder<I, String> inner, @Nullable Decoder<I, String> base) {
-        this.inner = inner;
-        this.base = base;
     }
 
     @Override
@@ -115,22 +101,6 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
             }
             return Result.ok(value);
         });
-    }
-
-    /**
-     * Removes a previously-applied {@link #nonBlank()} constraint, restoring blank-string acceptance.
-     *
-     * @return a new decoder that accepts blank strings
-     * @throws IllegalStateException if this decoder was not created via {@code net.unit8.raoh.json.JsonDecoders#string()}
-     *         or {@link net.unit8.raoh.decode.ObjectDecoders#string()} (i.e., no base decoder is available to restore)
-     */
-    public StringDecoder<I> allowBlank() {
-        if (base == null) {
-            throw new IllegalStateException(
-                    "allowBlank() can only be called on a StringDecoder created by JsonDecoders.string() " +
-                    "or ObjectDecoders.string(), which retain the base decoder for restoration.");
-        }
-        return new StringDecoder<>(base);
     }
 
     /**

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
@@ -3,6 +3,7 @@ package net.unit8.raoh.decode.builtin;
 import net.unit8.raoh.ErrorCodes;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -99,8 +100,11 @@ class ListDecoderTest {
     // --- conversion ---
 
     @Test
-    void toSetDeduplicatesElements() {
-        assertEquals(Set.of(1, 2, 3), decodeOk(list(int_()).toSet(), List.of(1, 2, 2, 3)));
+    void toSetDeduplicatesElementsPreservingInsertionOrder() {
+        var set = decodeOk(list(int_()).toSet(), List.of(3, 1, 3, 2));
+        // Deduplication: [3, 1, 3, 2] -> {3, 1, 2}, with first-seen (insertion) order preserved.
+        assertEquals(Set.of(1, 2, 3), set);
+        assertEquals(List.of(3, 1, 2), new ArrayList<>(set));
     }
 
     // --- base decoder behaviour ---

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class StringDecoderTest {
 
-    // --- nonBlank / allowBlank ---
+    // --- nonBlank ---
 
     @Test
     void nonBlankAcceptsNonBlankRejectsWhitespace() {

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -8,12 +8,10 @@ import java.net.URI;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import static net.unit8.raoh.decode.ObjectDecoders.allowBlankString;
 import static net.unit8.raoh.decode.ObjectDecoders.string;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -31,20 +29,6 @@ class StringDecoderTest {
         var issue = decodeErr(string().nonBlank(), "   ");
         assertEquals(ErrorCodes.BLANK, issue.code());
         assertEquals("must not be blank", issue.message());
-    }
-
-    @Test
-    void allowBlankReturnsBlankAcceptingDecoder() {
-        // string() retains a base decoder, so allowBlank() is permitted and yields a decoder
-        // that accepts blank input. Note: allowBlank() must be called directly on string();
-        // any chained constraint (e.g. nonBlank()) drops the base via chain().
-        assertEquals("  ", decodeOk(string().allowBlank(), "  "));
-    }
-
-    @Test
-    void allowBlankThrowsWhenNoBaseRetained() {
-        // allowBlankString() uses the single-argument constructor, so no base decoder is retained.
-        assertThrows(IllegalStateException.class, () -> allowBlankString().allowBlank());
     }
 
     // --- length constraints ---

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -11,6 +11,7 @@ import net.unit8.raoh.Presence;
 import net.unit8.raoh.Result;
 import net.unit8.raoh.decode.Decoder;
 import net.unit8.raoh.decode.Decoders;
+import net.unit8.raoh.decode.ObjectDecoders;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -467,7 +468,7 @@ class MapDecoderTest {
 
     @Test
     void allowBlankString() {
-        var dec = field("note", string().allowBlank());
+        var dec = field("note", ObjectDecoders.allowBlankString());
         assertEquals("", assertOk(dec.decode(Map.of("note", ""))));
         assertEquals("hello", assertOk(dec.decode(Map.of("note", "hello"))));
     }


### PR DESCRIPTION
Closes #69.

Two independent fixes surfaced by the #68 review, resolved after checking how Zod and Yavi handle the same territory.

## 1. Remove `StringDecoder.allowBlank()` (breaking, pre-1.0)

`allowBlank()` was a leftover from an earlier design where `string()` applied `nonBlank()` by default; it was meant to undo that default. Today `string()` accepts blank input by default, so `allowBlank()` had **no valid use**:

- On a raw `string()` it is a no-op (base and inner are the same blank-accepting decoder).
- After any constraint, `chain()` builds the next decoder via the single-arg constructor and drops the retained `base`, so the documented "undo `nonBlank()`" flow throws `IllegalStateException`.
- It had no production callers.

**Design check — neither Zod nor Yavi has an `allowBlank`-style opt-out:**

| | blank by default | constraints | remove/undo API |
|---|---|---|---|
| Zod (`z.string()`) | accepts `""` / whitespace | additive (`.min(1)` for non-empty) | none |
| Yavi (`CharSequenceConstraint`) | `notBlank` not applied by default | additive opt-in | none |

raoh's current `string()` (blank-accepting, additive constraints) already matches both. Making `allowBlank()` "work" would mean reverting `string()` to nonBlank-by-default and moving *away* from both libraries; removing it keeps raoh aligned.

Removed: `allowBlank()`, the retained `base` field, and the two-arg `StringDecoder(inner, base)` constructor. `string()` (Object + JSON) now uses the single-arg constructor. Fixed the contradictory `string()` Javadoc that referenced a non-existent "`nonBlank()` default". `allowBlankString()` (used by `MapDecoders` / `JsonDecoders`) is unchanged; the `MapDecoderTest` case that used `string().allowBlank()` now exercises `allowBlankString()` directly (its name finally matches).

## 2. `ListDecoder.toSet()` preserves insertion order

`toSet()` is documented as preserving insertion order, but `Set.copyOf(new LinkedHashSet<>(list))` returns a set with unspecified iteration order — the `LinkedHashSet` ordering was discarded immediately. Now returns `Collections.unmodifiableSet(new LinkedHashSet<>(list))`, and the test asserts order.

## Verification

Full reactor `mvn test` green (core 390, json 71, jooq 19, gsh, …). NullAway `nullcheck` gate passes on core + json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)