### PR TITLE
fix: accept ISO text in the ObjectDecoders temporal decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ detailed from the current development cycle onward.
 
 ### Changed
 
+- **The `ObjectDecoders` temporal decoders now accept ISO-8601 text**, the representation the
+  matching `ObjectEncoders` factory writes, so a codec pair built over the neutral `Object` tree
+  round-trips. `date()`, `time()`, `dateTime()`, `iso8601()` and `offsetDateTime()` parse a
+  `String` with the same parse and the same failure message as `string().date()` and friends;
+  unparseable text is now `invalid_format` where it used to be `type_mismatch`. `dateTime()` also
+  accepts `java.sql.Timestamp`, closing the gap against `iso8601()`. `offsetDateTime()` gets no
+  `java.sql` conversion on purpose — `Timestamp` carries no offset, so converting one would mean
+  picking a zone for the caller ([#104](https://github.com/kawasima/raoh/issues/104)).
+
 - **`StringDecoder.minLength` / `maxLength` / `fixedLength` now count Unicode code points** instead
   of UTF-16 code units, in both the comparison and the `actual` meta value. A supplementary-plane
   character — a kanji such as `𠮷`, an emoji — used to count as two, contradicting the `characters`

--- a/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/ObjectDecoders.java
@@ -26,16 +26,20 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Factory of primitive decoders for raw {@code Object} input.
  *
  * <p>These decoders accept a raw {@code Object} value and perform a runtime type check,
- * returning the value as the expected type or a {@code type_mismatch} error.
+ * returning the value as the expected type or a {@code type_mismatch} error. The temporal
+ * decoders additionally accept the {@code java.sql} counterpart of their type and ISO-8601 text,
+ * so they read both what a JDBC driver hands over and what {@code ObjectEncoders} writes.
  * They are used as building blocks for boundary-specific decoder factories such as
  * {@code MapDecoders} and {@code JooqRecordDecoders}, and can also be used directly
  * in custom decoder classes.
@@ -241,9 +245,11 @@ public final class ObjectDecoders {
     /**
      * Creates a {@link LocalDate} decoder.
      *
-     * <p>Accepts {@link LocalDate} values directly, and converts {@link java.sql.Date}
-     * via {@link java.sql.Date#toLocalDate()}. Returns {@code required} if the value
-     * is {@code null}, and {@code type_mismatch} if the value is neither type.
+     * <p>Accepts {@link LocalDate} values directly, converts {@link java.sql.Date}
+     * via {@link java.sql.Date#toLocalDate()}, and parses a {@link String} as ISO-8601 text —
+     * the representation {@code ObjectEncoders.date()} writes. Returns {@code required} if the
+     * value is {@code null}, {@code invalid_format} if the text does not parse, and
+     * {@code type_mismatch} for any other type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link LocalDate}
      */
@@ -252,6 +258,7 @@ public final class ObjectDecoders {
             case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
             case LocalDate d -> Result.ok(d);
             case java.sql.Date sd -> Result.ok(sd.toLocalDate());
+            case String s -> parseText(path, s, LocalDate::parse, "not a valid date (yyyy-MM-dd)");
             default -> typeMismatch(path, "date", in);
         });
     }
@@ -259,9 +266,11 @@ public final class ObjectDecoders {
     /**
      * Creates a {@link LocalTime} decoder.
      *
-     * <p>Accepts {@link LocalTime} values directly, and converts {@link java.sql.Time}
-     * via {@link java.sql.Time#toLocalTime()}. Returns {@code required} if the value
-     * is {@code null}, and {@code type_mismatch} if the value is neither type.
+     * <p>Accepts {@link LocalTime} values directly, converts {@link java.sql.Time}
+     * via {@link java.sql.Time#toLocalTime()}, and parses a {@link String} as ISO-8601 text —
+     * the representation {@code ObjectEncoders.time()} writes. Returns {@code required} if the
+     * value is {@code null}, {@code invalid_format} if the text does not parse, and
+     * {@code type_mismatch} for any other type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link LocalTime}
      */
@@ -270,6 +279,7 @@ public final class ObjectDecoders {
             case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
             case LocalTime t -> Result.ok(t);
             case java.sql.Time st -> Result.ok(st.toLocalTime());
+            case String s -> parseText(path, s, LocalTime::parse, "not a valid time (HH:mm:ss)");
             default -> typeMismatch(path, "time", in);
         });
     }
