### PR TITLE
feat(json+decode): double_()/float_() JSON primitives; reject out-of-range across both boundaries (#86)

### DIFF
--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -133,11 +133,16 @@ public final class JsonDecoders {
                         Map.of("expected", "double", "actual", in.getNodeType().name().toLowerCase()));
             }
             try {
-                return Result.ok(in.doubleValue());
+                double v = in.doubleValue();
+                // A very large integer node makes Jackson 3's doubleValue() throw (caught below); a
+                // large decimal node instead yields an infinity. Reject both as out-of-range rather
+                // than returning Infinity or letting the unchecked exception escape decode().
+                if (Double.isInfinite(v)) {
+                    return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
+                            Map.of("expected", "double"));
+                }
+                return Result.ok(v);
             } catch (JsonNodeException e) {
-                // Jackson 3's doubleValue() is strict: it throws when the numeric node does not fit
-                // a finite double. Convert that to a decode error rather than letting an unchecked
-                // exception escape decode().
                 return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
                         Map.of("expected", "double"));
             }

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -13,6 +13,8 @@ import net.unit8.raoh.decode.Decoders;
 import net.unit8.raoh.decode.FieldDecoder;
 import net.unit8.raoh.decode.builtin.BoolDecoder;
 import net.unit8.raoh.decode.builtin.DecimalDecoder;
+import net.unit8.raoh.decode.builtin.DoubleDecoder;
+import net.unit8.raoh.decode.builtin.FloatDecoder;
 import net.unit8.raoh.decode.builtin.IntDecoder;
 import net.unit8.raoh.decode.builtin.ListDecoder;
 import net.unit8.raoh.decode.builtin.LongDecoder;
@@ -108,6 +110,51 @@ public final class JsonDecoders {
                         Map.of("expected", "long", "actual", in.getNodeType().name().toLowerCase()));
             }
             return Result.ok(in.longValue());
+        });
+    }
+
+    /**
+     * Creates a double decoder.
+     *
+     * <p>Accepts any JSON number (integer or floating-point) and reads it via
+     * {@link JsonNode#doubleValue()}. This mirrors {@link #decimal()} in accepting the whole
+     * numeric range; use {@code double_()} when the domain wants a primitive {@code double}
+     * (and the {@link DoubleDecoder} constraint API) rather than a {@link java.math.BigDecimal}.
+     *
+     * @return a decoder that extracts a double value from a JSON node
+     */
+    public static DoubleDecoder<JsonNode> double_() {
+        return new DoubleDecoder<>((in, path) -> {
+            if (in == null || in.isNull() || in.isMissingNode()) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (!in.isNumber()) {
+                return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
+                        Map.of("expected", "double", "actual", in.getNodeType().name().toLowerCase()));
+            }
+            return Result.ok(in.doubleValue());
+        });
+    }
+
+    /**
+     * Creates a float decoder.
+     *
+     * <p>Accepts any JSON number (integer or floating-point) and narrows it via
+     * {@link JsonNode#floatValue()}. Like {@link #double_()}, but produces a primitive
+     * {@code float}; values outside the {@code float} range narrow per Java's usual rules.
+     *
+     * @return a decoder that extracts a float value from a JSON node
+     */
+    public static FloatDecoder<JsonNode> float_() {
+        return new FloatDecoder<>((in, path) -> {
+            if (in == null || in.isNull() || in.isMissingNode()) {
+                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            }
+            if (!in.isNumber()) {
+                return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
+                        Map.of("expected", "float", "actual", in.getNodeType().name().toLowerCase()));
+            }
+            return Result.ok(in.floatValue());
         });
     }
 

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -168,10 +168,16 @@ public final class JsonDecoders {
                         Map.of("expected", "float", "actual", in.getNodeType().name().toLowerCase()));
             }
             try {
-                return Result.ok(in.floatValue());
+                float v = in.floatValue();
+                // Jackson 3's floatValue() throws for most out-of-range nodes (caught below), but
+                // enforce the finite contract explicitly too — a node that narrows to Infinity
+                // without throwing must still be rejected, matching double_().
+                if (Float.isInfinite(v)) {
+                    return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
+                            Map.of("expected", "float"));
+                }
+                return Result.ok(v);
             } catch (JsonNodeException e) {
-                // See double_(): Jackson 3's floatValue() throws for a value outside the finite
-                // float range; surface it as a decode error instead.
                 return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
                         Map.of("expected", "float"));
             }

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -24,6 +24,7 @@ import net.unit8.raoh.decode.combinator.*;
 
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.exc.JsonNodeException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -116,10 +117,9 @@ public final class JsonDecoders {
     /**
      * Creates a double decoder.
      *
-     * <p>Accepts any JSON number (integer or floating-point) and reads it via
-     * {@link JsonNode#doubleValue()}. This mirrors {@link #decimal()} in accepting the whole
-     * numeric range; use {@code double_()} when the domain wants a primitive {@code double}
-     * (and the {@link DoubleDecoder} constraint API) rather than a {@link java.math.BigDecimal}.
+     * <p>Accepts any JSON number; a value that does not fit a finite {@code double}
+     * (e.g. a very large integer literal) fails with {@code type_mismatch}, mirroring how
+     * {@link #int_()} rejects a number that does not fit its target type.
      *
      * @return a decoder that extracts a double value from a JSON node
      */
@@ -132,16 +132,24 @@ public final class JsonDecoders {
                 return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
                         Map.of("expected", "double", "actual", in.getNodeType().name().toLowerCase()));
             }
