### PR TITLE
feat(decode): custom-message overloads for ListDecoder/RecordDecoder constraints (#87)

### DIFF
--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
@@ -46,9 +46,19 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the list is empty
      */
     public ListDecoder<I, T> nonempty() {
+        return nonempty(null);
+    }
+
+    /**
+     * Requires the list to be non-empty.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the list is empty
+     */
+    public ListDecoder<I, T> nonempty(@Nullable String message) {
         return chain((value, path) -> {
             if (value.isEmpty()) {
-                return Result.fail(path, ErrorCodes.TOO_SMALL, "must not be empty",
+                return Result.failWith(path, ErrorCodes.TOO_SMALL, message, "must not be empty",
                         Map.of("min", 1, "actual", 0));
             }
             return Result.ok(value);
@@ -62,9 +72,20 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if below
      */
     public ListDecoder<I, T> minSize(int n) {
+        return minSize(n, null);
+    }
+
+    /**
+     * Restricts the list to have at least {@code n} elements.
+     *
+     * @param n       the minimum number of elements (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if below
+     */
+    public ListDecoder<I, T> minSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() < n) {
-                return Result.fail(path, ErrorCodes.TOO_SMALL,
+                return Result.failWith(path, ErrorCodes.TOO_SMALL, message,
                         "must have at least %d elements".formatted(n),
                         Map.of("min", n, "actual", value.size()));
             }
@@ -79,9 +100,20 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if above
      */
     public ListDecoder<I, T> maxSize(int n) {
+        return maxSize(n, null);
+    }
+
+    /**
+     * Restricts the list to have at most {@code n} elements.
+     *
+     * @param n       the maximum number of elements (inclusive)
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if above
+     */
+    public ListDecoder<I, T> maxSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() > n) {
-                return Result.fail(path, ErrorCodes.TOO_BIG,
+                return Result.failWith(path, ErrorCodes.TOO_BIG, message,
                         "must have at most %d elements".formatted(n),
                         Map.of("max", n, "actual", value.size()));
             }
@@ -96,9 +128,20 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the size differs
      */
     public ListDecoder<I, T> fixedSize(int n) {
+        return fixedSize(n, null);
+    }
+
+    /**
+     * Restricts the list to have exactly {@code n} elements.
+     *
+     * @param n       the required number of elements
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the size differs
+     */
+    public ListDecoder<I, T> fixedSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() != n) {
-                return Result.fail(path, ErrorCodes.INVALID_SIZE,
+                return Result.failWith(path, ErrorCodes.INVALID_SIZE, message,
                         "must have exactly %d elements".formatted(n),
                         Map.of("expected", n, "actual", value.size()));
             }
@@ -113,12 +156,23 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#MISSING_ELEMENT} if the element is absent
      */
     public ListDecoder<I, T> contains(T element) {
+        return contains(element, null);
+    }
+
+    /**
+     * Requires the list to contain the specified element.
+     *
+     * @param element the element that must be present
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#MISSING_ELEMENT} if the element is absent
+     */
+    public ListDecoder<I, T> contains(T element, @Nullable String message) {
         Objects.requireNonNull(element, "element must not be null");
-        var message = "must contain %s".formatted(element);
         return chain((value, path) -> {
             if (!value.contains(element)) {
                 var meta = Map.<String, Object>of("expected", element);
-                return Result.fail(path, ErrorCodes.MISSING_ELEMENT, message, meta);
+                return Result.failWith(path, ErrorCodes.MISSING_ELEMENT, message,
+                        "must contain %s".formatted(element), meta);
             }
             return Result.ok(value);
         });
@@ -159,6 +213,16 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
      * @return a new decoder that fails with {@link ErrorCodes#DUPLICATE_ELEMENT} if duplicates are found
      */
     public ListDecoder<I, T> unique() {
+        return unique(null);
+    }
+
+    /**
+     * Requires all elements in the list to be unique (no duplicates).
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#DUPLICATE_ELEMENT} if duplicates are found
+     */
+    public ListDecoder<I, T> unique(@Nullable String message) {
         return chain((value, path) -> {
             var seen = new HashSet<T>();
             LinkedHashSet<T> duplicates = null;
@@ -173,7 +237,7 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
             if (duplicates != null) {
                 var duplicatesList = Collections.unmodifiableList(new ArrayList<>(duplicates));
                 var meta = Map.<String, Object>of("duplicates", duplicatesList);
-                return Result.fail(path, ErrorCodes.DUPLICATE_ELEMENT,
+                return Result.failWith(path, ErrorCodes.DUPLICATE_ELEMENT, message,
                         "must not contain duplicates: %s".formatted(duplicatesList), meta);
             }
             return Result.ok(value);

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
@@ -39,9 +39,19 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map is empty
      */
     public RecordDecoder<I, V> nonempty() {
+        return nonempty(null);
+    }
+
+    /**
+     * Requires the record to have at least one entry.
+     *
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map is empty
+     */
+    public RecordDecoder<I, V> nonempty(@Nullable String message) {
         return chain((value, path) -> {
             if (value.isEmpty()) {
-                return Result.fail(path, ErrorCodes.TOO_SMALL, "must not be empty",
+                return Result.failWith(path, ErrorCodes.TOO_SMALL, message, "must not be empty",
                         Map.of("min", 1, "actual", 0));
             }
             return Result.ok(value);
@@ -55,9 +65,20 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map has fewer entries
      */
     public RecordDecoder<I, V> minSize(int n) {
+        return minSize(n, null);
+    }
+
+    /**
+     * Requires the record to have at least {@code n} entries.
+     *
+     * @param n       the minimum number of entries
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_SMALL} if the map has fewer entries
+     */
+    public RecordDecoder<I, V> minSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() < n) {
-                return Result.fail(path, ErrorCodes.TOO_SMALL,
+                return Result.failWith(path, ErrorCodes.TOO_SMALL, message,
                         "must have at least %d entries".formatted(n),
                         Map.of("min", n, "actual", value.size()));
             }
@@ -72,9 +93,20 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
      * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if the map has more entries
      */
     public RecordDecoder<I, V> maxSize(int n) {
+        return maxSize(n, null);
+    }
+
+    /**
+     * Requires the record to have at most {@code n} entries.
+     *
+     * @param n       the maximum number of entries
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#TOO_BIG} if the map has more entries
+     */
+    public RecordDecoder<I, V> maxSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() > n) {
-                return Result.fail(path, ErrorCodes.TOO_BIG,
+                return Result.failWith(path, ErrorCodes.TOO_BIG, message,
                         "must have at most %d entries".formatted(n),
                         Map.of("max", n, "actual", value.size()));
             }
@@ -89,9 +121,20 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
      * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the map size differs
      */
     public RecordDecoder<I, V> fixedSize(int n) {
+        return fixedSize(n, null);
+    }
+
+    /**
+     * Requires the record to have exactly {@code n} entries.
+     *
+     * @param n       the required number of entries
+     * @param message custom error message, or {@code null} for the default
+     * @return a new decoder that fails with {@link ErrorCodes#INVALID_SIZE} if the map size differs
+     */
+    public RecordDecoder<I, V> fixedSize(int n, @Nullable String message) {
         return chain((value, path) -> {
             if (value.size() != n) {
-                return Result.fail(path, ErrorCodes.INVALID_SIZE,
+                return Result.failWith(path, ErrorCodes.INVALID_SIZE, message,
                         "must have exactly %d entries".formatted(n),
                         Map.of("expected", n, "actual", value.size()));
             }

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/ListDecoderTest.java
@@ -12,7 +12,9 @@ import static net.unit8.raoh.decode.ObjectDecoders.list;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Direct unit tests for {@link ListDecoder}, covering the size, content, and uniqueness
@@ -95,6 +97,70 @@ class ListDecoderTest {
         assertEquals(ErrorCodes.DUPLICATE_ELEMENT, issue.code());
         assertEquals("must not contain duplicates: [1]", issue.message());
         assertEquals(List.of(1), issue.meta().get("duplicates"));
+    }
+
+    // --- custom messages ---
+
+    @Test
+    void nonemptyUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(list(int_()).nonempty("pick at least one"), List.of());
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("pick at least one", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(1, issue.meta().get("min"));
+        assertEquals(0, issue.meta().get("actual"));
+    }
+
+    @Test
+    void minSizeUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(list(int_()).minSize(2, "need two"), List.of(1));
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("need two", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(2, issue.meta().get("min"));
+        assertEquals(1, issue.meta().get("actual"));
+    }
+
+    @Test
+    void maxSizeUsesCustomMessage() {
+        var issue = decodeErr(list(int_()).maxSize(2, "too many"), List.of(1, 2, 3));
+        assertEquals(ErrorCodes.TOO_BIG, issue.code());
+        assertEquals("too many", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    @Test
+    void fixedSizeUsesCustomMessage() {
+        var issue = decodeErr(list(int_()).fixedSize(2, "exactly two"), List.of(1, 2, 3));
+        assertEquals(ErrorCodes.INVALID_SIZE, issue.code());
+        assertEquals("exactly two", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    @Test
+    void containsUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(list(int_()).contains(2, "must include 2"), List.of(1, 3));
+        assertEquals(ErrorCodes.MISSING_ELEMENT, issue.code());
+        assertEquals("must include 2", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(2, issue.meta().get("expected"));
+    }
+
+    @Test
+    void uniqueUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(list(int_()).unique("options must be distinct"), List.of(1, 1, 2));
+        assertEquals(ErrorCodes.DUPLICATE_ELEMENT, issue.code());
+        assertEquals("options must be distinct", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(List.of(1), issue.meta().get("duplicates"));
+    }
+
+    @Test
+    void nullCustomMessageFallsBackToDefault() {
+        // A null message keeps the built-in default and leaves customMessage() false.
+        var issue = decodeErr(list(int_()).minSize(2, null), List.of(1));
+        assertEquals("must have at least 2 elements", issue.message());
+        assertFalse(issue.customMessage());
     }
 
     // --- conversion ---

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/RecordDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/RecordDecoderTest.java
@@ -10,6 +10,8 @@ import static net.unit8.raoh.decode.ObjectDecoders.map;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
 import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Direct unit tests for {@link RecordDecoder}, covering the entry-count constraints.
@@ -49,6 +51,52 @@ class RecordDecoderTest {
         var issue = decodeErr(map(int_()).fixedSize(2), Map.of("a", 1, "b", 2, "c", 3));
         assertEquals(ErrorCodes.INVALID_SIZE, issue.code());
         assertEquals("must have exactly 2 entries", issue.message());
+    }
+
+    // --- custom messages ---
+
+    @Test
+    void nonemptyUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(map(int_()).nonempty("need at least one entry"), Map.of());
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("need at least one entry", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(1, issue.meta().get("min"));
+        assertEquals(0, issue.meta().get("actual"));
+    }
+
+    @Test
+    void minSizeUsesCustomMessageAndKeepsMeta() {
+        var issue = decodeErr(map(int_()).minSize(2, "need two"), Map.of("a", 1));
+        assertEquals(ErrorCodes.TOO_SMALL, issue.code());
+        assertEquals("need two", issue.message());
+        assertTrue(issue.customMessage());
+        assertEquals(2, issue.meta().get("min"));
+        assertEquals(1, issue.meta().get("actual"));
+    }
+
+    @Test
+    void maxSizeUsesCustomMessage() {
+        var issue = decodeErr(map(int_()).maxSize(2, "too many"), Map.of("a", 1, "b", 2, "c", 3));
+        assertEquals(ErrorCodes.TOO_BIG, issue.code());
+        assertEquals("too many", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    @Test
+    void fixedSizeUsesCustomMessage() {
+        var issue = decodeErr(map(int_()).fixedSize(2, "exactly two"), Map.of("a", 1, "b", 2, "c", 3));
+        assertEquals(ErrorCodes.INVALID_SIZE, issue.code());
+        assertEquals("exactly two", issue.message());
+        assertTrue(issue.customMessage());
+    }
+
+    @Test
+    void nullCustomMessageFallsBackToDefault() {
+        // A null message keeps the built-in default and leaves customMessage() false.
+        var issue = decodeErr(map(int_()).minSize(2, null), Map.of("a", 1));
+        assertEquals("must have at least 2 entries", issue.message());
+        assertFalse(issue.customMessage());
     }
 
     // --- base decoder behaviour ---


### PR DESCRIPTION
Closes #87.

## What

`ListDecoder` and `RecordDecoder` were the only builtin decoders whose fluent constraints lacked the `(…, String message)` overloads that `StringDecoder` and the numeric/temporal decoders already provide. This adds them:

- **`ListDecoder`**: `nonempty`, `minSize`, `maxSize`, `fixedSize`, `contains`, `unique`
- **`RecordDecoder`**: `nonempty`, `minSize`, `maxSize`, `fixedSize`

Each new overload routes through the existing `Result.failWith` helper, so a caller-supplied message is marked custom and is **not** overwritten by `Issues.resolve()` — identical semantics to the string/numeric side. A `null` message falls back to the built-in default (and leaves `customMessage()` false).

## Why

Collection constraints are a common **user-facing** form-validation case, not just internal invariants: multi-select "pick at least one", "up to 5", tag pickers' "options must be distinct", etc. This is idiomatic in Zod (`z.array(...).min(1, "…")`), which raoh mirrors. Without these overloads the only way to customise the message was to drop out of the fluent API into a hand-written `(in, path) -> …` lambda.

## Scope note

`ListDecoder.containsAll(T...)` is intentionally **not** given a message overload, matching the existing `StringDecoder.oneOf(String...)` precedent: a trailing `String message` after a varargs parameter cannot be expressed without an ambiguous or awkward signature.

## Tests

Added custom-message tests to `ListDecoderTest` and `RecordDecoderTest` asserting the custom message, `customMessage() == true`, preserved `meta`, and the null-fallback path. Full module suite: 413 tests, all green; javadoc clean (no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