@@ -277,21 +287,33 @@ public final class ObjectDecoders {
     /**
      * Creates a {@link LocalDateTime} decoder.
      *
-     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
-     * if the value is not a {@link LocalDateTime}.
+     * <p>Accepts {@link LocalDateTime} values directly, converts {@link java.sql.Timestamp}
+     * via {@link java.sql.Timestamp#toLocalDateTime()}, and parses a {@link String} as ISO-8601
+     * text — the representation {@code ObjectEncoders.dateTime()} writes. Returns
+     * {@code required} if the value is {@code null}, {@code invalid_format} if the text does not
+     * parse, and {@code type_mismatch} for any other type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link LocalDateTime}
      */
     public static TemporalDecoder<@Nullable Object, LocalDateTime> dateTime() {
-        return temporalOf(LocalDateTime.class, "date-time");
+        return new TemporalDecoder<>((in, path) -> switch (in) {
+            case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            case LocalDateTime dt -> Result.ok(dt);
+            case java.sql.Timestamp ts -> Result.ok(ts.toLocalDateTime());
+            case String s -> parseText(path, s, LocalDateTime::parse,
+                    "not a valid ISO-8601 local date-time (e.g., 2024-01-15T10:30 or 2024-01-15T10:30:45)");
+            default -> typeMismatch(path, "date-time", in);
+        });
     }
 
     /**
      * Creates an {@link Instant} decoder.
      *
-     * <p>Accepts {@link Instant} values directly, and converts {@link java.sql.Timestamp}
-     * via {@link java.sql.Timestamp#toInstant()}. Returns {@code required} if the value
-     * is {@code null}, and {@code type_mismatch} if the value is neither type.
+     * <p>Accepts {@link Instant} values directly, converts {@link java.sql.Timestamp}
+     * via {@link java.sql.Timestamp#toInstant()}, and parses a {@link String} as ISO-8601 text —
+     * the representation {@code ObjectEncoders.iso8601()} writes. Returns {@code required} if the
+     * value is {@code null}, {@code invalid_format} if the text does not parse, and
+     * {@code type_mismatch} for any other type.
      *
      * @return a temporal decoder for {@code Object} input producing {@link Instant}
      */
@@ -300,6 +322,7 @@ public final class ObjectDecoders {
             case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
             case Instant i -> Result.ok(i);
             case java.sql.Timestamp ts -> Result.ok(ts.toInstant());
+            case String s -> parseText(path, s, Instant::parse, "not a valid ISO 8601 instant");
             default -> typeMismatch(path, "instant", in);
         });
     }
