### PR TITLE
docs: maturity-review polish — encode scope, JDK-25 LTS positioning, gsh experimental (#94/#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ At release time this section is renamed to the chosen version with a date.
   `comparisons.md` that `object(property(...), ...)` — not a symmetric `combine` — is the intended
   encode idiom, and how to bridge a `Map<String, Object>` to a Jackson `JsonNode`
   ([#94](https://github.com/kawasima/raoh/issues/94)).
+- **Schema-reuse guidance** (docs) — `comparisons.md` now documents how to cover Zod's
+  `.merge()`/`.extend()`/`.pick()`/`.omit()`/`.partial()` in Raoh's nominal-typed model by extracting
+  each field's value decoder into a variable and reusing it across related shapes (subset `combine`
+  for pick/omit, extra fragments for merge/extend, `optionalNullableField` + `Presence` for PATCH).
+  No structural schema operators are planned ([#95](https://github.com/kawasima/raoh/issues/95)).
 - **`Decoder.refine(...)`** — a generic predicate-based refinement combinator (three overloads: a
   `code`/`message` pair, a metadata-carrying variant, and a fully caller-controlled `onFail` variant).
   Keeps the value unchanged on success and produces an `Issue` at the current path on failure, with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ At release time this section is renamed to the chosen version with a date.
   `.merge()`/`.extend()`/`.pick()`/`.omit()`/`.partial()` in Raoh's nominal-typed model by extracting
   each field's value decoder into a variable and reusing it across related shapes (subset `combine`
   for pick/omit, extra fragments for merge/extend, `optionalNullableField` + `Presence` for PATCH).
-  No structural schema operators are planned ([#95](https://github.com/kawasima/raoh/issues/95)).
+  Raoh has no structural schema operators today; the fragment-reuse pattern is the recommended
+  approach ([#95](https://github.com/kawasima/raoh/issues/95)).
 - **`Decoder.refine(...)`** — a generic predicate-based refinement combinator (three overloads: a
   `code`/`message` pair, a metadata-carrying variant, and a fully caller-controlled `onFail` variant).
   Keeps the value unchanged on success and produces an `Issue` at the current path on failure, with a

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Map<String, Object> row = ITEM_ENCODER.encode(item);
 
 ### Built-in Encoders
 
-`ObjectEncoders` provides: `string()`, `int_()`, `long_()`, `double_()`, `float_()`, `bool()`, `decimal()`, `date()`, `time()`, `dateTime()`, `iso8601()`, `offsetDateTime()`, `enumOf()`.
+`ObjectEncoders` provides: `string()`, `int_()`, `long_()`, `double_()`, `float_()`, `bool()`, `decimal()`, `bytes()`, `date()`, `time()`, `dateTime()`, `iso8601()`, `offsetDateTime()`, `uuid()`, `uri()`, `enumOf()`.
 
 Null / optionality is handled in the property layer (encoders themselves are total, non-null functions):
 
@@ -771,6 +771,10 @@ Null / optionality is handled in the property layer (encoders themselves are tot
 - `presenceProperty(key, getter, enc)` — round-trips the tri-state `Presence` (omit / `null` / value)
 
 `MapEncoders` provides: `property()`, `nullableProperty()`, `propertyWithDefault()`, `optionalProperty()`, `presenceProperty()`, `object()`, `nested()`, `list()`, `mapOf()`, and `variant()` / `discriminate()` for tagged unions.
+
+### Scope
+
+Encoding targets the `Map<String, Object>` boundary by design. To produce JSON, encode to a map and bridge with Jackson (`objectMapper.valueToTree(map)`); to write with jOOQ, hand the map to the DSL. There is intentionally **no** separate JSON or jOOQ encoder, and no encode-side `combine`: an encoder is a total function with no failure channel, so the write path does not need the error accumulation that justifies the applicative `combine` and the boundary decoder modules on the decode side. See the [Encoding](docs/comparisons.md#encoding) notes for the reasoning.
 
 ## Comparisons
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ If you are coming from a validator-oriented library, the main difference in feel
 
 ## Requirements
 
-- **Java 25** (current LTS). Raoh targets the latest Java LTS deliberately: the API relies on
-  records, sealed types, pattern matching, and JSpecify type-use nullness, so it does not attempt to
-  support older baselines.
+- **Java 25** (an LTS release). Raoh targets a modern Java LTS baseline deliberately: the API relies
+  on records, sealed types, pattern matching, and JSpecify type-use nullness, so it does not attempt
+  to support older baselines.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ If you are coming from a validator-oriented library, the main difference in feel
 
 ## Requirements
 
-- Java 25
+- **Java 25** (current LTS). Raoh targets the latest Java LTS deliberately: the API relies on
+  records, sealed types, pattern matching, and JSpecify type-use nullness, so it does not attempt to
+  support older baselines.
 
 ## Installation
 
@@ -115,6 +117,10 @@ Test/CI-time guard that detects accidental `new` construction of domain objects 
 - `raoh-gsh`: runtime — `DomainConstructionScope`, `DomainConstructionGuardException`
 - `raoh-gsh-weaver`: bytecode weaver (ClassFile API), Java Agent, CLI
 - `raoh-gsh-maven-plugin`: Maven plugin for build-time weaving
+
+**Stability:** the `raoh-gsh*` modules are experimental / incubating. Their bytecode-weaving surface
+is built on the evolving JDK ClassFile API and may change outside the core library's SemVer promise;
+treat them as separate from the stability guarantees of `raoh` / `raoh-json` / `raoh-jooq`.
 
 See [raoh-gsh README](raoh-gsh/README.md) for usage.
 

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -134,8 +134,12 @@ Map<String, Object> body = user.encode(aUser);
 JsonNode json = objectMapper.valueToTree(body); // Jackson serialization is already good here
 ```
 
-A dedicated `JsonEncoders` (domain → `JsonNode`) is tracked in #94; for now the one-liner above
-covers the common case.
+Encoding targets the `Map<String, Object>` boundary by design; the Jackson bridge above is the
+intended way to reach JSON. Unlike decode — where `JsonDecoders` earns its place by adding error
+accumulation and structured issues on top of Jackson's weak data-binding — the write path has no
+errors to accumulate and Jackson's serialization is already good, so a dedicated `JsonEncoders`
+(domain → `JsonNode`) would add little. It is discussed in #94 but is not a planned part of the core
+boundary story; the one-liner above is the recommended approach.
 
 ## Elm Decoder Comparison
 

--- a/raoh-gsh/README.md
+++ b/raoh-gsh/README.md
@@ -1,5 +1,9 @@
 # raoh-gsh — Domain Construction Guard (Runtime)
 
+> **Experimental / incubating.** The `raoh-gsh*` modules build on the evolving JDK ClassFile API and
+> may change outside the core library's SemVer promise. They are a test/CI-time tool, separate from
+> the stability guarantees of `raoh` / `raoh-json` / `raoh-jooq`.
+
 Runtime library for the domain construction guard. Provides `DomainConstructionScope` and `DomainConstructionGuardException`.
 
 Within a `DomainConstructionScope`, any woven domain object construction is checked against the call stack. If a `decode` method in a class implementing `net.unit8.raoh.decode.Decoder` is on the stack, construction is allowed. If not (i.e., a direct `new`), a `DomainConstructionGuardException` is thrown. Outside of a scope, no checking occurs — so production code is never affected.


### PR DESCRIPTION
## What

Documentation fixes and strategic-positioning statements surfaced by the product-maturity review — no code change.

### Immediate fixes
- **README** — the `ObjectEncoders` list had drifted; add `bytes()` / `uuid()` / `uri()`.
- **CHANGELOG** — record the #95 schema-reuse documentation, previously unlogged in `[Unreleased]`.

### C — encode scope, formalized
- **README + `comparisons.md`** — state that **encoding targets the `Map<String, Object>` boundary by design**. JSON via `objectMapper.valueToTree(map)`; intentionally no separate JSON/jOOQ encoder and no encode-side `combine` (an encoder is a total function with no errors to accumulate). Reframes the absence from "deferred (#94)" to "intended scope."

### B — JDK 25 positioning
- **README Requirements** — reframe the bare "Java 25" as a deliberate **current-LTS** baseline (Java 25 is an LTS; the API relies on records, sealed types, pattern matching, and JSpecify type-use nullness, so older baselines are intentionally unsupported).

### A — raoh-gsh stability
- **README + `raoh-gsh/README.md`** — mark the `raoh-gsh*` modules (bytecode weaving on the evolving JDK ClassFile API) as **experimental / incubating**, explicitly outside the core library's SemVer promise.

## Deliberately not changed
- The README install snippet pins `0.6.0` while the last release is `0.5.0`. That is a release-timing decision (reconcile when `0.6.0` ships), left as-is.

## Follow-ups (not in this PR)
- Issue hygiene for C: relabel/close #94's deferred items (JsonEncoders, jOOQ encoder, encode `lazy`, encode `combine`) as out-of-scope-by-design rather than open aspirations.

## Verification
Docs only — no build impact. Internal anchor `docs/comparisons.md#encoding` resolves to the existing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
