### PR TITLE
test: harden Decoders/Issues/jOOQ coverage; document Issues ordering contract

### DIFF
--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -431,4 +431,63 @@ class JooqDecoderTest {
         assertEquals(ErrorCodes.MISSING_FIELD, issue.code());
         assertEquals("/type", issue.path().toJsonPointer());
     }
+
+    // -------------------------------------------------------------------------
+    // Error accumulation across a combine (applicative, not fail-fast)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void combineAccumulatesEveryFieldError() {
+        // Two columns are absent; the applicative combine must report BOTH, not stop at the first.
+        var rec = record("age", "not-a-number"); // name & email absent, age wrong type
+
+        Decoder<org.jooq.Record, User> dec = combine(
+                field("name",  string()),
+                field("age",   int_()),
+                field("email", string())
+        ).map(User::new);
+
+        var result = dec.decode(rec);
+        assertInstanceOf(Err.class, result);
+        var issues = ((Err<User>) result).issues().asList();
+        assertEquals(3, issues.size(), "all three field failures must accumulate");
+        var byPath = ((Err<User>) result).issues().groupByPath();
+        assertEquals(ErrorCodes.MISSING_FIELD, byPath.get("/name").getFirst().code());
+        assertEquals(ErrorCodes.TYPE_MISMATCH, byPath.get("/age").getFirst().code());
+        assertEquals(ErrorCodes.MISSING_FIELD, byPath.get("/email").getFirst().code());
+    }
+
+    // -------------------------------------------------------------------------
+    // List-based combine (CombinerList) at the jOOQ boundary
+    // -------------------------------------------------------------------------
+
+    @Test
+    void combineListFormDecodesAllFields() {
+        var rec = record("name", "Alice", "age", 30, "email", "alice@example.com");
+
+        Decoder<org.jooq.Record, User> dec = combine(java.util.List.of(
+                field("name",  string()),
+                field("age",   int_()),
+                field("email", string())
+        )).map(vals -> new User((String) vals[0], (int) vals[1], (String) vals[2]));
+
+        var result = dec.decode(rec);
+        assertInstanceOf(Ok.class, result);
+        assertEquals("Alice", ((Ok<User>) result).value().name());
+    }
+
+    @Test
+    void combineListFormAccumulatesErrors() {
+        var rec = record("name", "Alice"); // age & email absent
+
+        Decoder<org.jooq.Record, User> dec = combine(java.util.List.of(
+                field("name",  string()),
+                field("age",   int_()),
+                field("email", string())
+        )).map(vals -> new User((String) vals[0], (int) vals[1], (String) vals[2]));
+
+        var result = dec.decode(rec);
+        assertInstanceOf(Err.class, result);
+        assertEquals(2, ((Err<User>) result).issues().asList().size());
+    }
 }

--- a/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
+++ b/raoh-jooq/src/test/java/net/unit8/raoh/jooq/JooqDecoderTest.java
@@ -488,6 +488,11 @@ class JooqDecoderTest {
 
         var result = dec.decode(rec);
         assertInstanceOf(Err.class, result);
-        assertEquals(2, ((Err<User>) result).issues().asList().size());
+        var issues = ((Err<User>) result).issues();
+        assertEquals(2, issues.asList().size());
+        // Both absent columns must be reported, not just counted.
+        var byPath = issues.groupByPath();
+        assertEquals(ErrorCodes.MISSING_FIELD, byPath.get("/age").getFirst().code());
+        assertEquals(ErrorCodes.MISSING_FIELD, byPath.get("/email").getFirst().code());
     }
 }

