### PR TITLE
feat(encode): ObjectEncoders bytes()/uuid()/uri() + document the encode idiom (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ At release time this section is renamed to the chosen version with a date.
 
 ### Added
 
+- **`ObjectEncoders.bytes()` / `uuid()` / `uri()`** — the encode duals of the existing decoders.
+  `bytes()` passes a `byte[]` through as-is (for JDBC binary columns); `uuid()` and `uri()` emit the
+  canonical string form, round-tripping `StringDecoder.uuid()` / `uri()`. Also documents in
+  `comparisons.md` that `object(property(...), ...)` — not a symmetric `combine` — is the intended
+  encode idiom, and how to bridge a `Map<String, Object>` to a Jackson `JsonNode`
+  ([#94](https://github.com/kawasima/raoh/issues/94)).
 - **`Decoder.refine(...)`** — a generic predicate-based refinement combinator (three overloads: a
   `code`/`message` pair, a metadata-carrying variant, and a fully caller-controlled `onFail` variant).
   Keeps the value unchanged on success and produces an `Issue` at the current path on failure, with a

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -43,6 +43,38 @@ combine(
 
 The schema is already the parsing pipeline.
 
+## Encoding
+
+Encoding is the dual of decoding, but the two composition idioms are deliberately different.
+Decode composes fields with the applicative `combine(field(...), ...).map(ctor)`. Encode composes
+with `object(property(...), ...)` (from `MapEncoders`):
+
+```java
+import static net.unit8.raoh.encode.MapEncoders.*;
+import static net.unit8.raoh.encode.ObjectEncoders.*;
+
+Encoder<User, Map<String, Object>> user = object(
+        property("id",    User::id,    uuid().contramap(UserId::value)),
+        property("email", User::email, string().contramap(Email::value)),
+        property("age",   User::age,   int_().contramap(Age::value))
+);
+```
+
+There is intentionally no encode-side `combine`. Decode's `combine` is applicative *because decode
+can fail and must accumulate errors across fields*; an encoder is a total function with no failure
+channel (see #43 and the `refine` discussion in #93), so there is nothing to accumulate. `object(...)`
+is the encode idiom, and the asymmetry with `combine` is by design, not a gap.
+
+To produce JSON, encode to a `Map<String, Object>` and hand it to Jackson:
+
+```java
+Map<String, Object> body = user.encode(aUser);
+JsonNode json = objectMapper.valueToTree(body); // Jackson serialization is already good here
+```
+
+A dedicated `JsonEncoders` (domain → `JsonNode`) is tracked in #94; for now the one-liner above
+covers the common case.
+
 ## Elm Decoder Comparison
 
 Raoh also has a strong family resemblance to Elm's `Json.Decode.Decoder`.

--- a/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
@@ -3,11 +3,13 @@ package net.unit8.raoh.encode;
 import org.jspecify.annotations.NonNull;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 /**
  * Factory for primitive {@code Encoder} instances that encode domain values to {@code Object}.
@@ -94,6 +96,19 @@ public final class ObjectEncoders {
     }
 
     /**
+     * Returns an encoder that passes a {@code byte[]} through as-is.
+     *
+     * <p>The dual of {@link net.unit8.raoh.decode.ObjectDecoders#bytes()}, which accepts raw
+     * {@code byte[]} values directly (not base64). Suitable for JDBC binary columns such as
+     * PostgreSQL {@code BYTEA} or SQL standard {@code VARBINARY}.
+     *
+     * @return a byte array encoder
+     */
+    public static Encoder<byte @NonNull [], Object> bytes() {
+        return v -> v;
+    }
+
+    /**
      * Returns an encoder that converts an {@link Instant} to its ISO-8601 string representation.
      *
      * @return an instant encoder
@@ -143,6 +158,30 @@ public final class ObjectEncoders {
      * @return an offset date-time encoder
      */
     public static Encoder<@NonNull OffsetDateTime, Object> offsetDateTime() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts a {@link UUID} to its canonical string representation.
+     *
+     * <p>The dual of {@link net.unit8.raoh.decode.builtin.StringDecoder#uuid()}
+     * ({@link UUID#fromString(String)}); {@code UUID.fromString(uuid.toString())} round-trips exactly.
+     *
+     * @return a UUID encoder
+     */
+    public static Encoder<@NonNull UUID, Object> uuid() {
+        return v -> v.toString();
+    }
+
+    /**
+     * Returns an encoder that converts a {@link URI} to its string representation.
+     *
+     * <p>The dual of {@link net.unit8.raoh.decode.builtin.StringDecoder#uri()}
+     * ({@link URI#create(String)}); {@code URI.create(uri.toString())} round-trips exactly.
+     *
+     * @return a URI encoder
+     */
+    public static Encoder<@NonNull URI, Object> uri() {
         return v -> v.toString();
     }
 

--- a/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/encode/ObjectEncoders.java
@@ -102,6 +102,9 @@ public final class ObjectEncoders {
      * {@code byte[]} values directly (not base64). Suitable for JDBC binary columns such as
      * PostgreSQL {@code BYTEA} or SQL standard {@code VARBINARY}.
      *
+     * <p>The array is returned as-is and is <strong>not</strong> defensively copied, so the encoded
+     * value shares storage with the source object (consistent with the decoder). Do not mutate it.
+     *
      * @return a byte array encoder
      */
     public static Encoder<byte @NonNull [], Object> bytes() {

--- a/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/encode/MapEncoderTest.java
@@ -10,10 +10,12 @@ import net.unit8.raoh.decode.ObjectDecoders;
 import net.unit8.raoh.decode.map.MapDecoders;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static net.unit8.raoh.encode.MapEncoders.*;
 import static net.unit8.raoh.encode.ObjectEncoders.*;
@@ -98,6 +100,24 @@ class MapEncoderTest {
     @Test
     void floatEncoderPassesThrough() {
         assertEquals(2.5f, float_().encode(2.5f));
+    }
+
+    @Test
+    void bytesEncoderPassesThrough() {
+        byte[] b = {1, 2, 3};
+        assertSame(b, bytes().encode(b));
+    }
+
+    @Test
+    void uuidEncodesToCanonicalString() {
+        var u = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        assertEquals("00000000-0000-0000-0000-000000000001", uuid().encode(u));
+    }
+
+    @Test
+    void uriEncodesToString() {
+        var u = URI.create("https://example.com/x?q=1");
+        assertEquals("https://example.com/x?q=1", uri().encode(u));
     }
 
     @Test


### PR DESCRIPTION
## What

Partial resolution of #94 — the coverage-gap pieces only, not the framing.

**Primitive encoders** (`ObjectEncoders`), the duals of existing decoders:
- `bytes()` → identity pass-through of `byte[]` (mirrors `ObjectDecoders.bytes()`, which accepts raw `byte[]` for JDBC BYTEA/VARBINARY — not base64).
- `uuid()` → `UUID` to canonical string, round-trips `StringDecoder.uuid()` (`UUID.fromString`).
- `uri()` → `URI` to string, round-trips `StringDecoder.uri()` (`URI.create`).

All three follow the existing factory style exactly (one-line lambdas, `Encoder<@NonNull X, Object>`), matching the temporal encoders' `.toString()` convention.

**Documentation** (`comparisons.md`) — a new *Encoding* section that settles the `object()`-vs-`combine` question from #94: there is intentionally no encode-side `combine`, because decode's `combine` is applicative only so it can accumulate errors, while an encoder is a total function with no failure channel (#43, reaffirmed in #93). `object(property(...), ...)` is the encode idiom; the asymmetry is by design. Also records the `Map<String,Object>` → `JsonNode` bridge one-liner (`objectMapper.valueToTree(...)`).

## Scope / deferred to #94

Per the evaluation on #94, the following stay open there and are **not** in this PR:
- A full `JsonEncoders` (domain → `JsonNode`) — weakest-justified item; encode has no error-accumulation value to add over Jackson's already-good serialization, so the bridge one-liner is documented instead.
- jOOQ encoder and an encode-side `lazy`.
- Any symmetric encode-side `combine` builder (documented as intentionally absent).

## Verification

Full build green: `mvn -f raoh/pom.xml clean install` → 431 tests (was 428, +3), no Javadoc/doclint warnings, NullAway clean. New tests: `bytesEncoderPassesThrough`, `uuidEncodesToCanonicalString`, `uriEncodesToString` in `MapEncoderTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
