### PR TITLE
test(gsh): cover GuardWeaveMojo — the weave goal's directory gating (#56)

### DIFF
--- a/raoh-gsh-maven-plugin/pom.xml
+++ b/raoh-gsh-maven-plugin/pom.xml
@@ -36,6 +36,12 @@
             <version>3.15.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/GuardWeaveMojoTest.java
+++ b/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/GuardWeaveMojoTest.java
@@ -72,11 +72,11 @@ class GuardWeaveMojoTest {
         set(mojo, "packages", FIXTURE_PACKAGE_GLOB);
         set(mojo, "target", mainDir.toString());
         set(mojo, "testTarget", testDir.toString());
-        set(mojo, "weaveMain", false);
+        // weaveMain is left unset → the field's default (false) must gate off main weaving.
         mojo.execute();
 
         assertTrue(isWoven(testClass), "the guard must be woven into test classes");
-        assertFalse(isWoven(mainClass), "main classes must NOT be woven when weaveMain=false");
+        assertFalse(isWoven(mainClass), "main classes must NOT be woven by default");
     }
 
     @Test

--- a/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/GuardWeaveMojoTest.java
+++ b/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/GuardWeaveMojoTest.java
@@ -1,0 +1,151 @@
+package net.unit8.raoh.gsh.maven;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link GuardWeaveMojo}, exercising the {@code weave} goal's behaviour directly by
+ * invoking {@link GuardWeaveMojo#execute()} against temp class directories.
+ *
+ * <p>Rather than the maven-plugin-testing-harness (which is JUnit&nbsp;4 centric), the mojo is
+ * driven as a plain object: its {@code @Parameter} fields are set by reflection and {@code execute()}
+ * is called. That covers exactly what this issue asks — which directories get woven — without the
+ * harness's plexus/test-pom machinery. The guard-injection semantics themselves are covered by
+ * {@code GuardWeaverTest} in raoh-gsh-weaver.
+ *
+ * <p>"Woven" is detected by the {@code checkActive} marker: the weaver injects an
+ * {@code invokestatic DomainConstructionScope.checkActive} into each guarded constructor, so a woven
+ * class file contains the string {@code "checkActive"} in its constant pool; an unwoven one does not.
+ */
+class GuardWeaveMojoTest {
+
+    private static final String FIXTURE_INTERNAL = "net/unit8/raoh/gsh/maven/fixture/SampleDomain";
+    private static final String FIXTURE_FQCN = "net.unit8.raoh.gsh.maven.fixture.SampleDomain";
+    private static final String FIXTURE_PACKAGE_GLOB = "net.unit8.raoh.gsh.maven.fixture.**";
+
+    /** Reads the compiled fixture class bytes from the test classpath. */
+    private static byte[] fixtureBytes() throws IOException {
+        try (var in = GuardWeaveMojoTest.class.getResourceAsStream("/" + FIXTURE_INTERNAL + ".class")) {
+            assertNotNull(in, "SampleDomain.class fixture must be on the test classpath");
+            return in.readAllBytes();
+        }
+    }
+
+    /** Writes the fixture class into {@code dir} at its package path and returns the class file. */
+    private static Path writeFixture(Path dir) throws IOException {
+        Path classFile = dir.resolve(FIXTURE_INTERNAL + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, fixtureBytes());
+        return classFile;
+    }
+
+    /** True if the class file contains the injected guard call. */
+    private static boolean isWoven(Path classFile) throws IOException {
+        var text = new String(Files.readAllBytes(classFile), StandardCharsets.ISO_8859_1);
+        return text.contains("checkActive");
+    }
+
+    private static void set(GuardWeaveMojo mojo, String field, Object value) throws ReflectiveOperationException {
+        var f = GuardWeaveMojo.class.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(mojo, value);
+    }
+
+    @Test
+    void weavesTestClassesButNotMainByDefault(@TempDir Path tmp) throws Exception {
+        Path mainDir = Files.createDirectories(tmp.resolve("classes"));
+        Path testDir = Files.createDirectories(tmp.resolve("test-classes"));
+        Path mainClass = writeFixture(mainDir);
+        Path testClass = writeFixture(testDir);
+
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "packages", FIXTURE_PACKAGE_GLOB);
+        set(mojo, "target", mainDir.toString());
+        set(mojo, "testTarget", testDir.toString());
+        set(mojo, "weaveMain", false);
+        mojo.execute();
+
+        assertTrue(isWoven(testClass), "the guard must be woven into test classes");
+        assertFalse(isWoven(mainClass), "main classes must NOT be woven when weaveMain=false");
+    }
+
+    @Test
+    void weavesMainClassesWhenWeaveMainTrue(@TempDir Path tmp) throws Exception {
+        Path mainDir = Files.createDirectories(tmp.resolve("classes"));
+        Path testDir = Files.createDirectories(tmp.resolve("test-classes"));
+        Path mainClass = writeFixture(mainDir);
+        Path testClass = writeFixture(testDir);
+
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "packages", FIXTURE_PACKAGE_GLOB);
+        set(mojo, "target", mainDir.toString());
+        set(mojo, "testTarget", testDir.toString());
+        set(mojo, "weaveMain", true);
+        mojo.execute();
+
+        assertTrue(isWoven(mainClass), "main classes must be woven when weaveMain=true");
+        assertTrue(isWoven(testClass), "test classes are always woven");
+    }
+
+    @Test
+    void classesParameterSelectsByExactFqcn(@TempDir Path tmp) throws Exception {
+        Path testDir = Files.createDirectories(tmp.resolve("test-classes"));
+        Path testClass = writeFixture(testDir);
+
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "classes", FIXTURE_FQCN);
+        set(mojo, "target", tmp.resolve("classes").toString()); // non-existent → skipped
+        set(mojo, "testTarget", testDir.toString());
+        mojo.execute();
+
+        assertTrue(isWoven(testClass), "the guard must be woven when the class is selected by exact name");
+    }
+
+    @Test
+    void excludedClassIsNotWoven(@TempDir Path tmp) throws Exception {
+        Path testDir = Files.createDirectories(tmp.resolve("test-classes"));
+        Path testClass = writeFixture(testDir);
+
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "packages", FIXTURE_PACKAGE_GLOB);
+        set(mojo, "exclude", "net.unit8.raoh.gsh.maven.fixture.**"); // excludes what packages selects
+        set(mojo, "target", tmp.resolve("classes").toString());
+        set(mojo, "testTarget", testDir.toString());
+        mojo.execute();
+
+        assertFalse(isWoven(testClass), "an excluded class must not be woven");
+    }
+
+    @Test
+    void nonMatchingConfigWeavesNothing(@TempDir Path tmp) throws Exception {
+        Path testDir = Files.createDirectories(tmp.resolve("test-classes"));
+        Path testClass = writeFixture(testDir);
+
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "packages", "com.other.**"); // does not match the fixture
+        set(mojo, "target", tmp.resolve("classes").toString());
+        set(mojo, "testTarget", testDir.toString());
+        mojo.execute();
+
+        assertFalse(isWoven(testClass), "no class is woven when the config matches nothing");
+    }
+
+    @Test
+    void missingDirectoriesAreSkippedWithoutError(@TempDir Path tmp) throws Exception {
+        var mojo = new GuardWeaveMojo();
+        set(mojo, "packages", FIXTURE_PACKAGE_GLOB);
+        set(mojo, "target", tmp.resolve("nope-main").toString());
+        set(mojo, "testTarget", tmp.resolve("nope-test").toString());
+        assertDoesNotThrow(mojo::execute, "non-existent class directories must be skipped, not fail");
+    }
+}