--- a/raoh/src/main/java/net/unit8/raoh/Issues.java
+++ b/raoh/src/main/java/net/unit8/raoh/Issues.java
@@ -100,7 +100,11 @@ public record Issues(List<Issue> asList) {
     /**
      * Flattens issues into a map of JSON Pointer paths to lists of error messages.
      *
-     * @return a map from path to error messages
+     * <p>Both the keys and the messages under each key keep the order in which the issues were
+     * accumulated: paths appear in first-seen order, and each path's messages in the order they were
+     * added. This lets callers render errors in input order rather than an arbitrary one.
+     *
+     * @return a map from path to error messages, in accumulation order
      */
     public Map<String, List<String>> flatten() {
         return asList.stream()
@@ -179,7 +183,10 @@ public record Issues(List<Issue> asList) {
     /**
      * Groups issues by their JSON Pointer path.
      *
-     * @return a map from path to list of issues at that path
+     * <p>Like {@link #flatten()}, paths appear in first-seen order and the issues under each path
+     * keep their accumulation order.
+     *
+     * @return a map from path to list of issues at that path, in accumulation order
      */
     public Map<String, List<Issue>> groupByPath() {
         return asList.stream()

--- a/raoh/src/test/java/net/unit8/raoh/IssuesTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/IssuesTest.java
@@ -67,7 +67,7 @@ class IssuesTest {
         var flat = issues.flatten();
         assertEquals(List.of("is required", "not a valid email"), flat.get("/email"));
         assertEquals(List.of("is required"), flat.get("/address/city"));
-        // First-seen path ordering (LinkedHashMap): /email precedes /address/city.
+        // flatten() documents accumulation order: paths appear in first-seen order.
         assertEquals(List.of("/email", "/address/city"), List.copyOf(flat.keySet()));
     }
 

--- a/raoh/src/test/java/net/unit8/raoh/IssuesTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/IssuesTest.java
@@ -1,0 +1,131 @@
+package net.unit8.raoh;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Issues} accumulation and its serialization views (merge / rebase / add /
+ * flatten / groupByPath / toJsonList / format), which were previously covered only indirectly.
+ *
+ * <p>Expected values are derived from the documented contract — JSON Pointer paths from
+ * {@link Path#toJsonPointer()} (root is {@code ""}), and the nested {@code _errors} shape from the
+ * {@link Issues#format()} spec — not read back from the implementation.
+ */
+class IssuesTest {
+
+    private static final Issue EMAIL_REQUIRED =
+            Issue.of(Path.ROOT.append("email"), ErrorCodes.REQUIRED, "is required");
+    private static final Issue EMAIL_FORMAT =
+            Issue.of(Path.ROOT.append("email"), ErrorCodes.INVALID_FORMAT, "not a valid email");
+    private static final Issue CITY_REQUIRED =
+            Issue.of(Path.ROOT.append("address").append("city"), ErrorCodes.REQUIRED, "is required");
+    private static final Issue ROOT_ERROR =
+            Issue.of(Path.ROOT, ErrorCodes.INVALID_VALUE, "bad");
+
+    // --- add / merge / rebase ---
+
+    @Test
+    void addIsImmutableAndAppends() {
+        var base = Issues.EMPTY.add(EMAIL_REQUIRED);
+        var extended = base.add(CITY_REQUIRED);
+        assertEquals(1, base.asList().size(), "the original Issues must be unchanged");
+        assertEquals(List.of(EMAIL_REQUIRED, CITY_REQUIRED), extended.asList());
+    }
+
+    @Test
+    void mergeConcatenatesInOrder() {
+        var a = Issues.EMPTY.add(EMAIL_REQUIRED);
+        var b = Issues.EMPTY.add(CITY_REQUIRED);
+        assertEquals(List.of(EMAIL_REQUIRED, CITY_REQUIRED), a.merge(b).asList());
+    }
+
+    @Test
+    void mergeWithEmptyKeepsTheOtherSide() {
+        var a = Issues.EMPTY.add(EMAIL_REQUIRED);
+        assertEquals(a.asList(), Issues.EMPTY.merge(a).asList());
+        assertEquals(a.asList(), a.merge(Issues.EMPTY).asList());
+    }
+
+    @Test
+    void rebasePrependsPrefixToEveryPath() {
+        var issues = Issues.EMPTY.add(EMAIL_REQUIRED).add(CITY_REQUIRED);
+        var rebased = issues.rebase(Path.ROOT.append("user"));
+        assertEquals("/user/email", rebased.asList().get(0).path().toJsonPointer());
+        assertEquals("/user/address/city", rebased.asList().get(1).path().toJsonPointer());
+    }
+
+    // --- flatten / groupByPath ---
+
+    @Test
+    void flattenGroupsMessagesByPointerPreservingInsertionOrder() {
+        var issues = Issues.EMPTY.add(EMAIL_REQUIRED).add(EMAIL_FORMAT).add(CITY_REQUIRED);
+        var flat = issues.flatten();
+        assertEquals(List.of("is required", "not a valid email"), flat.get("/email"));
+        assertEquals(List.of("is required"), flat.get("/address/city"));
+        // First-seen path ordering (LinkedHashMap): /email precedes /address/city.
+        assertEquals(List.of("/email", "/address/city"), List.copyOf(flat.keySet()));
+    }
+
+    @Test
+    void groupByPathReturnsIssuesPerPointer() {
+        var issues = Issues.EMPTY.add(EMAIL_REQUIRED).add(EMAIL_FORMAT);
+        var grouped = issues.groupByPath();
+        assertEquals(List.of(EMAIL_REQUIRED, EMAIL_FORMAT), grouped.get("/email"));
+    }
+
+    // --- toJsonList ---
+
+    @Test
+    void toJsonListEmitsPathCodeMessageAndMeta() {
+        var meta = Map.<String, Object>of("expected", "string");
+        var issue = Issue.of(Path.ROOT.append("name"), ErrorCodes.TYPE_MISMATCH, "wrong type", meta);
+        var json = Issues.EMPTY.add(issue).toJsonList();
+        var entry = json.getFirst();
+        assertEquals("/name", entry.get("path"));
+        assertEquals(ErrorCodes.TYPE_MISMATCH, entry.get("code"));
+        assertEquals("wrong type", entry.get("message"));
+        assertEquals(meta, entry.get("meta"));
+    }
+
+    // --- format (nested _errors) ---
+
+    @Test
+    void formatNestsErrorsUnderTheStructurePath() {
+        // /address/city  ->  {address: {city: {_errors: ["is required"]}}}
+        var formatted = Issues.EMPTY.add(CITY_REQUIRED).format();
+        var address = asMap(formatted.get("address"));
+        var city = asMap(address.get("city"));
+        assertEquals(List.of("is required"), city.get("_errors"));
+    }
+
+    @Test
+    void formatPlacesRootErrorsAtTopLevel() {
+        // A ROOT-path issue has no segments, so its message lands in the top-level _errors.
+        var formatted = Issues.EMPTY.add(ROOT_ERROR).format();
+        assertEquals(List.of("bad"), formatted.get("_errors"));
+    }
+
+    @Test
+    void formatAccumulatesMultipleMessagesAtTheSamePath() {
+        var formatted = Issues.EMPTY.add(EMAIL_REQUIRED).add(EMAIL_FORMAT).format();
+        var email = asMap(formatted.get("email"));
+        assertEquals(List.of("is required", "not a valid email"), email.get("_errors"));
+    }
+
+    @Test
+    void emptyIssuesReportEmpty() {
+        assertTrue(Issues.EMPTY.isEmpty());
+        assertTrue(Issues.EMPTY.flatten().isEmpty());
+        assertTrue(Issues.EMPTY.toJsonList().isEmpty());
+    }
+
+    private static Map<?, ?> asMap(Object o) {
+        assertTrue(o instanceof Map, "expected a nested map, got: " + o);
+        return (Map<?, ?>) o;
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
@@ -144,8 +144,9 @@ class DecodersCombinatorTest {
             case Ok<String>(var v) -> fail("expected Err, got " + v);
             case Err<String>(var issues) -> {
                 var issue = issues.asList().getFirst();
+                // The error code is the documented contract; the fallback message wording is not,
+                // so it is deliberately not asserted here.
                 assertEquals(ErrorCodes.ONE_OF_FAILED, issue.code());
-                assertEquals("no variant matched", issue.message());
                 // Spec: the error carries one meta entry per failed candidate, in order.
                 var candidates = (List<?>) issue.meta().get("candidates");
                 assertEquals(2, candidates.size());
@@ -239,14 +240,14 @@ class DecodersCombinatorTest {
 
     private static String firstCode(Result<?> result) {
         return switch (result) {
-            case Ok<?> ignored -> fail("expected Err, got Ok");
+            case Ok<?> _ -> fail("expected Err, got Ok");
             case Err<?>(var issues) -> issues.asList().getFirst().code();
         };
     }
 
     private static int issueCount(Result<?> result) {
         return switch (result) {
-            case Ok<?> ignored -> fail("expected Err, got Ok");
+            case Ok<?> _ -> fail("expected Err, got Ok");
             case Err<?>(var issues) -> issues.asList().size();
         };
     }

--- a/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
@@ -1,0 +1,253 @@
+package net.unit8.raoh.decode;
+
+import net.unit8.raoh.Err;
+import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Issue;
+import net.unit8.raoh.Issues;
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Result;
+import net.unit8.raoh.decode.map.MapDecoders;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static net.unit8.raoh.decode.Decoders.combine;
+import static net.unit8.raoh.decode.Decoders.lazy;
+import static net.unit8.raoh.decode.Decoders.oneOf;
+import static net.unit8.raoh.decode.Decoders.recover;
+import static net.unit8.raoh.decode.Decoders.withDefault;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Direct unit tests for the {@link Decoders} utility combinators that previously lacked dedicated
+ * coverage: {@code oneOf}, {@code withDefault}, {@code recover}, {@code lazy}, and
+ * {@link ObjectDecoders#enumOf(Class)}.
+ *
+ * <p>Each test asserts the documented contract (Javadoc), not the current implementation shape:
+ * expected error codes/messages/metadata are taken from the spec, and the decoders under test are
+ * driven by tiny hand-written stubs so the exact success/failure of each input is controlled.
+ */
+class DecodersCombinatorTest {
+
+    /** A stub decoder that always succeeds with the given value, ignoring its input. */
+    private static Decoder<Object, String> succeed(String value) {
+        return (in, path) -> Result.ok(value);
+    }
+
+    /** A stub decoder that always fails with a single issue carrying the given code. */
+    private static Decoder<Object, String> failWith(String code) {
+        return (in, path) -> Result.fail(path, code, code + " failed");
+    }
+
+    // --- withDefault: default applies ONLY when every issue is "required" ---
+
+    @Test
+    void withDefaultSubstitutesDefaultWhenAllIssuesAreRequired() {
+        // Spec: default kicks in when the field is absent, i.e. all issues are `required`.
+        var dec = withDefault(failWith(ErrorCodes.REQUIRED), "fallback");
+        assertEquals("fallback", ok(dec.decode(null)));
+    }
+
+    @Test
+    void withDefaultPreservesNonRequiredError() {
+        // Spec: "If the decoder fails with a non-required error, the error is preserved."
+        var dec = withDefault(failWith(ErrorCodes.TYPE_MISMATCH), "fallback");
+        assertEquals(ErrorCodes.TYPE_MISMATCH, firstCode(dec.decode(null)));
+    }
+
+    @Test
+    void withDefaultPreservesErrorWhenRequiredIsMixedWithAnotherCode() {
+        // Boundary: shouldUseDefault requires *every* issue to be `required`. A single non-required
+        // sibling issue must keep the whole result an error (allMatch, not anyMatch).
+        Decoder<Object, String> mixed = (in, path) -> Result.err(
+                Issues.EMPTY
+                        .add(Issue.of(path, ErrorCodes.REQUIRED, "required"))
+                        .add(Issue.of(path, ErrorCodes.TYPE_MISMATCH, "wrong type")));
+        var dec = withDefault(mixed, "fallback");
+        assertEquals(2, issueCount(dec.decode(null)));
+    }
+
+    @Test
+    void withDefaultPassesSuccessThrough() {
+        var dec = withDefault(succeed("value"), "fallback");
+        assertEquals("value", ok(dec.decode(null)));
+    }
+
+    @Test
+    void withDefaultSupplierIsNotCalledOnSuccess() {
+        var calls = new AtomicInteger();
+        var dec = withDefault(succeed("value"), (Supplier<String>) () -> {
+            calls.incrementAndGet();
+            return "fallback";
+        });
+        assertEquals("value", ok(dec.decode(null)));
+        assertEquals(0, calls.get(), "supplier must not run when the decoder succeeds");
+    }
+
+    @Test
+    void withDefaultSupplierIsCalledOnRequiredFailure() {
+        var calls = new AtomicInteger();
+        var dec = withDefault(failWith(ErrorCodes.REQUIRED), (Supplier<String>) () -> {
+            calls.incrementAndGet();
+            return "fallback";
+        });
+        assertEquals("fallback", ok(dec.decode(null)));
+        assertEquals(1, calls.get());
+    }
+
+    // --- recover: recovers from ANY error ---
+
+    @Test
+    void recoverReplacesAnyErrorWithFallback() {
+        // Spec: recover ignores the error code — even a non-required error is replaced.
+        assertEquals("r", ok(recover(failWith(ErrorCodes.TYPE_MISMATCH), "r").decode(null)));
+        assertEquals("r", ok(recover(failWith(ErrorCodes.REQUIRED), "r").decode(null)));
+    }
+
+    @Test
+    void recoverPassesSuccessThrough() {
+        assertEquals("value", ok(recover(succeed("value"), "r").decode(null)));
+    }
+
+    @Test
+    void recoverFunctionComputesFallbackFromIssues() {
+        // Spec: the function variant derives the recovery value from the accumulated issues.
+        var dec = recover(failWith(ErrorCodes.OUT_OF_RANGE),
+                (Function<Issues, String>) issues -> "recovered:" + issues.asList().size());
+        assertEquals("recovered:1", ok(dec.decode(null)));
+    }
+
+    // --- oneOf: first success wins; all-fail yields one_of_failed with candidate meta ---
+
+    @Test
+    void oneOfReturnsFirstSuccessfulCandidate() {
+        // Both candidates succeed; the first one must win (order-sensitive).
+        assertEquals("first", ok(oneOf(succeed("first"), succeed("second")).decode(null)));
+    }
+
+    @Test
+    void oneOfFallsThroughToLaterCandidate() {
+        assertEquals("x", ok(oneOf(failWith(ErrorCodes.TYPE_MISMATCH), succeed("x")).decode(null)));
+    }
+
+    @Test
+    void oneOfFailsWithOneOfFailedAndPerCandidateMeta() {
+        var dec = oneOf(failWith(ErrorCodes.TYPE_MISMATCH), failWith(ErrorCodes.INVALID_FORMAT));
+        switch (dec.decode(null)) {
+            case Ok<String>(var v) -> fail("expected Err, got " + v);
+            case Err<String>(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.ONE_OF_FAILED, issue.code());
+                assertEquals("no variant matched", issue.message());
+                // Spec: the error carries one meta entry per failed candidate, in order.
+                var candidates = (List<?>) issue.meta().get("candidates");
+                assertEquals(2, candidates.size());
+                var first = (Map<?, ?>) candidates.getFirst();
+                assertEquals(0, first.get("candidate"));
+                assertNotNull(first.get("issues"), "each candidate records its own issues");
+            }
+        }
+    }
+
+    // --- lazy: deferred, recursive decoder definitions ---
+
+    @Test
+    void lazyDefersSupplierUntilEachDecodeInvocation() {
+        // Spec: "supplies the decoder on each invocation." Construction must not call the supplier;
+        // each decode call must.
+        var calls = new AtomicInteger();
+        Decoder<Object, String> dec = lazy(() -> {
+            calls.incrementAndGet();
+            return succeed("value");
+        });
+        assertEquals(0, calls.get(), "supplier must not run at construction time");
+        dec.decode(null);
+        dec.decode(null);
+        assertEquals(2, calls.get(), "supplier runs once per decode invocation");
+    }
+
+    record Node(int value, Optional<Node> next) {}
+
+    /** A self-referential decoder that only compiles because {@code lazy} defers the recursion. */
+    private static Decoder<Map<String, Object>, Node> node() {
+        return combine(
+                MapDecoders.field("value", ObjectDecoders.int_()),
+                MapDecoders.optionalField("next", MapDecoders.nested(lazy(DecodersCombinatorTest::node)))
+        ).map(Node::new);
+    }
+
+    @Test
+    void lazyEnablesRecursiveDecoding() {
+        var input = Map.<String, Object>of(
+                "value", 1,
+                "next", Map.of(
+                        "value", 2,
+                        "next", Map.of("value", 3)));
+        var node = ok(node().decode(input));
+        assertEquals(1, node.value());
+        assertEquals(2, node.next().orElseThrow().value());
+        assertEquals(3, node.next().orElseThrow().next().orElseThrow().value());
+        assertEquals(Optional.empty(), node.next().orElseThrow().next().orElseThrow().next());
+    }
+
+    // --- enumOf: case-insensitive name lookup, invalid_format on miss ---
+
+    enum Color { RED, GREEN, BLUE }
+
+    @Test
+    void enumOfMatchesExactName() {
+        assertEquals(Color.RED, ok(ObjectDecoders.enumOf(Color.class).decode("RED")));
+    }
+
+    @Test
+    void enumOfIsCaseInsensitive() {
+        // Spec: "Decodes a string into an enum constant (case-insensitive)."
+        assertEquals(Color.GREEN, ok(ObjectDecoders.enumOf(Color.class).decode("green")));
+        assertEquals(Color.BLUE, ok(ObjectDecoders.enumOf(Color.class).decode("bLuE")));
+    }
+
+    @Test
+    void enumOfRejectsUnknownValueWithAllowedList() {
+        switch (ObjectDecoders.enumOf(Color.class).decode("purple")) {
+            case Ok<Color>(var v) -> fail("expected Err, got " + v);
+            case Err<Color>(var issues) -> {
+                var issue = issues.asList().getFirst();
+                assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+                var allowed = (List<?>) issue.meta().get("allowed");
+                // The allowed list is the lower-cased constant names.
+                assertEquals(3, allowed.size());
+                assertNotNull(allowed);
+            }
+        }
+    }
+
+    // --- helpers ---
+
+    private static <T> T ok(Result<T> result) {
+        return switch (result) {
+            case Ok<T>(var value) -> value;
+            case Err<T>(var issues) -> fail("expected Ok, got Err: " + issues);
+        };
+    }
+
+    private static String firstCode(Result<?> result) {
+        return switch (result) {
+            case Ok<?> ignored -> fail("expected Err, got Ok");
+            case Err<?>(var issues) -> issues.asList().getFirst().code();
+        };
+    }
+
+    private static int issueCount(Result<?> result) {
+        return switch (result) {
+            case Ok<?> ignored -> fail("expected Err, got Ok");
+            case Err<?>(var issues) -> issues.asList().size();
+        };
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/DecodersCombinatorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -31,8 +32,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@link ObjectDecoders#enumOf(Class)}.
  *
  * <p>Each test asserts the documented contract (Javadoc), not the current implementation shape:
- * expected error codes/messages/metadata are taken from the spec, and the decoders under test are
- * driven by tiny hand-written stubs so the exact success/failure of each input is controlled.
+ * expected error codes and metadata are taken from the spec, and the decoders under test are driven
+ * by tiny hand-written stubs so the exact success/failure of each input is controlled. Fallback
+ * message wording is deliberately not asserted — it is not part of the documented contract.
  */
 class DecodersCombinatorTest {
 
@@ -221,10 +223,9 @@ class DecodersCombinatorTest {
             case Err<Color>(var issues) -> {
                 var issue = issues.asList().getFirst();
                 assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+                // Spec: the error lists the accepted values — the lower-cased constant names.
                 var allowed = (List<?>) issue.meta().get("allowed");
-                // The allowed list is the lower-cased constant names.
-                assertEquals(3, allowed.size());
-                assertNotNull(allowed);
+                assertEquals(Set.of("red", "green", "blue"), Set.copyOf(allowed));
             }
         }
     }


### PR DESCRIPTION
## What

Closes the **test has-gaps** flagged by the product-maturity review — item 1 of the "get to 100" plan. All tests are **spec-anchored**: expected error codes, JSON-Pointer paths, and output shapes are derived from the Javadoc contract, not read back from the implementation (per the retrofitting-tests discipline).

### `DecodersCombinatorTest` (new, 17 tests)
Combinators in `Decoders` that had no dedicated coverage:
- **`oneOf`** — first successful candidate wins (order-sensitive), fall-through to a later candidate, and all-fail → `one_of_failed` with one `candidate`/`issues` meta entry per failure.
- **`withDefault`** — default applies **only when every issue is `required`**; a non-required error, or a mix of `required` + another code, is preserved; supplier variant is lazy (not called on success, called once on required-failure).
- **`recover`** — any error (even `required`) → fallback; the function variant derives the value from the issues.
- **`lazy`** — supplier deferred and re-invoked per decode; a genuinely self-referential decoder (`Node`) that only compiles because `lazy` breaks the recursion.
- **`ObjectDecoders.enumOf`** — case-insensitive name match; unknown value → `invalid_format` with the `allowed` list.

### `IssuesTest` (new, 11 tests)
`Issues` accumulation and its serialization views, previously exercised only indirectly: `add`/`merge` (order, empty short-circuit), `rebase`, `flatten`, `groupByPath`, `toJsonList`, and `format` (nested `_errors`, root-level errors, same-path accumulation).

### `JooqDecoderTest` (+3 tests)
The thinnest of the three boundaries: strict **multi-error accumulation** across a `combine` (proves applicative, not fail-fast, at the jOOQ boundary), plus the **`List`-based `combine`** (`CombinerList`) form decode + accumulate.

## Verification

Core **431 → 459** tests; jOOQ **20 → 23**. Full reactor build green across all 7 modules (`mvn clean install`), NullAway and doclint included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
