### PR TITLE
feat(decode): typed variant()/discriminate(...) mirroring the encoder side (#82)

### DIFF
--- a/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
+++ b/raoh-jooq/src/main/java/net/unit8/raoh/jooq/JooqRecordDecoders.java
@@ -175,6 +175,36 @@ public final class JooqRecordDecoders {
         return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.string()), variants)::decode;
     }
 
+    /**
+     * Creates a {@link Decoders.Variant} for use with {@link #discriminate(String, Decoders.Variant[])},
+     * with the input type pinned to {@link org.jooq.Record}.
+     *
+     * @param <S>     the value type this variant decodes to
+     * @param tag     the discriminator value that selects this variant
+     * @param decoder the decoder producing the variant value
+     * @return a variant for use with {@link #discriminate(String, Decoders.Variant[])}
+     */
+    public static <S> Decoders.Variant<org.jooq.Record, S> variant(
+            String tag, Decoder<org.jooq.Record, S> decoder) {
+        return Decoders.variant(tag, decoder);
+    }
+
+    /**
+     * Typed, cast-free variant of {@link #discriminate(String, Map)}: dispatches on the string value
+     * of the discriminator column. See {@link Decoders#discriminate(String, Decoder, Decoders.Variant[])}.
+     *
+     * @param <T>       the decoded (supertype) type
+     * @param fieldName the discriminator column name (e.g., {@code "type"})
+     * @param variants  the variants, each pairing a tag with its decoder
+     * @return a discriminating decoder
+     * @throws IllegalArgumentException if two variants share the same tag
+     */
+    @SafeVarargs
+    public static <T> JooqRecordDecoder<T> discriminate(
+            String fieldName, Decoders.Variant<org.jooq.Record, ? extends T>... variants) {
+        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.string()), variants)::decode;
+    }
+
     // --- combine delegates ---
 
     /**

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -392,6 +392,19 @@ class JooqDecoderTest {
     }
 
     @Test
+    void typedDiscriminateIsCastFree() {
+        // Explicit target type pins T = Payment, so the variant arms need no up-cast.
+        Decoder<org.jooq.Record, Payment> dec = discriminate("type",
+                variant("credit_card", field("card_number", string()).map(CreditCard::new)),
+                variant("bank_transfer", field("bank_code", string()).map(BankTransfer::new)));
+
+        var ccRec = record("type", "credit_card", "card_number", "4111", "bank_code", "");
+        assertInstanceOf(CreditCard.class, ((Ok<Payment>) dec.decode(ccRec)).value());
+        var btRec = record("type", "bank_transfer", "card_number", "", "bank_code", "MUFG");
+        assertInstanceOf(BankTransfer.class, ((Ok<Payment>) dec.decode(btRec)).value());
+    }
+
+    @Test
     void discriminateUnknownTag() {
         Decoder<org.jooq.Record, Payment> dec = discriminate("type", Map.of(
                 "credit_card", field("card_number", string()).map(CreditCard::new)

--- a/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
+++ b/raoh-json/src/main/java/net/unit8/raoh/json/JsonDecoders.java
@@ -481,6 +481,35 @@ public final class JsonDecoders {
         return Decoders.<JsonNode, T>discriminate(fieldName, field(fieldName, string()), variants);
     }
 
+    /**
+     * Creates a {@link Decoders.Variant} for use with {@link #discriminate(String, Decoders.Variant[])},
+     * with the input type pinned to {@link JsonNode}.
+     *
+     * @param <S>     the value type this variant decodes to
+     * @param tag     the discriminator value that selects this variant
+     * @param decoder the decoder producing the variant value
+     * @return a variant for use with {@link #discriminate(String, Decoders.Variant[])}
+     */
+    public static <S> Decoders.Variant<JsonNode, S> variant(String tag, Decoder<JsonNode, S> decoder) {
+        return Decoders.variant(tag, decoder);
+    }
+
+    /**
+     * Typed, cast-free variant of {@link #discriminate(String, Map)}: dispatches on the string value
+     * of the discriminator field. See {@link Decoders#discriminate(String, Decoder, Decoders.Variant[])}.
+     *
+     * @param <T>       the decoded (supertype) type
+     * @param fieldName the discriminator field name (e.g., {@code "type"})
+     * @param variants  the variants, each pairing a tag with its decoder
+     * @return a discriminating decoder
+     * @throws IllegalArgumentException if two variants share the same tag
+     */
+    @SafeVarargs
+    public static <T> Decoder<JsonNode, T> discriminate(
+            String fieldName, Decoders.Variant<JsonNode, ? extends T>... variants) {
+        return Decoders.discriminate(fieldName, field(fieldName, string()), variants);
+    }
+
     // --- strict ---
 
     /**

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -335,6 +335,20 @@ class JsonDecoderTest {
     }
 
     @Test
+    void typedDiscriminateIsCastFree() {
+        // Explicit target type pins T = Contact, so the variant arms need no up-cast.
+        Decoder<JsonNode, Contact> contactDec = discriminate("type",
+                variant("phone", field("number", string()).map(Phone::new)),
+                variant("email", field("address", email()).map(EmailContact::new)));
+
+        assertInstanceOf(Phone.class, assertOk(contactDec.decode(
+                parse("{\"type\":\"phone\",\"number\":\"090-1234-5678\"}"))));
+        assertInstanceOf(EmailContact.class, assertOk(contactDec.decode(
+                parse("{\"type\":\"email\",\"address\":\"a@b.com\"}"))));
+        assertErr(contactDec.decode(parse("{\"type\":\"unknown\"}")));
+    }
+
+    @Test
     void uuidParsing() {
         var dec = field("id", string().uuid());
         var id = assertOk(dec.decode(parse("{\"id\":\"550e8400-e29b-41d4-a716-446655440000\"}")));

--- a/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
+++ b/raoh-json/src/test/java/net/unit8/raoh/json/JsonDecoderTest.java
@@ -345,7 +345,6 @@ class JsonDecoderTest {
                 parse("{\"type\":\"phone\",\"number\":\"090-1234-5678\"}"))));
         assertInstanceOf(EmailContact.class, assertOk(contactDec.decode(
                 parse("{\"type\":\"email\",\"address\":\"a@b.com\"}"))));
-        assertErr(contactDec.decode(parse("{\"type\":\"unknown\"}")));
     }
 
     @Test

--- a/raoh/src/main/java/net/unit8/raoh/decode/Decoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/Decoders.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -752,6 +753,81 @@ public final class Decoders {
                 }
             };
         };
+    }
+
+    /**
+     * A single tagged variant of a discriminated (tagged-union) decoder: the discriminator tag
+     * and the decoder that produces the variant's value.
+     *
+     * <p>Created via {@link #variant(String, Decoder)} and consumed by the typed
+     * {@link #discriminate(String, Decoder, Variant[])}. This is the decode-side mirror of
+     * {@link net.unit8.raoh.encode.MapEncoders.Variant MapEncoders.Variant}, but dispatches on the
+     * tag <em>string</em> rather than the runtime class, so it carries no {@code Class} token.
+     *
+     * @param <I>     the input type
+     * @param <S>     the value type this variant decodes to
+     * @param tag     the discriminator value that selects this variant; must not be {@code null}
+     * @param decoder the decoder producing the variant value; must not be {@code null}
+     */
+    public record Variant<I extends @Nullable Object, S>(String tag, Decoder<I, S> decoder) {
+        /**
+         * Creates a variant, rejecting a {@code null} tag or decoder.
+         *
+         * @throws NullPointerException if {@code tag} or {@code decoder} is {@code null}
+         */
+        public Variant {
+            Objects.requireNonNull(tag, "tag must not be null");
+            Objects.requireNonNull(decoder, "decoder must not be null");
+        }
+    }
+
+    /**
+     * Creates a {@link Variant} binding a discriminator tag to its decoder.
+     *
+     * @param <I>     the input type
+     * @param <S>     the value type this variant decodes to
+     * @param tag     the discriminator value that selects this variant
+     * @param decoder the decoder producing the variant value
+     * @return a variant for use with {@link #discriminate(String, Decoder, Variant[])}
+     */
+    public static <I extends @Nullable Object, S> Variant<I, S> variant(String tag, Decoder<I, S> decoder) {
+        return new Variant<>(tag, decoder);
+    }
+
+    /**
+     * Typed, cast-free variant of {@link #discriminate(String, Decoder, Map)}: dispatches to a
+     * {@link Variant}'s decoder by the decoded tag.
+     *
+     * <p>This is the decode-side mirror of
+     * {@link net.unit8.raoh.encode.MapEncoders#discriminate(String, net.unit8.raoh.encode.MapEncoders.Variant[])
+     * MapEncoders.discriminate}. Because each variant is typed {@code Variant<I, ? extends T>} and
+     * {@code T} is pinned by the target type, no per-arm up-cast to the supertype is needed
+     * (unlike the {@code Map}-based overload, whose common value type forces a cast on every arm).
+     *
+     * <p>Passing zero variants is permitted and yields a decoder that fails every tag with
+     * {@link ErrorCodes#NOT_ALLOWED}, matching {@code discriminate(fieldName, tagDec, Map.of())}.
+     *
+     * @param <I>       the input type
+     * @param <T>       the decoded (supertype) type
+     * @param fieldName the discriminator field name, used for error path reporting
+     * @param tagDec    a decoder that extracts the discriminator value as a string
+     * @param variants  the variants, each pairing a tag with its decoder
+     * @return a discriminating decoder
+     * @throws IllegalArgumentException if two variants share the same tag
+     */
+    @SafeVarargs
+    public static <I extends @Nullable Object, T> Decoder<I, T> discriminate(
+            String fieldName, Decoder<I, String> tagDec, Variant<I, ? extends T>... variants) {
+        var map = HashMap.<String, Decoder<I, ? extends T>>newHashMap(variants.length);
+        for (var v : variants) {
+            // Detect duplicates via an explicit presence check rather than the return of put(...),
+            // so it does not hinge on values being non-null.
+            if (map.containsKey(v.tag())) {
+                throw new IllegalArgumentException("duplicate variant tag '" + v.tag() + "'");
+            }
+            map.put(v.tag(), v.decoder());
+        }
+        return discriminate(fieldName, tagDec, map);
     }
 
     /**

--- a/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/map/MapDecoders.java
@@ -222,6 +222,36 @@ public final class MapDecoders {
     }
 
     /**
+     * Creates a {@link Decoders.Variant} for use with {@link #discriminate(String, Decoders.Variant[])},
+     * with the input type pinned to {@code Map<String, Object>}.
+     *
+     * @param <S>     the value type this variant decodes to
+     * @param tag     the discriminator value that selects this variant
+     * @param decoder the decoder producing the variant value
+     * @return a variant for use with {@link #discriminate(String, Decoders.Variant[])}
+     */
+    public static <S> Decoders.Variant<Map<String, Object>, S> variant(
+            String tag, Decoder<Map<String, Object>, S> decoder) {
+        return Decoders.variant(tag, decoder);
+    }
+
+    /**
+     * Typed, cast-free variant of {@link #discriminate(String, Map)}: dispatches on the string value
+     * of the discriminator field. See {@link Decoders#discriminate(String, Decoder, Decoders.Variant[])}.
+     *
+     * @param <T>       the decoded (supertype) type
+     * @param fieldName the discriminator field name (e.g., {@code "type"})
+     * @param variants  the variants, each pairing a tag with its decoder
+     * @return a discriminating decoder
+     * @throws IllegalArgumentException if two variants share the same tag
+     */
+    @SafeVarargs
+    public static <T> Decoder<Map<String, Object>, T> discriminate(
+            String fieldName, Decoders.Variant<Map<String, Object>, ? extends T>... variants) {
+        return Decoders.discriminate(fieldName, field(fieldName, ObjectDecoders.string()), variants);
+    }
+
+    /**
      * Wraps a decoder to reject maps containing keys not in the given set.
      *
      * @param <T>         the decoded value type

--- a/raoh/src/test/java/net/unit8/raoh/decode/DecodersDiscriminateTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/DecodersDiscriminateTest.java
@@ -1,0 +1,91 @@
+package net.unit8.raoh.decode;
+
+import net.unit8.raoh.Err;
+import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Issue;
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Result;
+import org.junit.jupiter.api.Test;
+
+import static net.unit8.raoh.decode.Decoders.discriminate;
+import static net.unit8.raoh.decode.Decoders.variant;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Direct unit tests for the typed {@code Decoders.discriminate(String, Decoder, Variant...)} and
+ * {@code Decoders.variant(...)}. Uses a computed tag decoder (the part before {@code ':'}) to
+ * exercise the core capability that facades and the computed-tag proposal build on.
+ */
+class DecodersDiscriminateTest {
+
+    sealed interface Animal permits Dog, Cat {}
+    record Dog(String name) implements Animal {}
+    record Cat(String name) implements Animal {}
+
+    // A computed tag: everything before the first ':'. Not a plain field lookup.
+    static final Decoder<String, String> TAG = (in, path) -> Result.ok(in.split(":", 2)[0]);
+    static final Decoder<String, Dog> DOG = (in, path) -> Result.ok(new Dog(in.split(":", 2)[1]));
+    static final Decoder<String, Cat> CAT = (in, path) -> Result.ok(new Cat(in.split(":", 2)[1]));
+
+    @Test
+    void typedDiscriminateDispatchesCastFree() {
+        // The Dog/Cat variants need no up-cast; T is pinned to Animal by the target type.
+        Decoder<String, Animal> dec = discriminate("type", TAG,
+                variant("dog", DOG),
+                variant("cat", CAT));
+        assertEquals(new Dog("rex"), assertOk(dec.decode("dog:rex")));
+        assertEquals(new Cat("mia"), assertOk(dec.decode("cat:mia")));
+    }
+
+    @Test
+    void unknownTagIsNotAllowed() {
+        Decoder<String, Animal> dec = discriminate("type", TAG, variant("dog", DOG));
+        var issue = assertErr(dec.decode("fish:nemo"));
+        assertEquals(ErrorCodes.NOT_ALLOWED, issue.code());
+        assertEquals("/type", issue.path().toJsonPointer());
+    }
+
+    @Test
+    void zeroVariantsFailsEveryTag() {
+        // Explicit decision: zero variants is allowed and always fails NOT_ALLOWED, matching
+        // discriminate(fieldName, tagDec, Map.of()).
+        Decoder<String, Animal> dec = discriminate("type", TAG);
+        assertEquals(ErrorCodes.NOT_ALLOWED, assertErr(dec.decode("dog:rex")).code());
+    }
+
+    @Test
+    void duplicateTagThrowsAtConstruction() {
+        assertThrows(IllegalArgumentException.class,
+                () -> discriminate("type", TAG, variant("dog", DOG), variant("dog", CAT)));
+    }
+
+    @Test
+    void variantRejectsNullTagAndDecoder() {
+        assertThrows(NullPointerException.class, () -> variant(null, DOG));
+        assertThrows(NullPointerException.class, () -> variant("dog", null));
+    }
+
+    // --- helpers ---
+
+    private static <T> T assertOk(Result<T> r) {
+        return switch (r) {
+            case Ok<T> ok -> ok.value();
+            case Err<T> err -> {
+                fail("expected Ok, got " + err);
+                yield null;
+            }
+        };
+    }
+
+    private static Issue assertErr(Result<?> r) {
+        return switch (r) {
+            case Ok<?> ok -> {
+                fail("expected Err, got " + ok);
+                yield null;
+            }
+            case Err<?> err -> err.issues().asList().getFirst();
+        };
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/map/MapDecoderTest.java
@@ -931,6 +931,24 @@ class MapDecoderTest {
         }
     }
 
+    @Test
+    void typedDiscriminateIsCastFreeAndMatchesMapForm() {
+        // Cast-free: the variant arms need no (Shape) up-cast; T is pinned by the target type.
+        Decoder<Map<String, Object>, Shape> typed = discriminate("type",
+                variant("circle", field("radius", decimal()).map(r -> new Circle(r.doubleValue()))),
+                variant("rect", combine(field("width", decimal()), field("height", decimal()))
+                        .map((w, h) -> new Rect(w.doubleValue(), h.doubleValue()))));
+        Decoder<Map<String, Object>, Shape> mapForm = discriminate("type", Map.of(
+                "circle", field("radius", decimal()).map(r -> new Circle(r.doubleValue())),
+                "rect", combine(field("width", decimal()), field("height", decimal()))
+                        .map((w, h) -> new Rect(w.doubleValue(), h.doubleValue()))));
+
+        var input = Map.<String, Object>of("type", "rect", "width", 3.0, "height", 4.0);
+        // The typed form produces the same result as the Map form.
+        assertEquals(assertOk(mapForm.decode(input)), assertOk(typed.decode(input)));
+        assertInstanceOf(Rect.class, assertOk(typed.decode(input)));
+    }
+
     // --- combine(List) ---
 
     @Test


### PR DESCRIPTION
Closes #82.

## What

The decode side only had the `Map`-based `discriminate`, whose single common value type forces an up-cast to the supertype on **every** arm:

```java
discriminate("type", Map.of(
    "github", combine(...).map((u,b,r) -> (ProblemRepository) new GitHubProblemRepository(u,b,r)),
    ...));
```

The encode side already has a typed, cast-free `variant()`/`discriminate()`. This mirrors it on decode, so the same union decoded from JSON and from jOOQ no longer pays the cast twice:

```java
discriminate("type",
    variant("github",    combine(...).map(GitHubProblemRepository::new)),
    variant("bitbucket", combine(...).map(BitBucketProblemRepository::new)),
    variant("generic",   combine(...).map(GenericProblemRepository::new)));
```

## API

Core `Decoders`:
- `record Variant<I, S>(String tag, Decoder<I, S> decoder)` — rejects a null tag/decoder in its compact constructor.
- `variant(tag, decoder)`.
- `@SafeVarargs discriminate(fieldName, tagDec, Variant...)` — delegates to the existing `Map`-based `discriminate`; detects duplicate tags via an explicit `containsKey` check (not the return of `put`).

`MapDecoders` / `JsonDecoders` / `JooqRecordDecoders` re-export `variant(...)` with the input type pinned and add the two-arg `discriminate(fieldName, Variant...)`. The `Map`-based overloads stay for back-compat (no behavior change).

## Design decisions (from review of the plan)

- **Ordering is not a feature** — dispatch is a map lookup and the `allowed` error list is sorted; a plain `HashMap` is used, and order is not cited as a rationale.
- **Null tag/decoder rejected** at the record's compact constructor (fail-fast, covers direct `new` too).
- **Duplicate detection** uses `containsKey`, not `put(...) != null`, so it does not hinge on values being non-null.
- **Zero variants is allowed** and always fails `NOT_ALLOWED`, matching `discriminate(fieldName, tagDec, Map.of())`.

## Tests

Duplicate-tag, zero-variant, null-rejection, unknown-tag, and custom-tag-decoder dispatch are tested once at the core level (`DecodersDiscriminateTest`, using a computed tag). Each facade test covers only the cast-free happy path and Map-form parity, to avoid re-testing core logic.

No new error codes (`NOT_ALLOWED` reused). raoh: 421 tests, raoh-json: 77, raoh-jooq: 20 — all green; javadoc clean; NullAway gate passes.

Pairs with #83 (computed-tag facades), which will reuse this `Variant` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
