### PR TITLE
docs(json): document string() as the canonical path for JSON temporals (#86)

### DIFF
--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -45,6 +45,17 @@ import java.util.Set;
  *     field("age", int_().range(0, 150))
  * ).map(User::new);
  * }</pre>
+ *
+ * <p><strong>Temporals.</strong> There are intentionally no temporal primitives here
+ * (no {@code date()} / {@code dateTime()} / {@code iso8601()} factory). A JSON temporal is
+ * always a string, so decode it through {@link #string()} and one of its temporal conversions —
+ * {@code string().date()}, {@code string().time()}, {@code string().dateTime()},
+ * {@code string().offsetDateTime()}, or {@code string().iso8601()} for an {@link java.time.Instant}:
+ *
+ * <pre>{@code
+ * field("bornOn",    string().date())            // LocalDate
+ * field("createdAt", string().iso8601())         // Instant
+ * }</pre>
  */
 public final class JsonDecoders {
 


### PR DESCRIPTION
Completes #86 (the temporals half; `double_()`/`float_()` shipped in #89).

## What

Adds a **Temporals** note to the `JsonDecoders` class Javadoc stating that there are intentionally no temporal primitives, and pointing to the canonical `string().date()` / `time()` / `dateTime()` / `offsetDateTime()` / `iso8601()` path.

## Why docs, not code

A `JsonNode` temporal is always a string (JSON has no date type), so a `JsonDecoders.date()` factory could only ever alias `string().date()` — zero added capability, and it would misleadingly imply JSON has a native date concept. Documenting the string path makes the absence discoverably intentional rather than an oversight.

Docs-only change (no code, no tests). javadoc clean (no warnings); compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
