### PR TITLE
refactor(decode): remove redundant allowBlankString() factory (#71)

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -172,7 +172,7 @@ public final class JooqRecordDecoders {
     public static <T> JooqRecordDecoder<T> discriminate(
             String fieldName,
             Map<String, Decoder<org.jooq.Record, ? extends T>> variants) {
-        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.allowBlankString()), variants)::decode;
+        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.string()), variants)::decode;
     }
 
     // --- combine delegates ---

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -58,15 +58,6 @@ public final class JsonDecoders {
         return new StringDecoder<>(allowBlankBase());
     }
 
-    /**
-     * Creates a string decoder that preserves blank values (no trim or nonBlank validation).
-     *
-     * @return a string decoder that allows blank strings
-     */
-    public static StringDecoder<JsonNode> allowBlankString() {
-        return new StringDecoder<>(allowBlankBase());
-    }
-
     private static Decoder<JsonNode, String> allowBlankBase() {
         return (in, path) -> {
             if (in == null || in.isNull() || in.isMissingNode()) {
@@ -377,7 +368,7 @@ public final class JsonDecoders {
      * @return an enum decoder
      */
     public static <E extends Enum<E>> Decoder<JsonNode, E> enumOf(Class<E> cls) {
-        return Decoders.<JsonNode, E>enumOf(cls, allowBlankString());
+        return Decoders.<JsonNode, E>enumOf(cls, string());
     }
 
     /**
@@ -387,7 +378,7 @@ public final class JsonDecoders {
      * @return a literal decoder
      */
     public static Decoder<JsonNode, String> literal(String expected) {
-        return Decoders.<JsonNode>literal(expected, allowBlankString());
+        return Decoders.<JsonNode>literal(expected, string());
     }
 
     // --- discriminate ---
@@ -403,7 +394,7 @@ public final class JsonDecoders {
     public static <T> Decoder<JsonNode, T> discriminate(
             String fieldName,
             Map<String, Decoder<JsonNode, ? extends T>> variants) {
-        return Decoders.<JsonNode, T>discriminate(fieldName, field(fieldName, allowBlankString()), variants);
+        return Decoders.<JsonNode, T>discriminate(fieldName, field(fieldName, string()), variants);
     }
 
     // --- strict ---

--- a/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
@@ -67,17 +67,6 @@ public final class ObjectDecoders {
         return new StringDecoder<@Nullable Object>(allowBlankBase());
     }
 
-    /**
-     * Creates a string decoder that preserves blank values (no trim or nonBlank validation).
-     *
-     * @return a string decoder for {@code Object} input that allows blank strings
-     */
-    // See string(): NullAway generics limitation on Decoder<@Nullable Object, String> vs Decoder<I, String>.
-    @SuppressWarnings("NullAway")
-    public static StringDecoder<@Nullable Object> allowBlankString() {
-        return new StringDecoder<@Nullable Object>(allowBlankBase());
-    }
-
     private static Decoder<@Nullable Object, String> allowBlankBase() {
         return (in, path) -> {
             if (in == null) {
@@ -470,7 +459,7 @@ public final class ObjectDecoders {
      * @return a decoder that produces enum constants from string input
      */
     public static <E extends Enum<E>> Decoder<@Nullable Object, E> enumOf(Class<E> cls) {
-        return Decoders.<@Nullable Object, E>enumOf(cls, allowBlankString());
+        return Decoders.<@Nullable Object, E>enumOf(cls, string());
     }
 
     /**
@@ -480,6 +469,6 @@ public final class ObjectDecoders {
      * @return a decoder that succeeds only when the input matches {@code expected}
      */
     public static Decoder<@Nullable Object, String> literal(String expected) {
-        return Decoders.<@Nullable Object>literal(expected, allowBlankString());
+        return Decoders.<@Nullable Object>literal(expected, string());
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
@@ -218,7 +218,7 @@ public final class MapDecoders {
     public static <T> Decoder<Map<String, Object>, T> discriminate(
             String fieldName,
             Map<String, Decoder<Map<String, Object>, ? extends T>> variants) {
-        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.allowBlankString()), variants);
+        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.string()), variants);
     }
 
     /**

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -11,7 +11,6 @@ import net.unit8.raoh.Presence;
 import net.unit8.raoh.Result;
 import net.unit8.raoh.decode.Decoder;
 import net.unit8.raoh.decode.Decoders;
-import net.unit8.raoh.decode.ObjectDecoders;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -464,13 +463,6 @@ class MapDecoderTest {
     void typeMismatch() {
         var dec = field("age", int_());
         assertErr(dec.decode(Map.of("age", "thirty")));
-    }
-
-    @Test
-    void allowBlankString() {
-        var dec = field("note", ObjectDecoders.allowBlankString());
-        assertEquals("", assertOk(dec.decode(Map.of("note", ""))));
-        assertEquals("hello", assertOk(dec.decode(Map.of("note", "hello"))));
     }
 
     @Test


### PR DESCRIPTION
Closes #71.

## Summary

After #70, `allowBlankString()` is behaviorally identical to `string()` in both `ObjectDecoders` and `JsonDecoders` — the same vestige of the era when `string()` applied `nonBlank()`/`trim()` by default and `allowBlankString()` opted out. It is undocumented (absent from README/docs/examples) and reveals no distinct intent to a caller, since `string()` already accepts blank input.

## Why remove rather than keep as an alias

Checked how Zod and Yavi shape their string surface:

| | string entry point | enum / literal / discriminator | separate "raw string" factory |
|---|---|---|---|
| **Zod** | single `z.string()` (no default trim) | first-class schemas, **not** built on `z.string()` | none |
| **Yavi** | single `_string` / `charSequence` | — (constraint-oriented) | none |

Neither library carries a second raw-string factory. raoh builds `enumOf` / `literal` / `discriminate` by passing a string decoder as the key reader — a fine combinator design — but `allowBlankString()` leaked that internal seam into the public API. Since `string()` is now raw and blank-accepting by settled design (#69/#70), one `string()` factory matches both libraries.

## Changes

- Remove `allowBlankString()` from `ObjectDecoders` and `JsonDecoders`.
- Internal key readers now use `string()`: `enumOf()` / `literal()` (core + JSON) and `discriminate()` (Map, JSON, **jOOQ**). Behavioral no-op — the two factories were identical.
- Drop the redundant `MapDecoderTest.allowBlankString` test (`stringAllowsBlankByDefault` already covers blank acceptance).

**BREAKING CHANGE** (pre-1.0): `ObjectDecoders.allowBlankString()` / `JsonDecoders.allowBlankString()` removed; use `string()`.

## Verification

Full reactor `mvn test` green (core, json, jooq 19, gsh, …), BUILD SUCCESS. NullAway `nullcheck` gate passes on core + json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)