### PR TITLE
fix: count code points in StringDecoder length constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ detailed from the current development cycle onward.
   character — a kanji such as `𠮷`, an emoji — used to count as two, contradicting the `characters`
   / `文字` wording of the messages. Strings made only of BMP characters are unaffected; for the
   rest, `maxLength` is now more permissive and `minLength` stricter. The length guards inside
-  `email()`, `url()` and `ip()` stay in UTF-16 units — they bound the value as transmitted rather
-  than expressing a character count ([#105](https://github.com/kawasima/raoh/issues/105)).
+  `email()`, `url()` and `ip()` stay in UTF-16 units — they cap the size of the string before it is
+  parsed or matched, and express neither a character count nor the length of the value as sent
+  ([#105](https://github.com/kawasima/raoh/issues/105)).
 
 ## [0.6.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ detailed from the current development cycle onward.
 
 ## [Unreleased]
 
+### Changed
+
+- **`StringDecoder.minLength` / `maxLength` / `fixedLength` now count Unicode code points** instead
+  of UTF-16 code units, in both the comparison and the `actual` meta value. A supplementary-plane
+  character — a kanji such as `𠮷`, an emoji — used to count as two, contradicting the `characters`
+  / `文字` wording of the messages. Strings made only of BMP characters are unaffected; for the
+  rest, `maxLength` is now more permissive and `minLength` stricter. The length guards inside
+  `email()`, `url()` and `ip()` stay in UTF-16 units — they bound the value as transmitted rather
+  than expressing a character count ([#105](https://github.com/kawasima/raoh/issues/105)).
+
 ## [0.6.0] - 2026-07-15
 
 ### Added

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -104,7 +104,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be at least {@code n} characters long.
+     * Restricts the string to be at least {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n the minimum length
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SHORT} if shorter
@@ -114,7 +115,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be at least {@code n} characters long.
+     * Restricts the string to be at least {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n       the minimum length
      * @param message custom error message, or {@code null} for the default
@@ -122,8 +124,9 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      */
     public StringDecoder<I> minLength(int n, @Nullable String message) {
         return chain((value, path) -> {
-            if (value.length() < n) {
-                var meta = Map.<String, Object>of("min", n, "actual", value.length());
+            int length = codePointLength(value);
+            if (length < n) {
+                var meta = Map.<String, Object>of("min", n, "actual", length);
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.TOO_SHORT, message, meta)
                         : Result.fail(path, ErrorCodes.TOO_SHORT, "must be at least %d characters".formatted(n), meta);
@@ -133,7 +136,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be at most {@code n} characters long.
+     * Restricts the string to be at most {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n the maximum length
      * @return a new decoder that fails with {@link ErrorCodes#TOO_LONG} if longer
@@ -143,7 +147,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be at most {@code n} characters long.
+     * Restricts the string to be at most {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n       the maximum length
      * @param message custom error message, or {@code null} for the default
@@ -151,8 +156,9 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      */
     public StringDecoder<I> maxLength(int n, @Nullable String message) {
         return chain((value, path) -> {
-            if (value.length() > n) {
-                var meta = Map.<String, Object>of("max", n, "actual", value.length());
+            int length = codePointLength(value);
+            if (length > n) {
+                var meta = Map.<String, Object>of("max", n, "actual", length);
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.TOO_LONG, message, meta)
                         : Result.fail(path, ErrorCodes.TOO_LONG, "must be at most %d characters".formatted(n), meta);
@@ -162,7 +168,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be exactly {@code n} characters long.
+     * Restricts the string to be exactly {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n the required length
      * @return a new decoder that fails with {@link ErrorCodes#INVALID_LENGTH} if the length differs
@@ -172,7 +179,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Restricts the string to be exactly {@code n} characters long.
+     * Restricts the string to be exactly {@code n} characters long, counted in Unicode code
+     * points (see {@link #codePointLength}).
      *
      * @param n       the required length
      * @param message custom error message, or {@code null} for the default
@@ -180,8 +188,9 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      */
     public StringDecoder<I> fixedLength(int n, @Nullable String message) {
         return chain((value, path) -> {
-            if (value.length() != n) {
-                var meta = Map.<String, Object>of("expected", n, "actual", value.length());
+            int length = codePointLength(value);
+            if (length != n) {
+                var meta = Map.<String, Object>of("expected", n, "actual", length);
                 return message != null
                         ? Result.failCustom(path, ErrorCodes.INVALID_LENGTH, message, meta)
                         : Result.fail(path, ErrorCodes.INVALID_LENGTH, "must be exactly %d characters".formatted(n), meta);
@@ -926,6 +935,21 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
                     : Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected boolean",
                             Map.of("expected", "boolean"));
         }));
+    }
+
+    /**
+     * The number of characters in {@code s}, counted in Unicode code points rather than the UTF-16
+     * units a JVM {@code String} stores. A character outside the basic multilingual plane — a
+     * supplementary-plane kanji such as {@code 𠮷}, an emoji — occupies two units and is one
+     * character, so the two counts disagree exactly where a length limit on a name or a remarks
+     * field would be surprising to whoever hits it.
+     *
+     * <p>This is not the grapheme cluster a reader counts: a base letter with a combining accent is
+     * two code points, and an emoji joined with zero-width joiners is several. That unit depends on
+     * Unicode segmentation and is not what a stored-length constraint is about.
+     */
+    private static int codePointLength(String s) {
+        return s.codePointCount(0, s.length());
     }
 
     private StringDecoder<I> chain(Decoder<String, String> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -105,7 +105,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be at least {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n the minimum length
      * @return a new decoder that fails with {@link ErrorCodes#TOO_SHORT} if shorter
@@ -116,7 +117,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be at least {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n       the minimum length
      * @param message custom error message, or {@code null} for the default
@@ -137,7 +139,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be at most {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n the maximum length
      * @return a new decoder that fails with {@link ErrorCodes#TOO_LONG} if longer
@@ -148,7 +151,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be at most {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n       the maximum length
      * @param message custom error message, or {@code null} for the default
@@ -169,7 +173,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be exactly {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n the required length
      * @return a new decoder that fails with {@link ErrorCodes#INVALID_LENGTH} if the length differs
@@ -180,7 +185,8 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
     /**
      * Restricts the string to be exactly {@code n} characters long, counted in Unicode code
-     * points (see {@link #codePointLength}).
+     * points via {@link String#codePointCount(int, int)}, so a supplementary-plane character
+     * counts as one.
      *
      * @param n       the required length
      * @param message custom error message, or {@code null} for the default
@@ -378,7 +384,9 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      * Decodes the string value to a {@link URI}, validating that it is a valid http or https URL.
      *
      * <p>Requires an absolute URL with the {@code http} or {@code https} scheme and a
-     * non-empty host. The maximum accepted length is 2048 characters.
+     * non-empty host. Values longer than 2048 UTF-16 code units are rejected before parsing; this
+     * caps the input handed to {@link URI}, and is neither a character count nor a bound on the
+     * percent-encoded form actually sent.
      * Uses {@link URI} parsing to avoid ReDoS from regex backtracking.
      *
      * <p>This is a terminal method — the returned decoder produces {@link URI},
@@ -395,7 +403,9 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      * Decodes the string value to a {@link URI}, validating that it is a valid http or https URL.
      *
      * <p>Requires an absolute URL with the {@code http} or {@code https} scheme and a
-     * non-empty host. The maximum accepted length is 2048 characters.
+     * non-empty host. Values longer than 2048 UTF-16 code units are rejected before parsing; this
+     * caps the input handed to {@link URI}, and is neither a character count nor a bound on the
+     * percent-encoded form actually sent.
      * Uses {@link URI} parsing to avoid ReDoS from regex backtracking.
      *
      * @param message custom error message, or {@code null} for the default

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -75,15 +75,30 @@ class StringDecoderTest {
      */
     @Test
     void lengthConstraintsCountCodePointsNotUtf16Units() {
-        String twoKanji = "\uD842\uDFB7\u7530";   // 𠮷田: two characters, four UTF-16 units
+        String twoKanji = "\uD842\uDFB7\u7530";   // 𠮷田: two characters, three UTF-16 units
 
+        // Counting units, both of these reject the value; counting code points, neither does.
         assertEquals(twoKanji, decodeOk(string().maxLength(2), twoKanji));
-        assertEquals(twoKanji, decodeOk(string().minLength(2), twoKanji));
         assertEquals(twoKanji, decodeOk(string().fixedLength(2), twoKanji));
 
         var tooLong = decodeErr(string().maxLength(1), twoKanji);
         assertEquals(ErrorCodes.TOO_LONG, tooLong.code());
         assertEquals(2, tooLong.meta().get("actual"), "the reported length is in code points too");
+    }
+
+    /**
+     * {@code minLength} is the direction the change tightens, so it needs a value that the old
+     * unit count would have let through.
+     */
+    @Test
+    void minLengthCountsCodePointsAndSoBecomesStricter() {
+        String oneKanji = "𠮷";   // 𠮷: one character, two UTF-16 units
+
+        var tooShort = decodeErr(string().minLength(2), oneKanji);
+        assertEquals(ErrorCodes.TOO_SHORT, tooShort.code());
+        assertEquals(1, tooShort.meta().get("actual"));
+
+        assertEquals(oneKanji, decodeOk(string().minLength(1), oneKanji));
     }
 
     // --- oneOf ---
@@ -188,8 +203,10 @@ class StringDecoderTest {
 
     @Test
     void urlLengthGuardCountsUtf16UnitsNotCodePoints() {
-        // The 2048 bound in url() limits the URL as transmitted; it is not a user-facing character
-        // count, so it stays in UTF-16 units even though minLength/maxLength count code points.
+        // The 2048 bound in url() caps the size of the Java string handed to URI.create, so it
+        // stays in UTF-16 units even though minLength/maxLength count code points. It is neither a
+        // character count nor a bound on the URL as sent: the percent-encoded ASCII form of a
+        // supplementary character is 12 characters where the Java string holds two.
         // java.net.URI accepts supplementary characters in a path, so this URL is otherwise valid
         // and only the guard rejects it — under a code point count it would decode successfully.
         var url = "https://example.com/" + "𠮷".repeat(1025);   // 𠮷 ×1025

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/StringDecoderTest.java
@@ -66,6 +66,26 @@ class StringDecoderTest {
         assertEquals("must be exactly 3 characters", issue.message());
     }
 
+    // --- length is counted in code points ---
+
+    /**
+     * A supplementary-plane character occupies two UTF-16 units and is one character. Counting the
+     * units makes a length limit depend on which characters a name happens to contain, which is a
+     * surprise wherever such characters are ordinary: 𠮷田, an emoji in a free-text field.
+     */
+    @Test
+    void lengthConstraintsCountCodePointsNotUtf16Units() {
+        String twoKanji = "\uD842\uDFB7\u7530";   // 𠮷田: two characters, four UTF-16 units
+
+        assertEquals(twoKanji, decodeOk(string().maxLength(2), twoKanji));
+        assertEquals(twoKanji, decodeOk(string().minLength(2), twoKanji));
+        assertEquals(twoKanji, decodeOk(string().fixedLength(2), twoKanji));
+
+        var tooLong = decodeErr(string().maxLength(1), twoKanji);
+        assertEquals(ErrorCodes.TOO_LONG, tooLong.code());
+        assertEquals(2, tooLong.meta().get("actual"), "the reported length is in code points too");
+    }
+
     // --- oneOf ---
 
     @Test
@@ -162,6 +182,21 @@ class StringDecoderTest {
         // Exceeds the 2048-character maximum, exercising the length guard branch of url().
         var tooLong = "https://example.com/" + "a".repeat(2048);
         var issue = decodeErr(string().url(), tooLong);
+        assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
+        assertEquals("not a valid URL", issue.message());
+    }
+
+    @Test
+    void urlLengthGuardCountsUtf16UnitsNotCodePoints() {
+        // The 2048 bound in url() limits the URL as transmitted; it is not a user-facing character
+        // count, so it stays in UTF-16 units even though minLength/maxLength count code points.
+        // java.net.URI accepts supplementary characters in a path, so this URL is otherwise valid
+        // and only the guard rejects it — under a code point count it would decode successfully.
+        var url = "https://example.com/" + "𠮷".repeat(1025);   // 𠮷 ×1025
+        assertTrue(url.length() > 2048, "over the guard when counted in UTF-16 units");
+        assertTrue(url.codePointCount(0, url.length()) < 2048, "under it when counted in code points");
+
+        var issue = decodeErr(string().url(), url);
         assertEquals(ErrorCodes.INVALID_FORMAT, issue.code());
         assertEquals("not a valid URL", issue.message());
     }


### PR DESCRIPTION
Fixes #105.

`minLength` / `maxLength` / `fixedLength` compared `String.length()`, which counts UTF-16 code units, while the fallback message and the `messages.properties` templates both say `characters` / `文字`. A supplementary-plane character occupies two units, so it was counted twice:

```java
MapDecoders.string().maxLength(2).decode("𠮷田", Path.ROOT);
// before: Err too_long, "must be at most 2 characters", meta {max=2, actual=3}
// after:  Ok "𠮷田"
```

This counts code points in the comparison and in the `actual` meta value, for all three constraints.

## Why code points

YAVI's `CharSequenceConstraint` sizes a `CharSequence` by `codePointCount`, and this follows it. That means departing from Bean Validation's `@Size`, which counts UTF-16 units — a deliberate choice for a library whose length constraints are written against Japanese form fields.

Grapheme clusters are not the unit here. A base letter plus a combining accent is two code points and a ZWJ emoji sequence is several, so a grapheme count depends on Unicode segmentation and is a different constraint rather than a more accurate version of this one. YAVI keeps it as an opt-in mode (`.emoji()`, backed by a counter its own Javadoc calls best-effort); Raoh can do the same later if it is wanted.

## What is not changed

The length guards inside `email()` (254), `url()` (2048) and `ip()` (45) still count UTF-16 units. They cap the size of the string before it is parsed or matched. That is not a character count, and not a bound on the value as sent either: the percent-encoded ASCII form of a supplementary character is 12 characters where the Java string holds two, so 600 of them stay under the `url()` guard while the URL actually sent is far over 2048. If a real wire-length bound is wanted, it has to measure `URI.toASCIIString()` or UTF-8 bytes — a separate change, not this one.

`urlLengthGuardCountsUtf16UnitsNotCodePoints` pins that. `java.net.URI` accepts supplementary characters in a path, so a URL of 2070 units / 1045 code points is otherwise valid and only the guard rejects it; switching the guard to code points makes the test fail with `Ok[...]`. `email()` and `ip()` have no equivalent test because their patterns are ASCII-only, so their guards never decide the outcome on their own and a test could not observe which unit they use.

## Compatibility

Behaviour changes only for strings containing supplementary-plane characters: `maxLength` becomes more permissive, `minLength` stricter. A value that validation used to reject now reaches the persistence layer, where a column sized in bytes or in UTF-16 units (`NVARCHAR(n)` on SQL Server) may reject it instead. CHANGELOG entry filed under `### Changed`.

## Follow-up

#106 covers the other half of the counting problem: without Unicode normalization, an NFD or IVS-tagged string still counts differently from the visually identical composed one. Left out of this PR — it adds a new transform method rather than correcting an existing count.

## Verification

`mvn -f raoh/pom.xml test` — 465 tests, 0 failures. `mvn javadoc:javadoc` clean.