-            return Result.ok(in.doubleValue());
+            try {
+                return Result.ok(in.doubleValue());
+            } catch (JsonNodeException e) {
+                // Jackson 3's doubleValue() is strict: it throws when the numeric node does not fit
+                // a finite double. Convert that to a decode error rather than letting an unchecked
+                // exception escape decode().
+                return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
+                        Map.of("expected", "double"));
+            }
         });
     }
 
     /**
      * Creates a float decoder.
      *
-     * <p>Accepts any JSON number (integer or floating-point) and narrows it via
-     * {@link JsonNode#floatValue()}. Like {@link #double_()}, but produces a primitive
-     * {@code float}; values outside the {@code float} range narrow per Java's usual rules.
+     * <p>Like {@link #double_()}, but produces a primitive {@code float}; a value that does not
+     * fit a finite {@code float} (e.g. a magnitude above the {@code float} range) fails with
+     * {@code type_mismatch}.
      *
      * @return a decoder that extracts a float value from a JSON node
      */
@@ -154,7 +162,14 @@ public final class JsonDecoders {
                 return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
                         Map.of("expected", "float", "actual", in.getNodeType().name().toLowerCase()));
             }
-            return Result.ok(in.floatValue());
+            try {
+                return Result.ok(in.floatValue());
+            } catch (JsonNodeException e) {
+                // See double_(): Jackson 3's floatValue() throws for a value outside the finite
+                // float range; surface it as a decode error instead.
+                return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
+                        Map.of("expected", "float"));
+            }
         });
     }
 

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -470,18 +470,20 @@ class JsonDecoderTest {
     }
 
     @Test
