### PR TITLE
docs(tutorial): pipe pattern for decoding JSON-in-a-string (#85)

### DIFF
--- a/docs/tutorial.ja.md
+++ b/docs/tutorial.ja.md
@@ -505,6 +505,54 @@ pricesDec.decode(Map.of("prices", Map.of("apple", 120, "banana", 80)))
 // ==> Ok[{apple=120, banana=80}]
 ```
 
+### 文字列に格納された JSON をデコードする
+
+JSON を文字列として持つケースはよくあります。`VARCHAR` カラムに JSON を保存する、あるいは JSON ボディのフィールド値自体が JSON 文字列（二重エンコード）になっている、といった形です。素朴に書くと、Jackson で手パースして例外を握り潰しがちです。
+
+```java
+// アンチパターン: パース失敗が空マップに化けて、エラーが闇に消える
+field("params", string()).map(s -> {
+    try { return mapper.readValue(s, Map.class); }
+    catch (Exception e) { return Map.of(); }   // silent data loss
+});
+```
+
+これでは不正な行が「空の params を持つ正常な行」になり、Raoh の issue 蓄積モデルが台無しです。
+
+`pipe` を使えば、パース段を「失敗を issue として報告するデコーダー」として挟めます。文字列 → パース → 内側のデコーダー、と繋ぐだけです。この例では JSON パーサーとして Jackson を使います（`var mapper = new tools.jackson.databind.ObjectMapper();`。raoh-json を使っているなら既に classpath にあります）。
+
+```java
+// String を JSON としてパースするデコーダー。失敗は握り潰さず issue にする（ここが肝）
+Decoder<String, Map<String, Object>> parseJson = (s, path) -> {
+    try {
+        Map<String, Object> parsed = (Map<String, Object>) mapper.readValue(s, Map.class);
+        return Result.ok(parsed);
+    } catch (Exception e) {
+        return Result.fail(path, "invalid_format", "JSONとして解析できません");
+    }
+};
+
+record Params(String kind, int count) {}
+var paramsDec = combine(
+        field("kind",  string()),
+        field("count", int_())
+).map(Params::new);
+
+// "params" は JSON を格納した文字列カラム
+var dec = field("params", string().pipe(parseJson).pipe(paramsDec));
+
+dec.decode(Map.of("params", "{\"kind\":\"like\",\"count\":3}"))
+// ==> Ok[Params[kind=like, count=3]]
+
+dec.decode(Map.of("params", "not json"))
+// ==> Err[/params: JSONとして解析できません]
+
+dec.decode(Map.of("params", "{\"kind\":\"like\"}"))
+// ==> Err[/params/count: is required]
+```
+
+パース失敗は `params` のパスに、内側のフィールド不足は `/params/count` のように**ネストしたパス**で報告されます。JSON-in-a-string も最後まで `Result` / `Issues` のパイプラインに留まり、握り潰しが起きません。
+
 ---
 
 ## 9. Optional / Nullable / 三値フィールド

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -503,6 +503,54 @@ pricesDec.decode(Map.of("prices", Map.of("apple", 120, "banana", 80)))
 // ==> Ok[{apple=120, banana=80}]
 ```
 
+### Decoding JSON stored in a string
+
+JSON is often kept as a string — a `VARCHAR` column holding JSON, or a JSON body field whose value is itself a JSON string (double-encoded). The naive approach hand-parses with Jackson and swallows the exception:
+
+```java
+// Anti-pattern: a parse failure becomes an empty map and the error vanishes
+field("params", string()).map(s -> {
+    try { return mapper.readValue(s, Map.class); }
+    catch (Exception e) { return Map.of(); }   // silent data loss
+});
+```
+
+A malformed row then decodes as a "valid row with empty params", defeating Raoh's issue-accumulation model.
+
+With `pipe` you can insert the parse step as a decoder that reports failures as issues: string → parse → inner decoder. This example uses Jackson as the parser (`var mapper = new tools.jackson.databind.ObjectMapper();` — already on your classpath if you use raoh-json).
+
+```java
+// A decoder that parses a String as JSON, reporting failures as issues instead of swallowing them
+Decoder<String, Map<String, Object>> parseJson = (s, path) -> {
+    try {
+        Map<String, Object> parsed = (Map<String, Object>) mapper.readValue(s, Map.class);
+        return Result.ok(parsed);
+    } catch (Exception e) {
+        return Result.fail(path, "invalid_format", "cannot be parsed as JSON");
+    }
+};
+
+record Params(String kind, int count) {}
+var paramsDec = combine(
+        field("kind",  string()),
+        field("count", int_())
+).map(Params::new);
+
+// "params" is a string column holding JSON
+var dec = field("params", string().pipe(parseJson).pipe(paramsDec));
+
+dec.decode(Map.of("params", "{\"kind\":\"like\",\"count\":3}"))
+// ==> Ok[Params[kind=like, count=3]]
+
+dec.decode(Map.of("params", "not json"))
+// ==> Err[/params: cannot be parsed as JSON]
+
+dec.decode(Map.of("params", "{\"kind\":\"like\"}"))
+// ==> Err[/params/count: is required]
+```
+
+A parse failure surfaces at the `params` path; a missing inner field surfaces at a **nested path** like `/params/count`. The JSON-in-a-string stays inside the `Result` / `Issues` pipeline end to end — nothing is swallowed.
+
 ---
 
 ## 9. Optional / Nullable / Three-state fields


### PR DESCRIPTION
Resolves #85 by documentation instead of new API.

## Decision

#85 proposed a `jsonString(subDecoder)` combinator for JSON stored in a string (a `VARCHAR` column, or a double-encoded JSON field). On closer look, this is **already expressible today** with the existing `Decoder.pipe(...)` — you compose a `Decoder<String, Map/JsonNode>` parse step (that reports parse failures as issues) with the inner decoder. The kysymys `deserialiseParams` that swallows malformed JSON into `Map.of()` is a hand-rolled shortcut, not a limitation of Raoh.

Rather than add a thin combinator (and pull a default `ObjectMapper` into the otherwise parse-agnostic `raoh-json`), this documents the correct `pipe` pattern so the non-swallowing path is the discoverable one.

## What

Adds a **"Decoding JSON stored in a string"** subsection to section 8 of both `docs/tutorial.ja.md` and `docs/tutorial.md`:

- the anti-pattern (hand-parse + swallow → silent data loss),
- the `pipe` pattern with a parse decoder that reports failures as `invalid_format` issues,
- worked examples: success, parse failure (`Err[/params: ...]`), and a nested inner error (`Err[/params/count: is required]`).

Snippet verified with jetshell (exact outputs match).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
