### PR TITLE
docs(changelog): expand with Unreleased section and pre-0.6 history (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,36 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0]
+Versions `0.1.0`–`0.5.0` are summarized from git history; entries become more
+detailed from the current development cycle onward.
+
+## [Unreleased]
+
+The accumulated development line since `0.5.0` (previously tracked as `0.6.0-SNAPSHOT`).
+At release time this section is renamed to the chosen version with a date.
 
 ### Added
 
-- **jspecify `@NullMarked` nullness contract** across the `raoh` core module. Consumers
-  running null analysis (Eclipse JDT / ecj, NullAway, IntelliJ) now receive precise, declared
-  contracts instead of guessed ones ([#43](https://github.com/kawasima/raoh/issues/43)).
-- **NullAway build gate** (`mvn -Pnullcheck`) that validates the core module's nullness
-  contract. Requires JDK 25 (Error Prone does not yet support JDK 26).
+- **jspecify `@NullMarked` nullness contract** across the `raoh` core module, extended to the
+  `raoh-json` and `raoh-jooq` sibling modules. Consumers running null analysis (Eclipse JDT / ecj,
+  NullAway, IntelliJ) receive precise, declared contracts instead of guessed ones
+  ([#43](https://github.com/kawasima/raoh/issues/43)).
+- **NullAway build gate** (`mvn -Pnullcheck`) that validates the core module's nullness contract.
+  Requires JDK 25 (Error Prone does not yet support JDK 26).
 - **`MapEncoders.nullableProperty(...)`** — the nullable counterpart of `property(...)`, for a
   getter that may return `null`. The `null` branch is handled in the property layer: the value
   encoder is not invoked and `null` is written to the map.
 - **`MapEncoders.propertyWithDefault(...)`** (value and `Supplier` overloads) — encodes a default
   value when the getter returns `null`, so the map entry is never `null`.
+- **`MapEncoders.discriminate(...)`** — tagged-union encoding, mirroring the decoder side; rejects
+  duplicate discriminator tags at construction ([#44](https://github.com/kawasima/raoh/issues/44)).
+- **`nullableField(...)`** targeting `@Nullable T`, in core `MapDecoders`, `JsonDecoders`, and
+  `JooqRecordDecoders` ([#46](https://github.com/kawasima/raoh/issues/46),
+  [#53](https://github.com/kawasima/raoh/issues/53)).
+- **Message overloads across the numeric decoders**, with `DecimalDecoder` brought to parity
+  (`min` / `max` / `range` / `multipleOf` / sign / `scale`)
+  ([#54](https://github.com/kawasima/raoh/issues/54)).
+- **CI**: GitHub Actions workflow for build/test and the NullAway null-analysis gate.
 
 ### Changed
 
@@ -28,23 +44,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stays a plain `Object` on purpose). All `null` / default handling lives in
   `MapEncoders.nullableProperty` / `propertyWithDefault`, mirroring `field` / `optionalField` on
   the decoder side. Keeping `@Nullable` out of `Encoder`'s type parameters lets consumers running
-  either NullAway or ecj/JSpecify use the encoder API without null-analysis noise (no
-  "Null constraint mismatch", no unchecked-conversion warnings on `property(..., string())`).
+  either NullAway or ecj/JSpecify use the encoder API without null-analysis noise.
 - The value-mapping methods now follow the standard PECS variance used by the JDK
   (`Stream.map`, `Comparator.comparing`, …): `Function<? super T, ? extends V>` /
   `BiFunction<...>` instead of the invariant forms. This covers `MapEncoders.property` /
   `nullableProperty` / `propertyWithDefault` getters, `Encoder.contramap`, `Decoder.map` /
   `flatMap` / `flatMapWithPath`, `Result.map` / `flatMap` / `fold` / `map2` / `traverse` /
-  `traverseResults`, `Decoders.recover`, and `Validated` / `Valid` / `Invalid.map`. A method
-  reference on a supertype, or one returning a subtype, now adapts without an explicit cast.
-  Binary-compatible (erasure unchanged) and a source-compatible widening. The N-ary `combine(...)`
-  builders (`Combiner2`–`Combiner16`, `CombinerList`) keep the invariant form.
+  `traverseResults`, `Decoders.recover`, and `Validated` / `Valid` / `Invalid.map`. Binary-compatible
+  (erasure unchanged) and a source-compatible widening. The N-ary `combine(...)` builders
+  (`Combiner2`–`Combiner16`, `CombinerList`) keep the invariant form.
 - `Result` and `Decoder` type-parameter bounds were widened to `<T extends @Nullable Object>` so
   that nullable-valued results and decoders (`ObjectDecoders.nullable`, `Presence`, …) are
   expressible. Invisible to the common non-null instantiation (e.g. `Result<Order>.value()` stays
   non-null).
 - Decode value inputs are now typed `@Nullable Object`, reflecting that decoders already accept a
   missing/`null` value and return a `required` error rather than throwing.
+- **`raoh-json` scopes Jackson as `provided`** (was `compile`), matching `raoh-jooq`. Because
+  raoh-json exposes Jackson's `JsonNode` in its public API, consumers already supply Jackson 3 on
+  their classpath; `provided` avoids pinning a specific Jackson 3.x version transitively
+  ([#60](https://github.com/kawasima/raoh/issues/60)).
+- `ListDecoder.toSet()` now preserves insertion order (previously unspecified via `Set.copyOf`)
+  ([#69](https://github.com/kawasima/raoh/issues/69)).
 
 ### Removed
 
@@ -53,11 +73,125 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ObjectEncoders.withDefault(Encoder, …)`** — replace
   `property("x", getter, withDefault(enc, default))` with
   `propertyWithDefault("x", getter, enc, default)`.
+- **`StringDecoder.allowBlank()`** and the two-argument `StringDecoder(inner, base)` constructor —
+  a vestige of an earlier design; `string()` accepts blank input by default
+  ([#69](https://github.com/kawasima/raoh/issues/69)).
+- **`ObjectDecoders.allowBlankString()` / `JsonDecoders.allowBlankString()`** — redundant with
+  `string()`; the internal `enumOf` / `literal` / `discriminate` key readers now use `string()`
+  ([#71](https://github.com/kawasima/raoh/issues/71)).
+
+### Fixed
+
+- Numeric decoders (`IntDecoder`, `LongDecoder`, `FloatDecoder`, `DoubleDecoder`, `DecimalDecoder`)
+  reject a zero divisor and an inverted range at construction instead of failing silently
+  ([#66](https://github.com/kawasima/raoh/issues/66)).
+- Encode `discriminate` guards against a `null` variant key at tag injection
+  ([#44](https://github.com/kawasima/raoh/issues/44)).
 
 ### Compatibility
 
-- The removed `ObjectEncoders.nullable` / `withDefault` are a **breaking source change** (they no
-  longer compile); migrate to the property-layer forms above.
+- **Breaking (source):** the removed `ObjectEncoders.nullable` / `withDefault`,
+  `StringDecoder.allowBlank()` + two-arg constructor, and `allowBlankString()` no longer compile;
+  migrate as noted above.
+- **Breaking (packaging):** `raoh-json` no longer brings Jackson transitively — add
+  `tools.jackson.core:jackson-databind` (Jackson 3) to your own build.
 - Otherwise runtime-unchanged (the full test suite passes). Consumers running null analysis need no
-  build-config workarounds: idiomatic `property(..., string())` / `nullableProperty(..., string())`
-  with method-reference getters compile clean under both NullAway and ecj/JSpecify.
+  build-config workarounds.
+
+## [0.5.0] - 2026-03-31
+
+### Added
+
+- `raoh-encoder` module for encoding domain objects back into boundary representations.
+- `double_()`, `float_()`, and `bytes()` decoders in `ObjectDecoders`.
+- Acceptance of `java.sql` temporal types (`Date`, `Time`, `Timestamp`) in the temporal decoders.
+- `ObjectEncoders.withDefault()` for null-to-default encoding.
+- Schema-versioning example (REST API with versioned decoders).
+
+### Changed
+
+- **Reorganized packages into `decode` / `encode` for symmetry** (breaking).
+- **`StringDecoder.url()` now returns `Decoder<I, URI>`** instead of a string (breaking).
+- Completed Javadoc across public methods.
+
+## [0.4.1] - 2026-03-15
+
+### Added
+
+- Core `discriminate()` for tagged-union decoding, plus `discriminate()` in the Map / jOOQ decoders
+  and `combine(List)` in the Map / JSON decoders.
+- `Result.map3` / `map4` and `Tuple2`–`Tuple8` for lightweight result destructuring.
+- Japanese messages (`messages_ja.properties`).
+
+### Fixed
+
+- `discriminate()` reports `NOT_ALLOWED` for unknown tag values and snapshots/sorts the allowed
+  values in the error metadata.
+
+## [0.4.0] - 2026-03-10
+
+### Added
+
+- **`raoh-gsh` domain construction guard** (split into runtime and weaver modules).
+- String coerce methods on `StringDecoder`: `toInt()` / `toLong()` / `toDecimal()` / `toBool()`.
+- `Path.of(String...)` factory.
+
+### Changed
+
+- Renamed `Combiner.apply()` to `map()` for consistency with the `map` / `flatMap` convention.
+- Extracted `ObjectDecoders` from `MapDecoders` and `JooqRecordDecoders`.
+- `nonBlank()` now reports its own `BLANK` error code, distinct from `REQUIRED`.
+- `Err.toString()` renders the root path as `"/"`; `Ok` gets a matching `toString()`.
+
+## [0.3.1] - 2026-03-08
+
+### Added
+
+- `ListDecoder` `contains` / `containsAll` / `unique` constraints.
+- `oneOf` constraint on `StringDecoder`, `IntDecoder`, and `LongDecoder`.
+- `BoolDecoder` `isTrue()` / `isFalse()` constraints.
+- Temporal constraint chain (`before` / `after` / `between`) for the date/time decoders.
+- `CombinerList` for combining more than 16 decoders.
+- Locale-aware message resolution.
+
+### Fixed
+
+- Split `MISSING_ELEMENT` / `MISSING_ELEMENTS` and included the missing/duplicate values in the
+  corresponding error messages; added the missing built-in codes to `MessageResolver.DEFAULT`.
+
+## [0.3.0] - 2026-03-07
+
+### Added
+
+- **`JooqRecordDecoders`** for decoding jOOQ `Record` input.
+- Membership REST example (user/group management).
+- `Result.fail` root-path helpers and `flatMapWithPath` for path-aware error handling.
+- Apache License 2.0; Maven Central / Javadoc / license / Java-version badges.
+
+### Changed
+
+- Use `Decoder.list()` for variable-length lists.
+
+## [0.2.0] - 2026-03-06
+
+### Added
+
+- **JSON decoders for Jackson `JsonNode` input** (`raoh-json`), with comprehensive JSON/Map decoder
+  tests and `package-info.java` documentation.
+
+## [0.1.0] - 2026-03-06
+
+### Added
+
+- Initial public release: the core decoder model (`Decoder`, `Result` / `Ok` / `Err`, `Path`,
+  `Presence`), `Map<String, Object>` decoders, error model, a Spring Boot example, and a README with
+  an Elm-decoder comparison.
+
+[Unreleased]: https://github.com/kawasima/raoh/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/kawasima/raoh/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/kawasima/raoh/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/kawasima/raoh/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/kawasima/raoh/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/kawasima/raoh/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/kawasima/raoh/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/kawasima/raoh/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,8 @@ At release time this section is renamed to the chosen version with a date.
 
 ### Added
 
-- `raoh-encoder` module for encoding domain objects back into boundary representations.
+- Encoder API (`net.unit8.raoh.encode`: `Encoder`, `ObjectEncoders`, `MapEncoders`) for encoding
+  domain objects back into boundary representations, living in the core `raoh` module.
 - `double_()`, `float_()`, and `bytes()` decoders in `ObjectDecoders`.
 - Acceptance of `java.sql` temporal types (`Date`, `Time`, `Timestamp`) in the temporal decoders.
 - `ObjectEncoders.withDefault()` for null-to-default encoding.


### PR DESCRIPTION
Closes #58.

## Summary

`CHANGELOG.md` previously held a single, undated `[0.6.0]` entry that stopped at the `#43` nullness work — later 0.6.0-cycle changes (`#44`–`#71`, `#60`, CI) were undocumented, and there was no history before 0.6.

Restructured to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/):

- **`[Unreleased]`** — consolidates the entire unreleased post-0.5.0 cycle (formerly `0.6.0-SNAPSHOT`), completing the missing entries. Since nothing after `v0.5.0` is tagged/released, this is the convention-correct home; at release the maintainer renames it to the chosen version + date (this also serves as the "prepare 1.0.0" staging area).
- **`[0.5.0]` … `[0.1.0]`** — backfilled with release dates (from git tags) and concise per-version summaries reconstructed from git history.
- **Version compare links** at the bottom.

Test-only changes (e.g. `#55`) are intentionally omitted as not consumer-visible.

## Note on structure

I folded the existing `[0.6.0]` content into `[Unreleased]` rather than keeping a standalone undated `[0.6.0]` heading, because `0.6.0` was never tagged/released and more unreleased work has accumulated on top of it. If you'd prefer a standalone pending `[0.6.0]` (or to label the next release `1.0.0` directly), it's a one-line heading rename — happy to adjust.

## Acceptance criteria

- [x] `[Unreleased]` section present
- [x] Release dates on published versions (0.1.0–0.5.0)
- [x] Pre-0.6 history backfilled (per-version summaries + dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)