### PR TITLE
build: add JaCoCo coverage reporting, surfaced in CI (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       # a downloadable HTML artifact. Reporting only — no coverage thresholds.
       - name: Coverage summary
         if: always()
+        # Reporting only: never let a summary-parsing hiccup red an otherwise-green build.
+        continue-on-error: true
         run: |
           {
             echo "## Coverage (line)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,33 @@ jobs:
           cache: maven
       - name: Build and test
         run: mvn -B --no-transfer-progress verify
+      # JaCoCo (configured in the parent pom) writes per-module reports under
+      # target/site/jacoco during `verify`. Surface them as a job-summary table and
+      # a downloadable HTML artifact. Reporting only — no coverage thresholds.
+      - name: Coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Coverage (line)"
+            echo "| Module | Covered/Total | % |"
+            echo "|---|---|---|"
+            for f in $(find . -path '*/target/site/jacoco/jacoco.xml' | sort); do
+              mod=$(echo "$f" | sed -E 's#\./([^/]+)/target.*#\1#')
+              c=$(grep -o '<counter type="LINE" missed="[0-9]*" covered="[0-9]*"/>' "$f" | tail -1)
+              missed=$(echo "$c" | sed -E 's/.*missed="([0-9]*)".*/\1/')
+              covered=$(echo "$c" | sed -E 's/.*covered="([0-9]*)".*/\1/')
+              total=$((missed + covered))
+              pct=$(awk "BEGIN{ if ($total>0) printf \"%.1f\", 100*$covered/$total; else print \"n/a\" }")
+              echo "| $mod | $covered/$total | ${pct}% |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage
+          path: '**/target/site/jacoco/'
+          if-no-files-found: warn
 
   nullcheck:
     name: NullAway null-analysis gate (JDK 25)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ version once as a property — use the latest shown on the Maven Central badge a
 mvn clean test
 ```
 
+`mvn verify` additionally runs [JaCoCo](https://www.jacoco.org/jacoco/) and writes a
+per-module coverage report to `target/site/jacoco/` (reporting only — no thresholds are
+enforced). CI publishes the same reports as a job-summary table and a downloadable artifact.
+
 ## Package Layout
 
 ### Core (`raoh`)

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,32 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
             </plugin>
+            <!--
+                Code coverage. 0.8.14+ is required for Java 25 (class file major version 69);
+                older versions fail with "Unsupported class file major version 69". prepare-agent
+                instruments the tests; report emits per-module HTML/XML under target/site/jacoco.
+                Reporting only — no coverage thresholds enforced.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
Closes #57.

## Tool choice (2026 re-check)

For a pure-Java, Maven, JDK 25 project, **JaCoCo is still the right choice in 2026** — the de-facto JVM coverage standard, actively maintained. The one modern alternative, [Kover](https://github.com/Kotlin/kotlinx-kover), is Kotlin-native / Gradle-first and doesn't fit. The one hard requirement: **JaCoCo ≥ 0.8.14**, which added official Java 25 support — older versions fail with `Unsupported class file major version 69`. Pinned to `0.8.14`.

## What

- `jacoco-maven-plugin` `0.8.14` in the parent `pom.xml`: `prepare-agent` instruments the tests; `report` (bound to `verify`) emits a per-module HTML/XML report under `target/site/jacoco/`. **Reporting only — no thresholds enforced** (a possible follow-up, per the issue).
- **CI** surfaces coverage from the existing Build & Test job (no new job):
  - a **job-summary table** of per-module line coverage, and
  - the HTML reports as a downloadable **artifact** (`jacoco-coverage`).
- README note under *Building from source*.

## Why it's worth it

1.0 trust hygiene, not a growth lever — but it makes the gaps **measurable**. The first run already quantifies them:

| Module | Line coverage |
|---|---|
| raoh | ~61% |
| raoh-json | ~67% |
| raoh-jooq | ~70% |
| raoh-gsh | ~97% |
| raoh-gsh-weaver | ~45% |
| raoh-gsh-maven-plugin | no tests → no report |

The two low spots (the bytecode weaver, and the untested Maven plugin) are exactly the risk **#56** targets.

## Verification

- Full `mvn verify` green with JaCoCo active — **no conflict between the JaCoCo agent and the gsh bytecode weaving** (gsh tests pass), reports generate for all five tested modules.
- The CI summary-parsing script was validated locally against the generated `jacoco.xml` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)