-    void doubleDecodesFloatingPointAndInteger() {
+    void doubleDecodesFloatingPointAndIntegerAndRejectsNonNumber() {
         var dec = field("v", double_());
-        // A JSON floating-point value.
         assertEquals(3.14, assertOk(dec.decode(parse("{\"v\":3.14}"))), 1e-9);
         // A JSON integer is a valid number and widens to double.
         assertEquals(5.0, assertOk(dec.decode(parse("{\"v\":5}"))), 1e-9);
+        assertErr(dec.decode(parse("{\"v\":\"3.14\"}")));
     }
 
     @Test
-    void doubleRejectsNonNumber() {
+    void doubleRejectsOutOfRangeInsteadOfThrowing() {
         var dec = field("v", double_());
-        assertErr(dec.decode(parse("{\"v\":\"3.14\"}")));
+        // A 401-digit integer does not fit a finite double. Jackson 3's doubleValue() throws for
+        // this; the decoder must convert it to an Err, not let the exception escape decode().
+        assertErr(dec.decode(parse("{\"v\":" + "1" + "0".repeat(400) + "}")));
     }
 
     @Test
@@ -492,10 +494,13 @@ class JsonDecoderTest {
     }
 
     @Test
-    void floatDecodesAndRejectsNonNumber() {
+    void floatDecodesAndRejectsNonNumberAndOutOfRange() {
         var dec = field("v", float_());
         assertEquals(1.5f, assertOk(dec.decode(parse("{\"v\":1.5}"))), 1e-6f);
         assertErr(dec.decode(parse("{\"v\":true}")));
+        // 1e40 is a valid double but outside the finite float range; floatValue() throws in
+        // Jackson 3, so the decoder must reject it rather than propagate the exception.
+        assertErr(dec.decode(parse("{\"v\":1e40}")));
     }
 
     @Test

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -506,6 +506,14 @@ class JsonDecoderTest {
     }
 
     @Test
+    void floatRejectsInfiniteNodeWithoutThrowing() {
+        // A node whose floatValue() yields Infinity directly (rather than throwing) must still be
+        // rejected — this exercises the explicit isInfinite guard, not the exception path.
+        var infiniteNode = mapper.getNodeFactory().numberNode(Float.POSITIVE_INFINITY);
+        assertErr(float_().decode(infiniteNode, Path.ROOT));
+    }
+
+    @Test
     void pipeDecoder() {
         // pipe string decoder to another decoder that parses the string further
         Decoder<String, Integer> parseInt = (in, path) -> {

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -470,6 +470,35 @@ class JsonDecoderTest {
     }
 
     @Test
+    void doubleDecodesFloatingPointAndInteger() {
+        var dec = field("v", double_());
+        // A JSON floating-point value.
+        assertEquals(3.14, assertOk(dec.decode(parse("{\"v\":3.14}"))), 1e-9);
+        // A JSON integer is a valid number and widens to double.
+        assertEquals(5.0, assertOk(dec.decode(parse("{\"v\":5}"))), 1e-9);
+    }
+
+    @Test
+    void doubleRejectsNonNumber() {
+        var dec = field("v", double_());
+        assertErr(dec.decode(parse("{\"v\":\"3.14\"}")));
+    }
+
+    @Test
+    void doubleConstraintApplies() {
+        var dec = field("v", double_().range(0.0, 1.0));
+        assertEquals(0.5, assertOk(dec.decode(parse("{\"v\":0.5}"))), 1e-9);
+        assertErr(dec.decode(parse("{\"v\":2.5}")));
+    }
+
+    @Test
+    void floatDecodesAndRejectsNonNumber() {
+        var dec = field("v", float_());
+        assertEquals(1.5f, assertOk(dec.decode(parse("{\"v\":1.5}"))), 1e-6f);
+        assertErr(dec.decode(parse("{\"v\":true}")));
+    }
+
+    @Test
     void pipeDecoder() {
         // pipe string decoder to another decoder that parses the string further
         Decoder<String, Integer> parseInt = (in, path) -> {

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -484,6 +484,8 @@ class JsonDecoderTest {
         // A 401-digit integer does not fit a finite double. Jackson 3's doubleValue() throws for
         // this; the decoder must convert it to an Err, not let the exception escape decode().
         assertErr(dec.decode(parse("{\"v\":" + "1" + "0".repeat(400) + "}")));
+        // A large decimal literal instead narrows to Infinity (no throw); rejected all the same.
+        assertErr(dec.decode(parse("{\"v\":1e400}")));
     }
 
     @Test

--- a/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
@@ -133,9 +133,9 @@ public final class ObjectDecoders {
     /**
      * Creates a double decoder.
      *
-     * <p>Accepts {@link Double} values directly, and widens other {@link Number} subtypes
-     * via {@link Number#doubleValue()}. Returns {@code required} if the value is {@code null},
-     * and {@code type_mismatch} if the value is not a number.
+     * <p>Accepts any {@link Number} via {@link Number#doubleValue()}. Returns {@code required} if
+     * the value is {@code null}, and {@code type_mismatch} if the value is not a number or its
+     * magnitude is beyond the {@code double} range (i.e. narrows to an infinity).
      *
      * @return a double decoder for {@code Object} input
      */
@@ -144,11 +144,17 @@ public final class ObjectDecoders {
             if (in == null) {
                 return Result.fail(path, ErrorCodes.REQUIRED, "is required");
             }
-            if (in instanceof Double d) {
-                return Result.ok(d);
-            }
             if (in instanceof Number n) {
-                return Result.ok(n.doubleValue());
+                double d = n.doubleValue();
+                // A magnitude beyond the double range (e.g. a huge BigInteger, or Double.INFINITY)
+                // is a representation failure, not a valid value — reject it rather than silently
+                // yielding Infinity. NaN is left to flow through so range constraints can reject it
+                // as out_of_range (see DoubleDecoderTest#rangeRejectsNaN).
+                if (Double.isInfinite(d)) {
+                    return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
+                            Map.of("expected", "double"));
+                }
+                return Result.ok(d);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected double",
                     Map.of("expected", "double", "actual", in.getClass().getSimpleName()));
@@ -158,9 +164,9 @@ public final class ObjectDecoders {
     /**
      * Creates a float decoder.
      *
-     * <p>Accepts {@link Float} values directly, and narrows other {@link Number} subtypes
-     * via {@link Number#floatValue()}. Returns {@code required} if the value is {@code null},
-     * and {@code type_mismatch} if the value is not a number.
+     * <p>Accepts any {@link Number} via {@link Number#floatValue()}. Returns {@code required} if
+     * the value is {@code null}, and {@code type_mismatch} if the value is not a number or its
+     * magnitude is beyond the {@code float} range (i.e. narrows to an infinity).
      *
      * @return a float decoder for {@code Object} input
      */
@@ -169,11 +175,15 @@ public final class ObjectDecoders {
             if (in == null) {
                 return Result.fail(path, ErrorCodes.REQUIRED, "is required");
             }
-            if (in instanceof Float f) {
-                return Result.ok(f);
-            }
             if (in instanceof Number n) {
-                return Result.ok(n.floatValue());
+                float f = n.floatValue();
+                // See double_(): a value beyond the float range narrows to Infinity — reject it as a
+                // representation failure. NaN flows through for range constraints to catch.
+                if (Float.isInfinite(f)) {
+                    return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
+                            Map.of("expected", "float"));
+                }
+                return Result.ok(f);
             }
             return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected float",
                     Map.of("expected", "float", "actual", in.getClass().getSimpleName()));

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/DoubleDecoderTest.java
@@ -68,6 +68,15 @@ class DoubleDecoderTest {
     }
 
     @Test
+    void rejectsOutOfRangeMagnitude() {
+        // A magnitude beyond the double range narrows to Infinity; the base decoder rejects it
+        // rather than silently yielding Infinity.
+        var huge = new java.math.BigInteger("1" + "0".repeat(400));
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(double_(), huge).code());
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(double_(), Double.POSITIVE_INFINITY).code());
+    }
+
+    @Test
     void rangeRejectsInvertedBoundsAtConstruction() {
         assertThrows(IllegalArgumentException.class, () -> double_().range(10.0, 1.0));
     }

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/FloatDecoderTest.java
@@ -67,6 +67,13 @@ class FloatDecoderTest {
     }
 
     @Test
+    void rejectsOutOfRangeMagnitude() {
+        // 1e40 exceeds the float range; narrowing gives Infinity, which the base decoder rejects.
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(float_(), 1e40).code());
+        assertEquals(ErrorCodes.TYPE_MISMATCH, decodeErr(float_(), Float.POSITIVE_INFINITY).code());
+    }
+
+    @Test
     void rangeRejectsInvertedBoundsAtConstruction() {
         assertThrows(IllegalArgumentException.class, () -> float_().range(10.0f, 1.0f));
     }


### PR DESCRIPTION
Partially addresses #86 (the `double_()`/`float_()` half; temporals deferred — see below).

## What

1. **Adds `double_()` / `float_()` to `JsonDecoders`** — the JSON boundary lacked floating-point primitives, so a JSON number could only reach a `BigDecimal` via `decimal()`, never a primitive `double`/`float` or the `DoubleDecoder`/`FloatDecoder` constraint API. Closes that parity gap with `ObjectDecoders`.
2. **Rejects out-of-range magnitudes on both boundaries** — a value whose magnitude exceeds the target type (narrows to Infinity) now fails with `type_mismatch` instead of silently becoming `Infinity` (Object side) or throwing an unchecked exception out of `decode()` (JSON side).

## Why #2 was necessary (found in review)

Jackson 3 made `JsonNode.doubleValue()`/`floatValue()` **strict**: they throw an unchecked `JsonNodeException` when a numeric node doesn't fit a finite double/float. `float_()` on `1e40` — a perfectly ordinary JSON number well within the double range — threw straight out of `decode()`, defeating the `Result` channel. The JSON decoders now catch that (and the analogous Infinity-without-throw case for large decimal literals) and return a clean `Err`.

While aligning this, `ObjectDecoders.double_()`/`float_()` were found to silently return `Infinity` for the same out-of-range inputs (`Number.doubleValue()` never throws). Both boundaries now share one contract: **out-of-range magnitude → `type_mismatch`**, mirroring how `int_()` rejects a number that doesn't fit its target type. `NaN` is deliberately still passed through so `range()` constraints catch it as `out_of_range` (preserving the documented `rangeRejectsNaN` behavior).

No new error codes; `type_mismatch` is reused, so the `ErrorCodesDefaultCoverageTest` machinery is untouched.

## Temporals — intentionally out of scope

A `JsonNode` temporal is always a string (JSON has no date type), so `JsonDecoders.date()` could only alias `string().date()` — zero added capability. `string().iso8601()`/`date()`/`dateTime()` is the canonical path; that half of #86 is to be resolved by documentation, not new primitives. #86 stays open for it.

## Tests

- `JsonDecoderTest`: floating-point/integer decode, non-number reject, `range()` round-trip, and **out-of-range regression guards** for both the throwing (large integer) and Infinity (large decimal) paths.
- `DoubleDecoderTest`/`FloatDecoderTest`: new out-of-range rejection tests; existing `rangeRejectsNaN` still green (NaN passthrough preserved).
- raoh core: 415 tests; raoh-json: 75 tests; NullAway gate passes; javadoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