@@ -307,13 +330,26 @@ public final class ObjectDecoders {
     /**
      * Creates an {@link OffsetDateTime} decoder.
      *
-     * <p>Returns {@code required} if the value is {@code null}, and {@code type_mismatch}
-     * if the value is not an {@link OffsetDateTime}.
+     * <p>Accepts {@link OffsetDateTime} values directly and parses a {@link String} as ISO-8601
+     * text — the representation {@code ObjectEncoders.offsetDateTime()} writes. Returns
+     * {@code required} if the value is {@code null}, {@code invalid_format} if the text does not
+     * parse, and {@code type_mismatch} for any other type.
+     *
+     * <p>Unlike the other temporal decoders this one has no {@code java.sql} conversion.
+     * {@link java.sql.Timestamp} carries no offset, so converting one would mean picking a zone
+     * on the caller's behalf; JDBC 4.2 reads {@code TIMESTAMP WITH TIME ZONE} as an
+     * {@link OffsetDateTime} directly.
      *
      * @return a temporal decoder for {@code Object} input producing {@link OffsetDateTime}
      */
     public static TemporalDecoder<@Nullable Object, OffsetDateTime> offsetDateTime() {
-        return temporalOf(OffsetDateTime.class, "offset-date-time");
+        return new TemporalDecoder<>((in, path) -> switch (in) {
+            case null -> Result.fail(path, ErrorCodes.REQUIRED, "is required");
+            case OffsetDateTime odt -> Result.ok(odt);
+            case String s -> parseText(path, s, OffsetDateTime::parse,
+                    "not a valid ISO-8601 offset date-time (e.g., 2024-01-15T10:30:00+09:00)");
+            default -> typeMismatch(path, "offset-date-time", in);
+        });
     }
 
     private static <T> Result<T> typeMismatch(Path path, String expected, Object actual) {
@@ -321,18 +357,17 @@ public final class ObjectDecoders {
                 Map.of("expected", expected, "actual", actual.getClass().getSimpleName()));
     }
 
-    private static <T extends Comparable<? super T>> TemporalDecoder<@Nullable Object, T> temporalOf(
-            Class<T> type, String typeName) {
-        return new TemporalDecoder<>((in, path) -> {
-            if (in == null) {
-                return Result.fail(path, ErrorCodes.REQUIRED, "is required");
-            }
-            if (type.isInstance(in)) {
-                return Result.ok(type.cast(in));
-            }
-            return Result.fail(path, ErrorCodes.TYPE_MISMATCH, "expected " + typeName,
-                    Map.of("expected", typeName, "actual", in.getClass().getSimpleName()));
-        });
+    /**
+     * Parses ISO-8601 text with {@code parse}, reporting {@code invalid_format} on failure with
+     * the same message {@code StringDecoder} uses, so the two routes to a temporal value are
+     * indistinguishable from the caller's side.
+     */
+    private static <T> Result<T> parseText(Path path, String text, Function<String, T> parse, String message) {
+        try {
+            return Result.ok(parse.apply(text));
+        } catch (DateTimeParseException e) {
+            return Result.fail(path, ErrorCodes.INVALID_FORMAT, message);
+        }
     }
 
     // --- nullable / list / map ---

--- a/raoh/src/test/java/net/unit8/raoh/decode/ObjectDecoderTemporalTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/ObjectDecoderTemporalTest.java
@@ -2,8 +2,11 @@ package net.unit8.raoh.decode;
 
 import net.unit8.raoh.Err;
 import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Issue;
 import net.unit8.raoh.Ok;
 import net.unit8.raoh.Path;
+import net.unit8.raoh.Result;
+import net.unit8.raoh.encode.ObjectEncoders;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -53,9 +56,9 @@ class ObjectDecoderTemporalTest {
     }
 
     @Test
-    void iso8601RejectsString() {
-        switch (iso8601().decode("not a timestamp", Path.ROOT)) {
-            case Ok<Instant> _ -> fail("Expected Err for String");
+    void iso8601RejectsWrongType() {
+        switch (iso8601().decode(42, Path.ROOT)) {
+            case Ok<Instant> _ -> fail("Expected Err for Integer");
             case Err<Instant>(var issues) ->
                     assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
         }
@@ -132,8 +135,8 @@ class ObjectDecoderTemporalTest {
 
     @Test
     void timeRejectsWrongType() {
-        switch (time().decode("10:30", Path.ROOT)) {
-            case Ok<LocalTime> _ -> fail("Expected Err for String");
+        switch (time().decode(42, Path.ROOT)) {
+            case Ok<LocalTime> _ -> fail("Expected Err for Integer");
             case Err<LocalTime>(var issues) ->
                     assertEquals(ErrorCodes.TYPE_MISMATCH, issues.asList().getFirst().code());
         }
@@ -177,5 +180,106 @@ class ObjectDecoderTemporalTest {
             case Err<OffsetDateTime>(var issues) ->
                     assertEquals(ErrorCodes.REQUIRED, issues.asList().getFirst().code());
         }
+    }
+
+    @Test
+    void dateTimeAcceptsSqlTimestamp() {
+        var dt = LocalDateTime.of(2024, 6, 15, 10, 30);
+        var ts = java.sql.Timestamp.valueOf(dt);
+        switch (dateTime().decode(ts, Path.ROOT)) {
+            case Ok<LocalDateTime>(var v) -> assertEquals(dt, v);
+            case Err<LocalDateTime>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    // --- ISO text: the representation ObjectEncoders writes ---
+
+    @Test
+    void iso8601DecodesWhatTheEncoderWrote() {
+        var instant = Instant.parse("2024-06-15T10:30:00Z");
+        assertRoundTrips(instant, ObjectEncoders.iso8601().encode(instant), iso8601());
+    }
+
+    @Test
+    void dateDecodesWhatTheEncoderWrote() {
+        var date = LocalDate.of(2024, 6, 15);
+        assertRoundTrips(date, ObjectEncoders.date().encode(date), date());
+    }
+
+    @Test
+    void timeDecodesWhatTheEncoderWrote() {
+        var time = LocalTime.of(10, 30, 0);
+        assertRoundTrips(time, ObjectEncoders.time().encode(time), time());
+    }
+
+    @Test
+    void dateTimeDecodesWhatTheEncoderWrote() {
+        var dt = LocalDateTime.of(2024, 6, 15, 10, 30);
+        assertRoundTrips(dt, ObjectEncoders.dateTime().encode(dt), dateTime());
+    }
+
+    @Test
+    void offsetDateTimeDecodesWhatTheEncoderWrote() {
+        var odt = OffsetDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.ofHours(9));
+        assertRoundTrips(odt, ObjectEncoders.offsetDateTime().encode(odt), offsetDateTime());
+    }
+
+    // --- unparseable text fails the same way as the string route ---
+
+    @Test
+    void iso8601FailsOnUnparseableTextLikeTheStringRoute() {
+        assertSameFailure(iso8601().decode("nonsense", Path.ROOT),
+                string().iso8601().decode("nonsense", Path.ROOT));
+    }
+
+    @Test
+    void dateFailsOnUnparseableTextLikeTheStringRoute() {
+        assertSameFailure(date().decode("nonsense", Path.ROOT),
+                string().date().decode("nonsense", Path.ROOT));
+    }
+
+    @Test
+    void timeFailsOnUnparseableTextLikeTheStringRoute() {
+        assertSameFailure(time().decode("nonsense", Path.ROOT),
+                string().time().decode("nonsense", Path.ROOT));
+    }
+
+    @Test
+    void dateTimeFailsOnUnparseableTextLikeTheStringRoute() {
+        assertSameFailure(dateTime().decode("nonsense", Path.ROOT),
+                string().dateTime().decode("nonsense", Path.ROOT));
+    }
+
+    @Test
+    void offsetDateTimeFailsOnUnparseableTextLikeTheStringRoute() {
+        assertSameFailure(offsetDateTime().decode("nonsense", Path.ROOT),
+                string().offsetDateTime().decode("nonsense", Path.ROOT));
+    }
+
+    private static <T> void assertRoundTrips(T original, Object encoded, Decoder<Object, T> decoder) {
+        assertInstanceOf(String.class, encoded, "the encoder writes ISO text");
+        switch (decoder.decode(encoded, Path.ROOT)) {
+            case Ok<T>(var v) -> assertEquals(original, v);
+            case Err<T>(var issues) -> fail("Expected Ok but got: " + issues);
+        }
+    }
+
+    /**
+     * Both routes read the same ISO text, so a value they both reject must be rejected with the
+     * same code and the same message.
+     */
+    private static void assertSameFailure(Result<?> viaObject, Result<?> viaString) {
+        Issue expected = firstIssue(viaString);
+        Issue actual = firstIssue(viaObject);
+        assertEquals(ErrorCodes.INVALID_FORMAT, actual.code());
+        assertEquals(expected.code(), actual.code());
+        assertEquals(expected.message(), actual.message());
+    }
+
+    private static Issue firstIssue(Result<?> result) {
+        return switch (result) {
+            case Ok<?> ok -> fail("Expected Err but got: " + ok);
+            case Err<?>(var issues) -> issues.asList().getFirst();
+        };
     }
 }


### PR DESCRIPTION
Fixes #104.

The five `ObjectDecoders` temporal decoders now accept the ISO-8601 text the matching `ObjectEncoders` factory writes, so a codec pair over the neutral `Object` tree round-trips:

```java
Object encoded = ObjectEncoders.date().encode(LocalDate.of(2026, 8, 1));  // "2026-08-01"
ObjectDecoders.date().decode(encoded, Path.ROOT);                          // Ok[2026-08-01]
```

## What each decoder accepts now

| decoder | accepts |
| --- | --- |
| `date()` → `LocalDate` | `LocalDate`, `java.sql.Date`, ISO text |
| `time()` → `LocalTime` | `LocalTime`, `java.sql.Time`, ISO text |
| `dateTime()` → `LocalDateTime` | `LocalDateTime`, `java.sql.Timestamp`, ISO text |
| `iso8601()` → `Instant` | `Instant`, `java.sql.Timestamp`, ISO text |
| `offsetDateTime()` → `OffsetDateTime` | `OffsetDateTime`, ISO text |

`dateTime()` accepting `java.sql.Timestamp` is new — the table in #104 listed it as already supported, but `dateTime()` was `temporalOf(LocalDateTime.class, …)` and took nothing else.

`offsetDateTime()` gets no `java.sql` conversion on purpose. `Timestamp` carries no offset, so converting one would mean the library picking a zone for the caller, and JDBC 4.2 reads `TIMESTAMP WITH TIME ZONE` as an `OffsetDateTime` directly. The Javadoc says so at the method.

## Errors

`null` stays `required`, and a value that is neither text nor a temporal type stays `type_mismatch`. Text that does not parse is now `invalid_format` — once a `String` is an accepted representation, a malformed one is a content error, not a type error.

The parse and the message come from the same place as `StringDecoder`, so `string().date()` and `date()` fail identically on the same input. Five tests assert exactly that by decoding the same text through both routes and comparing code and message, rather than hardcoding the strings.

## Compatibility

Two behaviour changes for callers who feed text to these decoders: what used to be `Err` is now `Ok`, and an unparseable string reports `invalid_format` instead of `type_mismatch`. `ObjectDecoderTemporalTest.iso8601RejectsString` pinned the old code and is now `iso8601RejectsWrongType` over an `Integer`; `timeRejectsWrongType` used `"10:30"`, which parses under the new behaviour, so it moved to an `Integer` too.

`raoh-jooq` delegates to `ObjectDecoders` and picks this up automatically. `raoh-json` decodes temporals through `string().date()` and is unaffected.

## Implementation note

The reflective `temporalOf` helper is gone. `dateTime()` and `offsetDateTime()` needed real branches for the added cases, so all five decoders are now explicit pattern-matching switches with one shared parse helper.

## Verification

`mvn test` across all modules — 618 tests, 0 failures. `mvn javadoc:javadoc` clean.

Written test-first: the 11 new assertions failed with `type_mismatch` before the change.