--- a/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/fixture/SampleDomain.java
+++ b/raoh-gsh-maven-plugin/src/test/java/net/unit8/raoh/gsh/maven/fixture/SampleDomain.java
@@ -1,0 +1,10 @@
+package net.unit8.raoh.gsh.maven.fixture;
+
+/**
+ * A weavable domain type used only by {@code GuardWeaveMojoTest}: its compiled {@code .class}
+ * file is copied into temp directories and fed to the mojo, which should inject a construction
+ * guard into its constructor.
+ *
+ * @param value an arbitrary value so the record has a constructor to weave
+ */
+public record SampleDomain(String value) {}


### PR DESCRIPTION
Closes #56.

## Why

`raoh-gsh-maven-plugin` shipped with **no tests at all** — `src/test` didn't exist — despite being a published artifact that **rewrites bytecode**. #57's coverage reporting made the hole explicit (the module produced no JaCoCo report because it had no tests). This is the riskiest untested component, so it should not ship untested for 1.0.

## Approach

The mojo is driven **as a plain object**: its `@Parameter` fields are set by reflection and `execute()` is called against temp class directories. This covers exactly what the issue asks — *which directories get woven* — without the [maven-plugin-testing-harness](https://maven.apache.org/plugin-testing/maven-plugin-testing-harness/), which is JUnit-4-centric and would need plexus + a test pom for no added value here. The guard-**injection** semantics are already covered by `GuardWeaverTest` in `raoh-gsh-weaver`.

"Woven" is detected by the injected **`checkActive` marker**: the weaver injects `invokestatic DomainConstructionScope.checkActive` into each guarded constructor, so a woven class file carries `"checkActive"` in its constant pool and an unwoven one does not.

## Covered (6 tests)

- **the AC**: test classes are woven while **main classes are NOT woven by default** (`weaveMain=false`);
- `weaveMain=true` also weaves main;
- selection by `packages` glob and by exact `classes` FQCN;
- `exclude` suppresses an otherwise-matched class;
- a non-matching config weaves nothing;
- missing class directories are skipped without error.

## Result

Module line coverage: **none (no report) → 88.2%** (the 4 uncovered lines are the deliberately-untested thin delegates: config-file load, classpath-properties load, and the `IOException → MojoExecutionException` path). Full reactor `mvn verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)