### PR TITLE
feat(encode): EntryEncoder + optionalProperty + presenceProperty (#41, #61)

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/encode/EntryEncoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/EntryEncoder.java
@@ -1,0 +1,37 @@
+package net.unit8.raoh.encode;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * A map-entry encoder that writes zero or more key/value pairs for a domain object into an
+ * output map.
+ *
+ * <p>This generalizes {@link PropertyEncoder}, which always writes exactly one key. An
+ * {@code EntryEncoder} may write:
+ *
+ * <ul>
+ *   <li>exactly one entry (a plain {@link MapEncoders#property property}),</li>
+ *   <li>zero or one entry (e.g. {@link MapEncoders#optionalProperty optionalProperty}, which
+ *       omits the key when the value is absent), or</li>
+ *   <li>zero, one, or a {@code null}-valued entry (e.g.
+ *       {@link MapEncoders#presenceProperty presenceProperty}).</li>
+ * </ul>
+ *
+ * <p>Consumed by {@link MapEncoders#object(EntryEncoder[])}, which applies each entry encoder in
+ * order to a shared output map.
+ *
+ * @param <T> the domain type from which entries are extracted
+ */
+@FunctionalInterface
+public interface EntryEncoder<T> {
+
+    /**
+     * Writes this encoder's key/value pair(s) for {@code value} into {@code out}.
+     *
+     * @param value the domain object being encoded
+     * @param out   the output map to write entries into
+     */
+    void encodeTo(T value, Map<String, @Nullable Object> out);
+}

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -1,5 +1,7 @@
 package net.unit8.raoh.encode;
 
+import net.unit8.raoh.Presence;
+
 import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
@@ -68,7 +70,7 @@ public final class MapEncoders {
      * @param key          the output map key (e.g., column name)
      * @param getter       extracts the property value from the domain object
      * @param valueEncoder encodes the extracted value to {@code Object}
-     * @return a property encoder for use with {@link #object(PropertyEncoder[])}
+     * @return a property encoder for use with {@link #object(EntryEncoder[])}
      */
     public static <T, V> PropertyEncoder<T> property(
             String key,
@@ -92,7 +94,7 @@ public final class MapEncoders {
      * @param key          the output map key (e.g., column name)
      * @param getter       extracts the property value, which may be {@code null}
      * @param valueEncoder encodes the extracted value (only invoked when non-null) to {@code Object}
-     * @return a property encoder for use with {@link #object(PropertyEncoder[])}
+     * @return a property encoder for use with {@link #object(EntryEncoder[])}
      */
     public static <T, V> PropertyEncoder<T> nullableProperty(
             String key,
@@ -117,7 +119,7 @@ public final class MapEncoders {
      * @param getter       extracts the property value, which may be {@code null}
      * @param valueEncoder encodes the value (or the default) to {@code Object}
      * @param defaultValue the value to encode when the getter returns {@code null}
-     * @return a property encoder for use with {@link #object(PropertyEncoder[])}
+     * @return a property encoder for use with {@link #object(EntryEncoder[])}
      */
     public static <T, V> PropertyEncoder<T> propertyWithDefault(
             String key,
@@ -141,7 +143,7 @@ public final class MapEncoders {
      * @param getter       extracts the property value, which may be {@code null}
      * @param valueEncoder encodes the value (or the supplied default) to {@code Object}
      * @param defaultValue supplies the value to encode when the getter returns {@code null}
-     * @return a property encoder for use with {@link #object(PropertyEncoder[])}
+     * @return a property encoder for use with {@link #object(EntryEncoder[])}
      */
     public static <T, V> PropertyEncoder<T> propertyWithDefault(
             String key,
@@ -152,22 +154,85 @@ public final class MapEncoders {
     }
 
     /**
-     * Creates an encoder that builds a {@code Map<String, Object>} from a domain object
-     * by applying each property encoder in order.
+     * Creates an entry encoder that omits the key entirely when the getter returns {@code null}.
      *
-     * <p>The resulting map preserves insertion order (backed by {@link LinkedHashMap}).
-     * Corresponds to {@code combine(...).map(Constructor::new)} on the decoder side.
+     * <p>This is the encode counterpart of
+     * {@link net.unit8.raoh.decode.map.MapDecoders#optionalField optionalField} (which produces
+     * {@code Optional.empty()} for an absent key). Contrast with {@link #nullableProperty}, which
+     * <em>writes</em> the key with a {@code null} value; {@code optionalProperty} leaves the key out.
      *
-     * @param <T>        the domain type to encode
-     * @param properties the property encoders that define the output map entries
+     * @param <T>          the domain type
+     * @param <V>          the property value type
+     * @param key          the output map key
+     * @param getter       extracts the property value; when it returns {@code null} the key is omitted
+     * @param valueEncoder encodes the extracted value (only invoked when non-null) to {@code Object}
+     * @return an entry encoder that writes zero or one entry
+     */
+    public static <T, V> EntryEncoder<T> optionalProperty(
+            String key,
+            Function<? super T, ? extends @Nullable V> getter,
+            Encoder<V, Object> valueEncoder) {
+        return (value, out) -> {
+            @Nullable V v = getter.apply(value);
+            if (v != null) {
+                out.put(key, valueEncoder.encode(v));
+            }
+        };
+    }
+
+    /**
+     * Creates an entry encoder that round-trips a tri-state {@link Presence} value:
+     *
+     * <ul>
+     *   <li>{@link Presence.Absent} — the key is omitted entirely;</li>
+     *   <li>{@link Presence.PresentNull} — the key is written with a {@code null} value;</li>
+     *   <li>{@link Presence.Present} — the key is written with the encoded value.</li>
+     * </ul>
+     *
+     * <p>This is the exact encode counterpart of
+     * {@link net.unit8.raoh.decode.map.MapDecoders#optionalNullableField optionalNullableField}, so a
+     * {@link Presence}-carrying domain field can be decoded in and encoded back out without loss.
+     *
+     * @param <T>          the domain type
+     * @param <V>          the present value type
+     * @param key          the output map key
+     * @param getter       extracts the {@link Presence} field from the domain object
+     * @param valueEncoder encodes the present value (only invoked for {@link Presence.Present}) to {@code Object}
+     * @return an entry encoder that writes zero or one (possibly {@code null}-valued) entry
+     */
+    public static <T, V> EntryEncoder<T> presenceProperty(
+            String key,
+            Function<? super T, ? extends Presence<V>> getter,
+            Encoder<V, Object> valueEncoder) {
+        return (value, out) -> {
+            Presence<V> p = getter.apply(value);
+            switch (p) {
+                case Presence.Absent<V> _ -> { }
+                case Presence.PresentNull<V> _ -> out.put(key, null);
+                case Presence.Present<V> present -> out.put(key, valueEncoder.encode(present.value()));
+            }
+        };
+    }
+
+    /**
+     * Creates an encoder that builds a {@code Map<String, Object>} from a domain object by applying
+     * each entry encoder in order to a shared output map.
+     *
+     * <p>Each {@link EntryEncoder} may write zero, one, or (via {@link #presenceProperty}) a
+     * {@code null}-valued entry; a plain {@link #property} always writes exactly one. The resulting
+     * map preserves insertion order (backed by {@link LinkedHashMap}). Corresponds to
+     * {@code combine(...).map(Constructor::new)} on the decoder side.
+     *
+     * @param <T>     the domain type to encode
+     * @param entries the entry encoders that define the output map entries
      * @return an encoder producing {@code Map<String, Object>}
      */
     @SafeVarargs
-    public static <T> Encoder<T, Map<String, @Nullable Object>> object(PropertyEncoder<T>... properties) {
+    public static <T> Encoder<T, Map<String, @Nullable Object>> object(EntryEncoder<T>... entries) {
         return value -> {
-            var map = new LinkedHashMap<String, @Nullable Object>(properties.length * 2);
-            for (var prop : properties) {
-                map.put(prop.key(), prop.encode(value));
+            var map = new LinkedHashMap<String, @Nullable Object>(entries.length * 2);
+            for (var entry : entries) {
+                entry.encodeTo(value, map);
             }
             return map;
         };
@@ -268,7 +333,7 @@ public final class MapEncoders {
      *
      * <p>The tag is placed first in the resulting {@link LinkedHashMap} and is authoritative: if a
      * variant encoder also emits the discriminator key, that entry is discarded in favour of the
-     * injected tag. The return type matches {@link #object(PropertyEncoder[])}, so the result can be
+     * injected tag. The return type matches {@link #object(EntryEncoder[])}, so the result can be
      * embedded via {@link #nested(Encoder)} or used as a top-level encoder.
      *
      * <p><strong>Exact-class dispatch.</strong> Variants are matched against

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -186,7 +186,9 @@ public final class MapEncoders {
      * <ul>
      *   <li>{@link Presence.Absent} — the key is omitted entirely;</li>
      *   <li>{@link Presence.PresentNull} — the key is written with a {@code null} value;</li>
-     *   <li>{@link Presence.Present} — the key is written with the encoded value.</li>
+     *   <li>{@link Presence.Present} — the key is written with the encoded value (a {@code Present}
+     *       carrying a {@code null} value is written as a {@code null} entry, never passed to the
+     *       value encoder).</li>
      * </ul>
      *
      * <p>This is the exact encode counterpart of
@@ -209,7 +211,10 @@ public final class MapEncoders {
             switch (p) {
                 case Presence.Absent<V> _ -> { }
                 case Presence.PresentNull<V> _ -> out.put(key, null);
-                case Presence.Present<V> present -> out.put(key, valueEncoder.encode(present.value()));
+                case Presence.Present<V> present -> {
+                    @Nullable V v = present.value();
+                    out.put(key, v == null ? null : valueEncoder.encode(v));
+                }
             }
         };
     }

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -235,7 +235,9 @@ public final class MapEncoders {
     @SafeVarargs
     public static <T> Encoder<T, Map<String, @Nullable Object>> object(EntryEncoder<T>... entries) {
         return value -> {
-            var map = new LinkedHashMap<String, @Nullable Object>(entries.length * 2);
+            // No pre-size: an EntryEncoder may write zero or many keys, so the entry count is not a
+            // reliable bound on the output size.
+            var map = new LinkedHashMap<String, @Nullable Object>();
             for (var entry : entries) {
                 entry.encodeTo(value, map);
             }

--- a/raoh/src/main/java/net/unit8/raoh/encode/PropertyEncoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/PropertyEncoder.java
@@ -2,6 +2,7 @@ package net.unit8.raoh.encode;
 
 import org.jspecify.annotations.Nullable;
 
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -18,11 +19,11 @@ import java.util.function.Supplier;
  * </ul>
  *
  * <p>Created via {@link MapEncoders#property(String, Function, Encoder)} and consumed by
- * {@link MapEncoders#object(PropertyEncoder[])}.
+ * {@link MapEncoders#object(EntryEncoder[])}.
  *
  * @param <T> the domain type from which the property is extracted
  */
-public final class PropertyEncoder<T> {
+public final class PropertyEncoder<T> implements EntryEncoder<T> {
 
     private final String key;
     private final Function<T, @Nullable Object> extractor;
@@ -125,5 +126,19 @@ public final class PropertyEncoder<T> {
      */
     public @Nullable Object encode(T value) {
         return extractor.apply(value);
+    }
+
+    /**
+     * Writes this property's single key/value pair into the output map.
+     *
+     * <p>Part of the {@link EntryEncoder} contract: a {@code PropertyEncoder} always writes
+     * exactly one entry (the value may be {@code null}).
+     *
+     * @param value the domain object being encoded
+     * @param out   the output map to write the entry into
+     */
+    @Override
+    public void encodeTo(T value, Map<String, @Nullable Object> out) {
+        out.put(key, encode(value));
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/encode/package-info.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/package-info.java
@@ -8,7 +8,8 @@
  *   <li>{@link net.unit8.raoh.encode.Encoder} — the core encoding interface</li>
  *   <li>{@link net.unit8.raoh.encode.ObjectEncoders} — primitive value encoders</li>
  *   <li>{@link net.unit8.raoh.encode.MapEncoders} — encoders producing {@code Map<String, Object>}</li>
- *   <li>{@link net.unit8.raoh.encode.PropertyEncoder} — field-level encoder</li>
+ *   <li>{@link net.unit8.raoh.encode.PropertyEncoder} — field-level encoder (exactly one key)</li>
+ *   <li>{@link net.unit8.raoh.encode.EntryEncoder} — general map-entry encoder (zero or more keys)</li>
  * </ul>
  */
 @NullMarked

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -12,6 +12,7 @@ import net.unit8.raoh.decode.map.MapDecoders;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static net.unit8.raoh.encode.MapEncoders.*;
 import static net.unit8.raoh.encode.ObjectEncoders.*;
@@ -291,6 +292,15 @@ class MapEncoderTest {
     }
 
     @Test
+    void presencePropertyPresentWithNullValueIsWrittenAsNull() {
+        // A Present carrying a null value (a modeling error, but not enforced at runtime) is
+        // normalized to a null entry and never reaches the non-null value encoder.
+        var out = PATCH_ENCODER.encode(new Patch(new Presence.Present<>(null)));
+        assertTrue(out.containsKey("nickname"));
+        assertNull(out.get("nickname"));
+    }
+
+    @Test
     void presencePropertyRoundTripsThroughOptionalNullableField() {
         // The boundary-completeness test: decode-in (optionalNullableField -> Presence) and
         // encode-out (presenceProperty) are exact inverses across all three states.
@@ -306,6 +316,24 @@ class MapEncoderTest {
             var asInput = (Map<String, Object>) (Map<String, ?>) encoded;
             assertEquals(original, dec.decode(asInput).getOrThrow());
         }
+    }
+
+    @Test
+    void optionalPropertyRoundTripsThroughOptionalField() {
+        // The #41 half: optionalProperty (omit key) and optionalField (-> Optional) are inverses.
+        record Row(@Nullable String note) {}
+        Encoder<Row, Map<String, @Nullable Object>> enc =
+                object(optionalProperty("note", Row::note, string()));
+        Decoder<Map<String, Object>, Optional<String>> dec =
+                MapDecoders.optionalField("note", ObjectDecoders.string());
+
+        @SuppressWarnings("unchecked")
+        var present = (Map<String, Object>) (Map<String, ?>) enc.encode(new Row("hi"));
+        assertEquals(Optional.of("hi"), dec.decode(present).getOrThrow());
+
+        @SuppressWarnings("unchecked")
+        var absent = (Map<String, Object>) (Map<String, ?>) enc.encode(new Row(null));
+        assertEquals(Optional.empty(), dec.decode(absent).getOrThrow());
     }
 
     @Test

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import org.jspecify.annotations.Nullable;
 
+import net.unit8.raoh.Presence;
 import net.unit8.raoh.decode.Decoder;
 import net.unit8.raoh.decode.ObjectDecoders;
 import net.unit8.raoh.decode.map.MapDecoders;
@@ -234,5 +235,91 @@ class MapEncoderTest {
         var out = enc.encode(new Circle(1.0));
         assertEquals("circle", out.get("type"));
         assertEquals(1.0, out.get("radius"));
+    }
+
+    // --- optionalProperty / presenceProperty (#41, #61) ---
+
+    record Membership(long id, @Nullable List<String> groups) {}
+
+    @Test
+    void optionalPropertyOmitsKeyWhenNull() {
+        Encoder<Membership, Map<String, @Nullable Object>> enc = object(
+                property("id", Membership::id, long_()),
+                optionalProperty("groups", Membership::groups, list(string())));
+
+        var present = enc.encode(new Membership(1L, List.of("a", "b")));
+        assertEquals(List.of("a", "b"), present.get("groups"));
+
+        var absent = enc.encode(new Membership(2L, null));
+        assertFalse(absent.containsKey("groups")); // key omitted entirely, not written as null
+    }
+
+    @Test
+    void optionalPropertyVersusNullableProperty() {
+        record Row(@Nullable String note) {}
+        // nullableProperty writes the key with a null value; optionalProperty omits it.
+        var nullable = object(nullableProperty("note", Row::note, string())).encode(new Row(null));
+        assertTrue(nullable.containsKey("note"));
+        assertNull(nullable.get("note"));
+
+        var optional = object(optionalProperty("note", Row::note, string())).encode(new Row(null));
+        assertFalse(optional.containsKey("note"));
+    }
+
+    record Patch(Presence<String> nickname) {}
+
+    static final Encoder<Patch, Map<String, @Nullable Object>> PATCH_ENCODER =
+            object(presenceProperty("nickname", Patch::nickname, string()));
+
+    @Test
+    void presencePropertyAbsentOmitsKey() {
+        var out = PATCH_ENCODER.encode(new Patch(new Presence.Absent<>()));
+        assertFalse(out.containsKey("nickname"));
+    }
+
+    @Test
+    void presencePropertyPresentNullWritesNull() {
+        var out = PATCH_ENCODER.encode(new Patch(new Presence.PresentNull<>()));
+        assertTrue(out.containsKey("nickname"));
+        assertNull(out.get("nickname"));
+    }
+
+    @Test
+    void presencePropertyPresentWritesEncodedValue() {
+        var out = PATCH_ENCODER.encode(new Patch(new Presence.Present<>("bob")));
+        assertEquals("bob", out.get("nickname"));
+    }
+
+    @Test
+    void presencePropertyRoundTripsThroughOptionalNullableField() {
+        // The boundary-completeness test: decode-in (optionalNullableField -> Presence) and
+        // encode-out (presenceProperty) are exact inverses across all three states.
+        Decoder<Map<String, Object>, Presence<String>> dec =
+                MapDecoders.optionalNullableField("nickname", ObjectDecoders.string());
+
+        for (Presence<String> original : List.<Presence<String>>of(
+                new Presence.Absent<>(),
+                new Presence.PresentNull<>(),
+                new Presence.Present<>("bob"))) {
+            var encoded = PATCH_ENCODER.encode(new Patch(original));
+            @SuppressWarnings("unchecked")
+            var asInput = (Map<String, Object>) (Map<String, ?>) encoded;
+            assertEquals(original, dec.decode(asInput).getOrThrow());
+        }
+    }
+
+    @Test
+    void objectMixesPropertyKinds() {
+        record User(long id, @Nullable String bio, Presence<String> nickname) {}
+        Encoder<User, Map<String, @Nullable Object>> enc = object(
+                property("id", User::id, long_()),
+                optionalProperty("bio", User::bio, string()),
+                presenceProperty("nickname", User::nickname, string()));
+
+        var full = enc.encode(new User(1L, "hi", new Presence.Present<>("bob")));
+        assertEquals(List.of("id", "bio", "nickname"), full.keySet().stream().toList());
+
+        var sparse = enc.encode(new User(2L, null, new Presence.Absent<>()));
+        assertEquals(List.of("id"), sparse.keySet().stream().toList()); // bio + nickname omitted
     }
 }


### PR DESCRIPTION
Closes #41. Closes #61.

## Why

Raoh's thesis (README) is *parse-don't-validate*: the domain is protected by a formal, **bidirectional** boundary. For that to hold, the encoder must express everything the decoder produces — otherwise users are pushed to breach the discipline (imperative `Map` building / Jackson), the exact failure Raoh exists to prevent. Two leaks are sealed here (the presence/optionality half of the boundary).

## The one generalization

Today an "entry" writes **exactly one** key (`PropertyEncoder`). Introduce **`EntryEncoder<T>`** — an entry that writes **zero-or-more** keys into the output map. `PropertyEncoder` becomes a special case (always one).

## What this unlocks

- **`optionalProperty(key, getter, valueEncoder)`** (#41) — omits the key when the getter returns `null`. The encode dual of decode's `optionalField` (→ `Optional`). Distinct from `nullableProperty`, which *writes* `key: null`.
- **`presenceProperty(key, getter, valueEncoder)`** (#61) — round-trips the tri-state `Presence`: `Absent` → omit key, `PresentNull` → write `null`, `Present(v)` → write encoded value. The exact inverse of decode's `optionalNullableField`. This was the sharpest leak: a type Raoh's own decoder *produces* but the encoder couldn't consume.

`object(...)` is collapsed to a single `object(EntryEncoder<T>...)`; `PropertyEncoder implements EntryEncoder`, so existing `object(property(...), ...)` call sites still compile.

**Out of scope (deliberately):** `spread()` — once `EntryEncoder` is public, dynamic expansion is a one-line user lambda (`(v, out) -> out.putAll(v.someMap())`), so a named `spread` adds surface without expressive power. `#62 lazy` / `#63 mapOf` — separate follow-up.

## The money test

`presencePropertyRoundTripsThroughOptionalNullableField`: a `Presence<String>` field encoded via `presenceProperty` and decoded back via `optionalNullableField` is identical across all three states (Absent / PresentNull / Present) — proving the boundary is complete for `Presence`.

## Verification

- `raoh` module tests green (MapEncoderTest 28, +8 new; NestedEncoderTest unchanged → the `object` collapse is source-compatible).
- Full reactor `mvn test` green.
- NullAway `nullcheck` gate clean.
- `mvn javadoc:javadoc` clean (no warnings; repo forbids doclint suppression).

**BREAKING CHANGE** (pre-1.0 SNAPSHOT): `MapEncoders.object(PropertyEncoder<T>...)` → `object(EntryEncoder<T>...)`. Source-compatible; only the binary signature changed, and 0.5.0's encode API is already broken by the 0.6.0 property-layer change, so there's no released contract to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)