### PR TITLE
feat(encode): add mapOf() — value-map encoder mirroring ObjectDecoders.map (#63)

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -309,7 +309,8 @@ public final class MapEncoders {
      */
     public static <V> Encoder<Map<String, V>, Object> mapOf(Encoder<V, Object> valueEncoder) {
         return values -> {
-            var out = new LinkedHashMap<String, Object>();
+            // Output size is exactly the input size (one entry per value), so pre-size to avoid rehashes.
+            var out = LinkedHashMap.<String, Object>newLinkedHashMap(values.size());
             values.forEach((key, value) -> out.put(key, valueEncoder.encode(value)));
             return out;
         };

--- a/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/MapEncoders.java
@@ -290,6 +290,32 @@ public final class MapEncoders {
     }
 
     /**
+     * Creates an encoder that applies a value encoder to every value of a homogeneous
+     * {@code Map<String, V>}, preserving the keys.
+     *
+     * <p>The encode counterpart of
+     * {@link net.unit8.raoh.decode.ObjectDecoders#map(net.unit8.raoh.decode.Decoder) ObjectDecoders.map()}
+     * on the decoder side, so a value-map decoded in can be encoded back out. The result preserves
+     * insertion order (backed by {@link LinkedHashMap}). Like {@link #list}, this is the map sibling
+     * for a homogeneous collection; use it with {@link #nested} to encode a map of nested objects:
+     *
+     * <pre>{@code
+     * property("prices", Order::prices, mapOf(decimal()))
+     * }</pre>
+     *
+     * @param <V>          the value domain type
+     * @param valueEncoder the encoder for each map value
+     * @return an encoder that produces {@code Map<String, Object>}
+     */
+    public static <V> Encoder<Map<String, V>, Object> mapOf(Encoder<V, Object> valueEncoder) {
+        return values -> {
+            var out = new LinkedHashMap<String, Object>();
+            values.forEach((key, value) -> out.put(key, valueEncoder.encode(value)));
+            return out;
+        };
+    }
+
+    /**
      * A single tagged variant of a discriminated (tagged-union) encoder: the concrete subtype,
      * the discriminator tag written for it, and the encoder that produces its body.
      *

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -10,6 +10,7 @@ import net.unit8.raoh.decode.ObjectDecoders;
 import net.unit8.raoh.decode.map.MapDecoders;
 
 import java.math.BigDecimal;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -349,5 +350,40 @@ class MapEncoderTest {
 
         var sparse = enc.encode(new User(2L, null, new Presence.Absent<>()));
         assertEquals(List.of("id"), sparse.keySet().stream().toList()); // bio + nickname omitted
+    }
+
+    // --- mapOf (#63) ---
+
+    @Test
+    void mapOfEncodesEachValuePreservingKeysAndOrder() {
+        Encoder<Map<String, BigDecimal>, Object> enc = mapOf(decimal());
+        var domain = new LinkedHashMap<String, BigDecimal>();
+        domain.put("usd", new BigDecimal("100"));
+        domain.put("eur", new BigDecimal("90"));
+
+        @SuppressWarnings("unchecked")
+        var out = (Map<String, Object>) enc.encode(domain);
+        assertEquals(new BigDecimal("100"), out.get("usd"));
+        assertEquals(new BigDecimal("90"), out.get("eur"));
+        assertEquals(List.of("usd", "eur"), out.keySet().stream().toList());
+    }
+
+    @Test
+    void mapOfEncodesEmptyMap() {
+        @SuppressWarnings("unchecked")
+        var out = (Map<String, Object>) mapOf(decimal()).encode(Map.of());
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    void mapOfRoundTripsThroughObjectDecodersMap() {
+        // The value-map is the encode counterpart of ObjectDecoders.map:
+        // decode-in and encode-out are inverses.
+        Encoder<Map<String, BigDecimal>, Object> enc = mapOf(decimal());
+        Decoder<@Nullable Object, Map<String, BigDecimal>> dec =
+                ObjectDecoders.map(ObjectDecoders.decimal());
+
+        var domain = Map.of("usd", new BigDecimal("100"), "eur", new BigDecimal("90"));
+        assertEquals(domain, dec.decode(enc.encode(domain)).getOrThrow());
     }
 }


### PR DESCRIPTION
Closes #63.

## Why

The decoder side has `ObjectDecoders.map(dec)` — a homogeneous value-map decoder producing `Map<String, V>` (dictionaries, currency/rate tables, i18n, dynamic attributes). The encoder side had `object(...)` for **fixed** keys and `list(...)` for sequences, but **nothing for a dynamic-key value-map**. So a `Map<String, V>` decoded in through the boundary could not be encoded back out through it, forcing an imperative loop or Jackson — a boundary breach for a shape the decoder explicitly produces.

Unlike `#62 lazy` (shelved — expressible as a functional-interface one-liner), a value-map encoder cannot be a one-liner: it requires iterating and rebuilding the map. And `object`/`list` cannot cover it (fixed keys / sequences). `mapOf` is the direct **map sibling of the already-provided `list`** — omitting it was an inconsistency.

## What

```java
public static <V> Encoder<Map<String, V>, Object> mapOf(Encoder<V, Object> valueEncoder)
```

Applies the value encoder to every value, preserves keys and insertion order (`LinkedHashMap`), and returns its output as `Object` — mirroring `list()`, so it composes as a value encoder:

```java
property("prices", Order::prices, mapOf(decimal()))
```

## The round-trip test

`mapOfRoundTripsThroughObjectDecodersMap`: a `Map<String, BigDecimal>` encoded via `mapOf(decimal())` and decoded back via `ObjectDecoders.map(decimal())` is identical — proving the two are inverses and the value-map boundary is complete.

## Verification

- `raoh` module tests green (MapEncoderTest 33, +3 new).
- Full reactor `mvn test` green.
- NullAway `nullcheck` gate clean.
- `mvn javadoc:javadoc` clean.

Additive, non-breaking. Completes the homogeneous-collection encoder pair (`list` for sequences, `mapOf` for value-maps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)