### PR TITLE
build(json): scope Jackson as provided to match jOOQ (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ version once as a property — use the latest shown on the Maven Central badge a
         <version>${raoh.version}</version>
     </dependency>
 
-    <!-- Optional: decode Jackson JsonNode (pulls in Jackson 3) -->
+    <!-- Optional: decode Jackson JsonNode (Jackson 3 is a provided dependency — supply your own) -->
     <dependency>
         <groupId>net.unit8.raoh</groupId>
         <artifactId>raoh-json</artifactId>
@@ -617,6 +617,12 @@ Raoh ships three boundary modules for different input types:
 - **`MapDecoders`** — `Map<String, Object>` (`raoh`)
 
 Each provides the same set of helpers (`string()`, `field(...)`, `combine(...)`, etc.) adapted to its input type.
+
+Both integration modules scope their third-party library as `provided`: `raoh-json` for
+Jackson 3 (`tools.jackson.core:jackson-databind`) and `raoh-jooq` for jOOQ (`org.jooq:jooq`).
+Because each module exposes that library's type (`JsonNode`, `Record`) in its public API, a
+consumer already supplies it on the classpath — so `provided` avoids pinning a specific
+version transitively on downstreams. Add the matching library to your own build.
 
 See [docs/boundary-modules.md](docs/boundary-modules.md) for the full API listing and examples.
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,18 @@ version once as a property — use the latest shown on the Maven Central badge a
         <version>${raoh.version}</version>
     </dependency>
 
-    <!-- Optional: decode Jackson JsonNode (Jackson 3 is a provided dependency — supply your own) -->
+    <!-- Optional: decode Jackson JsonNode -->
     <dependency>
         <groupId>net.unit8.raoh</groupId>
         <artifactId>raoh-json</artifactId>
         <version>${raoh.version}</version>
+    </dependency>
+    <!-- raoh-json scopes Jackson as 'provided', so add Jackson 3 yourself.
+         Note the groupId is tools.jackson.core (Jackson 3), not com.fasterxml.jackson (Jackson 2). -->
+    <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>3.1.0</version>
     </dependency>
 
     <!-- Optional: decode jOOQ Record (jOOQ is a provided dependency) -->

--- a/raoh-json/pom.xml
+++ b/raoh-json/pom.xml
@@ -25,10 +25,17 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!--
+            Jackson is scoped 'provided': raoh-json exposes Jackson's JsonNode in its
+            public API, so any consumer already supplies Jackson 3 on their classpath.
+            Keeping it 'provided' (matching jOOQ in raoh-jooq) avoids pinning a specific
+            Jackson 3.x version transitively on downstreams.
+        -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Closes #60.

## Decision

Scope Jackson (`tools.jackson.core:jackson-databind`, Jackson 3) as **`provided`** in `raoh-json`, matching how `raoh-jooq` scopes jOOQ.

## Rationale

The two boundary modules were structurally parallel but scoped inconsistently:

| Module | Third-party type in public API | Scope (before) |
|---|---|---|
| `raoh-json` | `JsonNode` — **33** public signatures | `compile` (leaks Jackson 3.x transitively) |
| `raoh-jooq` | `org.jooq.Record` — **23** public signatures | `provided` |

Because `JsonNode` is unavoidable in raoh-json's public API, any consumer already supplies Jackson 3 on their classpath to reference it — so `provided`:

- **avoids pinning** a specific Jackson 3.x version transitively on downstreams (compile scope can silently downgrade/conflict a consumer's newer Jackson),
- is **fail-safe**: a consumer who forgets Jackson gets a compile error against `JsonNode`, not a runtime `NoClassDefFoundError`,
- makes the two boundary modules **consistent** before the 1.0 packaging freeze.

The only thing `compile` bought — consumers not declaring Jackson — is moot, since they reference `JsonNode` and must declare it anyway.

## Verification

- `raoh-json` builds and all 71 tests pass (`provided` is on the test classpath).
- `dependency:tree` confirms `jackson-databind:3.1.0:provided` — no longer a transitive compile dep.
- The Spring example (`examples/spring`, a real consumer) still `test-compile`s cleanly: Spring Boot 4 supplies Jackson 3 itself, so no consumer breakage.

## Acceptance criteria

- [x] Decision recorded (this PR + commit)
- [x] Scope made consistent with the decision (`provided`, matching jOOQ)
- [x] Documented in the README boundary-modules section

**BREAKING CHANGE** (pre-1.0): `raoh-json` no longer brings Jackson transitively; consumers add `tools.jackson.core:jackson-databind` (Jackson 3) themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)