### PR TITLE
feat: override refine() with a covariant return type on the builtin decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ detailed from the current development cycle onward.
 
 ### Changed
 
+- **`refine()` on a builtin decoder now returns that decoder's own type**, so a refinement no
+  longer has to come last in a chain: `string().refine(...).minLength(3)` compiles where it
+  previously did not, because `refine` is declared on `Decoder` and returned `Decoder<I, T>`. All
+  three overloads are overridden on `BoolDecoder`, `DecimalDecoder`, `DoubleDecoder`,
+  `FloatDecoder`, `IntDecoder`, `ListDecoder`, `LongDecoder`, `RecordDecoder`, `StringDecoder` and
+  `TemporalDecoder`. Behaviour is unchanged, and a covariant override generates a bridge method, so
+  this is both source and binary compatible ([#110](https://github.com/kawasima/raoh/issues/110)).
+
 - **The `ObjectDecoders` temporal decoders now accept ISO-8601 text**, the representation the
   matching `ObjectEncoders` factory writes, so a codec pair built over the neutral `Object` tree
   round-trips. `date()`, `time()`, `dateTime()`, `iso8601()` and `offsetDateTime()` parse a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,20 @@ detailed from the current development cycle onward.
   previously did not, because `refine` is declared on `Decoder` and returned `Decoder<I, T>`. All
   three overloads are overridden on `BoolDecoder`, `DecimalDecoder`, `DoubleDecoder`,
   `FloatDecoder`, `IntDecoder`, `ListDecoder`, `LongDecoder`, `RecordDecoder`, `StringDecoder` and
-  `TemporalDecoder`. Behaviour is unchanged, and a covariant override generates a bridge method, so
-  this is both source and binary compatible ([#110](https://github.com/kawasima/raoh/issues/110)).
+  `TemporalDecoder`. Existing callers stay binary compatible through the compiler-generated bridge
+  methods; a subclass that overrode `refine` would need source changes to recompile, which is moot
+  now that these classes are `final` (see below)
+  ([#110](https://github.com/kawasima/raoh/issues/110)).
+
+- **The builtin decoders are `final`.** `BoolDecoder`, `DecimalDecoder`, `DoubleDecoder`,
+  `FloatDecoder`, `IntDecoder`, `ListDecoder`, `LongDecoder`, `RecordDecoder`, `StringDecoder` and
+  `TemporalDecoder` no longer permit subclassing. They were open by default rather than by design:
+  every constraint runs through a private `chain(...)` helper, so a subclass could neither add a
+  constraint in the same style nor intercept the existing ones — overriding `flatMapWithPath` caught
+  `refine` and nothing else, not `minLength()`, not `email()`. Composition is the supported route,
+  via the public constructor each class already takes an inner decoder through, or
+  `StringDecoder.from(Decoder)`. **Breaks any existing subclass**, at both compile time and link
+  time ([#115](https://github.com/kawasima/raoh/issues/115)).
 
 - **The `ObjectDecoders` temporal decoders now accept ISO-8601 text**, the representation the
   matching `ObjectEncoders` factory writes, so a codec pair built over the neutral `Object` tree

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/BoolDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/BoolDecoder.java
@@ -17,7 +17,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boolean> {
+public final class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boolean> {
 
     private final Decoder<I, Boolean> inner;
 
@@ -100,13 +100,10 @@ public class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boole
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link BoolDecoder} so that boolean constraints can still be chained
+     * after the refinement.
      */
     @Override
     public BoolDecoder<I> refine(Predicate<? super Boolean> ok, String code, String message) {
@@ -114,15 +111,10 @@ public class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boole
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link BoolDecoder} so that boolean constraints can still be chained
+     * after the refinement.
      */
     @Override
     public BoolDecoder<I> refine(Predicate<? super Boolean> ok, String code, String message,
@@ -131,12 +123,10 @@ public class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boole
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link BoolDecoder} so that boolean constraints can still be chained
+     * after the refinement.
      */
     @Override
     public BoolDecoder<I> refine(Predicate<? super Boolean> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/BoolDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/BoolDecoder.java
@@ -8,6 +8,9 @@ import net.unit8.raoh.Result;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for boolean values with optional value constraints.
@@ -93,6 +96,52 @@ public class BoolDecoder<I extends @Nullable Object> implements Decoder<I, Boole
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public BoolDecoder<I> refine(Predicate<? super Boolean> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public BoolDecoder<I> refine(Predicate<? super Boolean> ok, String code, String message,
+                                 Function<? super Boolean, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public BoolDecoder<I> refine(Predicate<? super Boolean> ok,
+                                 BiFunction<? super Boolean, ? super Path, ? extends Result<Boolean>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private BoolDecoder<I> chain(Decoder<Boolean, Boolean> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, BigDecimal> {
+public final class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, BigDecimal> {
 
     private final Decoder<I, BigDecimal> inner;
 
@@ -290,13 +290,10 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link DecimalDecoder} so that decimal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok, String code, String message) {
@@ -304,15 +301,10 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link DecimalDecoder} so that decimal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok, String code, String message,
@@ -321,12 +313,10 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link DecimalDecoder} so that decimal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DecimalDecoder.java
@@ -9,6 +9,9 @@ import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for {@link BigDecimal} values with a fluent API for numeric constraints.
@@ -283,6 +286,52 @@ public class DecimalDecoder<I extends @Nullable Object> implements Decoder<I, Bi
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok, String code, String message,
+                                    Function<? super BigDecimal, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public DecimalDecoder<I> refine(Predicate<? super BigDecimal> ok,
+                                    BiFunction<? super BigDecimal, ? super Path, ? extends Result<BigDecimal>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private DecimalDecoder<I> chain(Decoder<BigDecimal, BigDecimal> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Double> {
+public final class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Double> {
 
     private final Decoder<I, Double> inner;
 
@@ -216,13 +216,10 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link DoubleDecoder} so that double constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DoubleDecoder<I> refine(Predicate<? super Double> ok, String code, String message) {
@@ -230,15 +227,10 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link DoubleDecoder} so that double constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DoubleDecoder<I> refine(Predicate<? super Double> ok, String code, String message,
@@ -247,12 +239,10 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link DoubleDecoder} so that double constraints can still be chained
+     * after the refinement.
      */
     @Override
     public DoubleDecoder<I> refine(Predicate<? super Double> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/DoubleDecoder.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for double values with a fluent API for numeric constraints.
@@ -209,6 +212,52 @@ public class DoubleDecoder<I extends @Nullable Object> implements Decoder<I, Dou
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public DoubleDecoder<I> refine(Predicate<? super Double> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public DoubleDecoder<I> refine(Predicate<? super Double> ok, String code, String message,
+                                   Function<? super Double, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public DoubleDecoder<I> refine(Predicate<? super Double> ok,
+                                   BiFunction<? super Double, ? super Path, ? extends Result<Double>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private DoubleDecoder<I> chain(Decoder<Double, Double> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for float values with a fluent API for numeric constraints.
@@ -209,6 +212,52 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public FloatDecoder<I> refine(Predicate<? super Float> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public FloatDecoder<I> refine(Predicate<? super Float> ok, String code, String message,
+                                  Function<? super Float, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public FloatDecoder<I> refine(Predicate<? super Float> ok,
+                                  BiFunction<? super Float, ? super Path, ? extends Result<Float>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private FloatDecoder<I> chain(Decoder<Float, Float> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/FloatDecoder.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Float> {
+public final class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Float> {
 
     private final Decoder<I, Float> inner;
 
@@ -216,13 +216,10 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link FloatDecoder} so that float constraints can still be chained
+     * after the refinement.
      */
     @Override
     public FloatDecoder<I> refine(Predicate<? super Float> ok, String code, String message) {
@@ -230,15 +227,10 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link FloatDecoder} so that float constraints can still be chained
+     * after the refinement.
      */
     @Override
     public FloatDecoder<I> refine(Predicate<? super Float> ok, String code, String message,
@@ -247,12 +239,10 @@ public class FloatDecoder<I extends @Nullable Object> implements Decoder<I, Floa
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link FloatDecoder} so that float constraints can still be chained
+     * after the refinement.
      */
     @Override
     public FloatDecoder<I> refine(Predicate<? super Float> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -20,7 +20,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Integer> {
+public final class IntDecoder<I extends @Nullable Object> implements Decoder<I, Integer> {
 
     private final Decoder<I, Integer> inner;
 
@@ -283,13 +283,10 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link IntDecoder} so that int constraints can still be chained
+     * after the refinement.
      */
     @Override
     public IntDecoder<I> refine(Predicate<? super Integer> ok, String code, String message) {
@@ -297,15 +294,10 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link IntDecoder} so that int constraints can still be chained
+     * after the refinement.
      */
     @Override
     public IntDecoder<I> refine(Predicate<? super Integer> ok, String code, String message,
@@ -314,12 +306,10 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link IntDecoder} so that int constraints can still be chained
+     * after the refinement.
      */
     @Override
     public IntDecoder<I> refine(Predicate<? super Integer> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/IntDecoder.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for integer values with a fluent API for numeric constraints.
@@ -276,6 +279,52 @@ public class IntDecoder<I extends @Nullable Object> implements Decoder<I, Intege
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public IntDecoder<I> refine(Predicate<? super Integer> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public IntDecoder<I> refine(Predicate<? super Integer> ok, String code, String message,
+                                Function<? super Integer, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public IntDecoder<I> refine(Predicate<? super Integer> ok,
+                                BiFunction<? super Integer, ? super Path, ? extends Result<Integer>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private IntDecoder<I> chain(Decoder<Integer, Integer> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
@@ -25,7 +25,7 @@ import java.util.function.Predicate;
  * @param <I> the input type
  * @param <T> the element type
  */
-public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, List<T>> {
+public final class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, List<T>> {
 
     private final Decoder<I, List<T>> inner;
 
@@ -259,13 +259,10 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link ListDecoder} so that list constraints can still be chained
+     * after the refinement.
      */
     @Override
     public ListDecoder<I, T> refine(Predicate<? super List<T>> ok, String code, String message) {
@@ -273,15 +270,10 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link ListDecoder} so that list constraints can still be chained
+     * after the refinement.
      */
     @Override
     public ListDecoder<I, T> refine(Predicate<? super List<T>> ok, String code, String message,
@@ -290,12 +282,10 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link ListDecoder} so that list constraints can still be chained
+     * after the refinement.
      */
     @Override
     public ListDecoder<I, T> refine(Predicate<? super List<T>> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/ListDecoder.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for list (array) values with a fluent API for size constraints.
@@ -252,6 +255,52 @@ public class ListDecoder<I extends @Nullable Object, T> implements Decoder<I, Li
     public Decoder<I, Set<T>> toSet() {
         return (in, path) -> this.decode(in, path)
                 .map(list -> Collections.unmodifiableSet(new LinkedHashSet<>(list)));
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public ListDecoder<I, T> refine(Predicate<? super List<T>> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public ListDecoder<I, T> refine(Predicate<? super List<T>> ok, String code, String message,
+                                    Function<? super List<T>, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public ListDecoder<I, T> refine(Predicate<? super List<T>> ok,
+                                    BiFunction<? super List<T>, ? super Path, ? extends Result<List<T>>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private ListDecoder<I, T> chain(Decoder<List<T>, List<T>> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for long integer values with a fluent API for numeric constraints.
@@ -276,6 +279,52 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public LongDecoder<I> refine(Predicate<? super Long> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public LongDecoder<I> refine(Predicate<? super Long> ok, String code, String message,
+                                 Function<? super Long, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public LongDecoder<I> refine(Predicate<? super Long> ok,
+                                 BiFunction<? super Long, ? super Path, ? extends Result<Long>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private LongDecoder<I> chain(Decoder<Long, Long> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/LongDecoder.java
@@ -20,7 +20,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long> {
+public final class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long> {
 
     private final Decoder<I, Long> inner;
 
@@ -283,13 +283,10 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link LongDecoder} so that long constraints can still be chained
+     * after the refinement.
      */
     @Override
     public LongDecoder<I> refine(Predicate<? super Long> ok, String code, String message) {
@@ -297,15 +294,10 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link LongDecoder} so that long constraints can still be chained
+     * after the refinement.
      */
     @Override
     public LongDecoder<I> refine(Predicate<? super Long> ok, String code, String message,
@@ -314,12 +306,10 @@ public class LongDecoder<I extends @Nullable Object> implements Decoder<I, Long>
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link LongDecoder} so that long constraints can still be chained
+     * after the refinement.
      */
     @Override
     public LongDecoder<I> refine(Predicate<? super Long> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
  * @param <I> the input type
  * @param <V> the value type
  */
-public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, Map<String, V>> {
+public final class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, Map<String, V>> {
 
     private final Decoder<I, Map<String, V>> inner;
 
@@ -147,13 +147,10 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link RecordDecoder} so that record constraints can still be chained
+     * after the refinement.
      */
     @Override
     public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok, String code, String message) {
@@ -161,15 +158,10 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link RecordDecoder} so that record constraints can still be chained
+     * after the refinement.
      */
     @Override
     public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok, String code, String message,
@@ -178,12 +170,10 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link RecordDecoder} so that record constraints can still be chained
+     * after the refinement.
      */
     @Override
     public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/RecordDecoder.java
@@ -8,6 +8,9 @@ import net.unit8.raoh.Result;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for string-keyed map (record/object) values with a fluent API for size constraints.
@@ -140,6 +143,52 @@ public class RecordDecoder<I extends @Nullable Object, V> implements Decoder<I, 
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok, String code, String message,
+                                      Function<? super Map<String, V>, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public RecordDecoder<I, V> refine(Predicate<? super Map<String, V>> ok,
+                                      BiFunction<? super Map<String, V>, ? super Path, ? extends Result<Map<String, V>>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private RecordDecoder<I, V> chain(Decoder<Map<String, V>, Map<String, V>> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
  *
  * @param <I> the input type
  */
-public class StringDecoder<I extends @Nullable Object> implements Decoder<I, String> {
+public final class StringDecoder<I extends @Nullable Object> implements Decoder<I, String> {
 
     private static final int MAX_EMAIL_LENGTH = 254;
     private static final int MAX_URL_LENGTH = 2048;
@@ -967,13 +967,10 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link StringDecoder} so that string constraints can still be chained
+     * after the refinement.
      */
     @Override
     public StringDecoder<I> refine(Predicate<? super String> ok, String code, String message) {
@@ -981,15 +978,10 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link StringDecoder} so that string constraints can still be chained
+     * after the refinement.
      */
     @Override
     public StringDecoder<I> refine(Predicate<? super String> ok, String code, String message,
@@ -998,12 +990,10 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link StringDecoder} so that string constraints can still be chained
+     * after the refinement.
      */
     @Override
     public StringDecoder<I> refine(Predicate<? super String> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/StringDecoder.java
@@ -24,6 +24,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for string values with a fluent API for constraints, transforms, and type conversions.
@@ -960,6 +963,52 @@ public class StringDecoder<I extends @Nullable Object> implements Decoder<I, Str
      */
     private static int codePointLength(String s) {
         return s.codePointCount(0, s.length());
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public StringDecoder<I> refine(Predicate<? super String> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public StringDecoder<I> refine(Predicate<? super String> ok, String code, String message,
+                                   Function<? super String, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public StringDecoder<I> refine(Predicate<? super String> ok,
+                                   BiFunction<? super String, ? super Path, ? extends Result<String>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private StringDecoder<I> chain(Decoder<String, String> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/TemporalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/TemporalDecoder.java
@@ -38,7 +38,7 @@ import java.util.function.Predicate;
  * @param <I> the input type
  * @param <T> the temporal type (must be {@link Comparable} to itself)
  */
-public class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? super T>> implements Decoder<I, T> {
+public final class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? super T>> implements Decoder<I, T> {
 
     private final Decoder<I, T> inner;
 
@@ -153,13 +153,10 @@ public class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? 
 
 
     /**
-     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
-     * decoder's own constraints can still be chained after the refinement.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link TemporalDecoder} so that temporal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public TemporalDecoder<I, T> refine(Predicate<? super T> ok, String code, String message) {
@@ -167,15 +164,10 @@ public class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? 
     }
 
     /**
-     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok      the predicate the decoded value must satisfy
-     * @param code    the error code to report on failure
-     * @param message the error message to report on failure
-     * @param metaFn  a function producing the issue metadata from the failing value
-     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
-     *         rejects the value
+     * <p>The return type is narrowed to {@link TemporalDecoder} so that temporal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public TemporalDecoder<I, T> refine(Predicate<? super T> ok, String code, String message,
@@ -184,12 +176,10 @@ public class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? 
     }
 
     /**
-     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
-     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     * {@inheritDoc}
      *
-     * @param ok     the predicate the decoded value must satisfy
-     * @param onFail builds the failing result from the rejected value and the current path
-     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     * <p>The return type is narrowed to {@link TemporalDecoder} so that temporal constraints can still be chained
+     * after the refinement.
      */
     @Override
     public TemporalDecoder<I, T> refine(Predicate<? super T> ok,

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/TemporalDecoder.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/TemporalDecoder.java
@@ -8,6 +8,9 @@ import net.unit8.raoh.Result;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A decoder for temporal values with a fluent API for range constraints.
@@ -146,6 +149,52 @@ public class TemporalDecoder<I extends @Nullable Object, T extends Comparable<? 
             }
             return Result.ok(value);
         });
+    }
+
+
+    /**
+     * Refines the decoded value with a predicate, narrowing the inherited return type so that this
+     * decoder's own constraints can still be chained after the refinement.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @return a decoder that fails with the given code and message when {@code ok} rejects the value
+     */
+    @Override
+    public TemporalDecoder<I, T> refine(Predicate<? super T> ok, String code, String message) {
+        return refine(ok, code, message, v -> Map.of());
+    }
+
+    /**
+     * Refines the decoded value with a predicate, attaching metadata derived from the failing value.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok      the predicate the decoded value must satisfy
+     * @param code    the error code to report on failure
+     * @param message the error message to report on failure
+     * @param metaFn  a function producing the issue metadata from the failing value
+     * @return a decoder that fails with the given code, message, and metadata when {@code ok}
+     *         rejects the value
+     */
+    @Override
+    public TemporalDecoder<I, T> refine(Predicate<? super T> ok, String code, String message,
+                                        Function<? super T, ? extends Map<String, Object>> metaFn) {
+        return refine(ok, (v, path) -> Result.failCustom(path, code, message, metaFn.apply(v)));
+    }
+
+    /**
+     * Refines the decoded value with a predicate whose failure branch is caller-controlled.
+     * Narrows the inherited return type so that this decoder's own constraints can still be chained.
+     *
+     * @param ok     the predicate the decoded value must satisfy
+     * @param onFail builds the failing result from the rejected value and the current path
+     * @return a decoder that delegates to {@code onFail} when {@code ok} rejects the value
+     */
+    @Override
+    public TemporalDecoder<I, T> refine(Predicate<? super T> ok,
+                                        BiFunction<? super T, ? super Path, ? extends Result<T>> onFail) {
+        return chain((value, path) -> ok.test(value) ? Result.ok(value) : onFail.apply(value, path));
     }
 
     private TemporalDecoder<I, T> chain(Decoder<T, T> constraint) {

--- a/raoh/src/main/java/net/unit8/raoh/decode/builtin/package-info.java
+++ b/raoh/src/main/java/net/unit8/raoh/decode/builtin/package-info.java
@@ -5,6 +5,30 @@
  * {@link net.unit8.raoh.decode.ObjectDecoders} or {@code net.unit8.raoh.json.JsonDecoders}.
  * For map-structure utilities ({@code field()}, {@code combine()}, etc.),
  * see {@link net.unit8.raoh.decode.map.MapDecoders}.
+ *
+ * <p><strong>These classes are {@code final}: extend them by composition, not by subclassing.</strong>
+ * Each one wraps an inner {@link net.unit8.raoh.decode.Decoder} and builds every constraint through
+ * a private {@code chain} helper, so a subclass could neither add a constraint in the same style nor
+ * intercept the ones already there — overriding {@code flatMapWithPath} would not have caught
+ * {@code minLength()}, {@code email()} or any other built-in constraint.
+ *
+ * <p>To wrap or instrument a decoder, take the inner one and hand a new one back. Every class here
+ * has a public constructor for exactly that, and {@link
+ * net.unit8.raoh.decode.builtin.StringDecoder#from(net.unit8.raoh.decode.Decoder) StringDecoder.from}
+ * is the same route spelled as a factory:
+ *
+ * <pre>{@code
+ * StringDecoder<I> traced(StringDecoder<I> dec) {
+ *     return StringDecoder.from((in, path) -> {
+ *         log(path);
+ *         return dec.decode(in, path);
+ *     });
+ * }
+ * }</pre>
+ *
+ * <p>To add a domain rule, use {@link net.unit8.raoh.decode.Decoder#refine(java.util.function.Predicate,
+ * String, String) refine}: it returns the same decoder type, so it composes with the built-in
+ * constraints in either order.
  */
 @NullMarked
 package net.unit8.raoh.decode.builtin;

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/CovariantRefineTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/CovariantRefineTest.java
@@ -1,0 +1,168 @@
+package net.unit8.raoh.decode.builtin;
+
+import net.unit8.raoh.ErrorCodes;
+import net.unit8.raoh.Path;
+import net.unit8.raoh.Result;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static net.unit8.raoh.decode.ObjectDecoders.bool;
+import static net.unit8.raoh.decode.ObjectDecoders.date;
+import static net.unit8.raoh.decode.ObjectDecoders.decimal;
+import static net.unit8.raoh.decode.ObjectDecoders.double_;
+import static net.unit8.raoh.decode.ObjectDecoders.float_;
+import static net.unit8.raoh.decode.ObjectDecoders.int_;
+import static net.unit8.raoh.decode.ObjectDecoders.list;
+import static net.unit8.raoh.decode.ObjectDecoders.long_;
+import static net.unit8.raoh.decode.ObjectDecoders.map;
+import static net.unit8.raoh.decode.ObjectDecoders.string;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeErr;
+import static net.unit8.raoh.decode.builtin.BuiltinTestSupport.decodeOk;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code refine} is overridden on every builtin decoder with a covariant return type, so a
+ * refinement no longer has to come last in a chain. Each case below applies a builtin constraint
+ * <em>after</em> the refinement — which only compiles if the refinement returned the specific
+ * decoder type — and checks that both the refinement and the following constraint still fire.
+ */
+class CovariantRefineTest {
+
+    @Test
+    void string_() {
+        StringDecoder<@Nullable Object> dec = string()
+                .refine(s -> !s.startsWith("_"), "no_underscore", "must not start with _")
+                .minLength(3);
+        assertEquals("abc", decodeOk(dec, "abc"));
+        assertEquals("no_underscore", decodeErr(dec, "_abc").code());
+        assertEquals(ErrorCodes.TOO_SHORT, decodeErr(dec, "ab").code());
+    }
+
+    @Test
+    void int_covariant() {
+        IntDecoder<@Nullable Object> dec = int_()
+                .refine(n -> n % 2 == 0, "must_be_even", "must be even")
+                .max(10);
+        assertEquals(4, decodeOk(dec, 4));
+        assertEquals("must_be_even", decodeErr(dec, 3).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, 12).code());
+    }
+
+    @Test
+    void long_covariant() {
+        LongDecoder<@Nullable Object> dec = long_()
+                .refine(n -> n % 2 == 0, "must_be_even", "must be even")
+                .max(10L);
+        assertEquals(4L, decodeOk(dec, 4L));
+        assertEquals("must_be_even", decodeErr(dec, 3L).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, 12L).code());
+    }
+
+    @Test
+    void double_covariant() {
+        DoubleDecoder<@Nullable Object> dec = double_()
+                .refine(n -> n > 0, "must_be_positive", "must be positive")
+                .max(10.0);
+        assertEquals(4.0, decodeOk(dec, 4.0));
+        assertEquals("must_be_positive", decodeErr(dec, -1.0).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, 12.0).code());
+    }
+
+    @Test
+    void float_covariant() {
+        FloatDecoder<@Nullable Object> dec = float_()
+                .refine(n -> n > 0, "must_be_positive", "must be positive")
+                .max(10.0f);
+        assertEquals(4.0f, decodeOk(dec, 4.0f));
+        assertEquals("must_be_positive", decodeErr(dec, -1.0f).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, 12.0f).code());
+    }
+
+    @Test
+    void decimal_covariant() {
+        DecimalDecoder<@Nullable Object> dec = decimal()
+                .refine(n -> n.signum() > 0, "must_be_positive", "must be positive")
+                .max(new BigDecimal("10"));
+        assertEquals(new BigDecimal("4"), decodeOk(dec, new BigDecimal("4")));
+        assertEquals("must_be_positive", decodeErr(dec, new BigDecimal("-1")).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, new BigDecimal("12")).code());
+    }
+
+    @Test
+    void bool_covariant() {
+        BoolDecoder<@Nullable Object> dec = bool()
+                .refine(b -> b, "must_be_true", "must be true")
+                .isTrue();
+        assertEquals(true, decodeOk(dec, true));
+        assertEquals("must_be_true", decodeErr(dec, false).code());
+    }
+
+    @Test
+    void list_covariant() {
+        ListDecoder<@Nullable Object, String> dec = list(string())
+                .refine(v -> v.size() % 2 == 0, "even_only", "size must be even")
+                .nonempty();
+        assertEquals(List.of("a", "b"), decodeOk(dec, List.of("a", "b")));
+        assertEquals("even_only", decodeErr(dec, List.of("a")).code());
+        assertEquals(ErrorCodes.TOO_SMALL, decodeErr(dec, List.of()).code());
+    }
+
+    @Test
+    void record_covariant() {
+        RecordDecoder<@Nullable Object, Integer> dec = map(int_())
+                .refine(m -> m.values().stream().allMatch(v -> v > 0), "all_positive", "must all be positive")
+                .minSize(1);
+        assertEquals(Map.of("a", 1), decodeOk(dec, Map.of("a", 1)));
+        assertEquals("all_positive", decodeErr(dec, Map.of("a", -1)).code());
+        assertEquals(ErrorCodes.TOO_SMALL, decodeErr(dec, Map.of()).code());
+    }
+
+    @Test
+    void temporal_covariant() {
+        var epoch = LocalDate.parse("2000-01-01");
+        var limit = LocalDate.parse("2030-01-01");
+        TemporalDecoder<@Nullable Object, LocalDate> dec = date()
+                .refine(d -> d.isAfter(epoch), "too_early", "must be after 2000-01-01")
+                .before(limit);
+        assertEquals(LocalDate.parse("2020-06-01"), decodeOk(dec, LocalDate.parse("2020-06-01")));
+        assertEquals("too_early", decodeErr(dec, LocalDate.parse("1999-01-01")).code());
+        assertEquals(ErrorCodes.OUT_OF_RANGE, decodeErr(dec, LocalDate.parse("2031-01-01")).code());
+    }
+
+    @Test
+    void metaOverloadKeepsTheSpecificType() {
+        StringDecoder<@Nullable Object> dec = string()
+                .refine(s -> s.length() % 2 == 0, "even_length", "length must be even",
+                        s -> Map.of("actual", s.length()))
+                .toUpperCase();
+        assertEquals("ABCD", decodeOk(dec, "abcd"));
+        assertEquals(3, decodeErr(dec, "abc").meta().get("actual"));
+    }
+
+    @Test
+    void onFailOverloadKeepsTheSpecificTypeAndItsFailurePath() {
+        StringDecoder<@Nullable Object> dec = string()
+                .refine(s -> s.length() % 2 == 0,
+                        (s, path) -> Result.fail(path.append("len"), "even_length", "length must be even"))
+                .toUpperCase();
+        assertEquals("ABCD", decodeOk(dec, "abcd"));
+        var issue = decodeErr(dec, "abc");
+        assertEquals("even_length", issue.code());
+        assertEquals("/len", issue.path().toJsonPointer());
+    }
+
+    @Test
+    void refinementStillReportsAtTheCurrentPath() {
+        var dec = string().refine(s -> false, "always_fails", "always fails");
+        var result = dec.decode("x", Path.ROOT.append("a").append("b"));
+        assertEquals("/a/b", switch (result) {
+            case net.unit8.raoh.Err<?> err -> err.issues().asList().getFirst().path().toJsonPointer();
+            default -> throw new AssertionError("expected Err but got: " + result);
+        });
+    }
+}

--- a/raoh/src/test/java/net/unit8/raoh/decode/builtin/CovariantRefineTest.java
+++ b/raoh/src/test/java/net/unit8/raoh/decode/builtin/CovariantRefineTest.java
@@ -100,6 +100,14 @@ class CovariantRefineTest {
                 .isTrue();
         assertEquals(true, decodeOk(dec, true));
         assertEquals("must_be_true", decodeErr(dec, false).code());
+
+        // The refinement above rejects false before isTrue() ever runs, so a second decoder with a
+        // predicate that accepts everything is what proves the following constraint still fires.
+        BoolDecoder<@Nullable Object> constraintFires = bool()
+                .refine(b -> true, "never_fails", "never fails")
+                .isTrue();
+        assertEquals(true, decodeOk(constraintFires, true));
+        assertEquals(ErrorCodes.INVALID_VALUE, decodeErr(constraintFires, false).code());
     }
 
     @Test


### PR DESCRIPTION
Closes #110 and #115. Follow-up to #93, independent of #111.

## Problem

`refine` is declared on `Decoder` and returns `Decoder<I, T>`, so refining a builtin decoder discards its fluent API and forces the refinement to come last in a chain:

```java
string().minLength(3).refine(...)   // ok
string().refine(...).minLength(3)   // did not compile — refine returned a Decoder
```

`refine` is the only combinator where this is fixable. `map`, `flatMap` and `pipe` change the output type, so there is no more specific type to return.

## What changed

All three `refine` overloads are overridden with a covariant return type on the ten builtin decoders: `BoolDecoder`, `DecimalDecoder`, `DoubleDecoder`, `FloatDecoder`, `IntDecoder`, `ListDecoder`, `LongDecoder`, `RecordDecoder`, `StringDecoder`, `TemporalDecoder`. Only the `BiFunction` overload has a real body — it routes through the same private `chain(...)` helper every other constraint uses. The other two restate the interface defaults, which Java offers no way to avoid for a covariant return.

The overrides carry `{@inheritDoc}` plus a line about the narrowed return type, so the `Decoder.refine` contract — nullness, the `metaFn` no-null-values rule, accumulation with sibling errors — stays visible on the concrete types and cannot drift from it.

**The ten classes are now `final`** (#115). They were open by default rather than by design. Every constraint runs through the private `chain(...)`, so a subclass could neither add a constraint in the same style nor intercept the existing ones. Measured by subclassing `StringDecoder` and overriding `flatMapWithPath`:

```
minLength  -> not intercepted
email      -> not intercepted
trim       -> not intercepted
map        -> not intercepted
refine     -> intercepted     (on develop, before this branch)
```

One method out of roughly sixty, and only because `refine` alone was inherited from `Decoder` rather than implemented on the class. Composition is the supported route, and the API already provides it — each class takes its inner decoder in a public constructor, and `StringDecoder.from(Decoder)` is the same thing as a factory. The policy and the reasoning are in the `builtin` package Javadoc.

## Compatibility

Behaviour is unchanged for the intended usage, and existing callers stay **binary compatible** through the compiler-generated bridge methods.

Not source compatible for subclasses, and that is now moot: **making the classes `final` breaks any existing subclass outright**, at both compile time and link time. Deliberate — none exists in this repository, and pre-1.0 is the moment to close an extension point that never worked. Recorded in the CHANGELOG.

## Tests

`CovariantRefineTest` covers all ten decoders. Each case applies a builtin constraint *after* a refinement — which only compiles if the refinement returned the specific type — and asserts that both the refinement and the following constraint fire. `bool_covariant` carries a second decoder whose predicate accepts everything, because the first one's refinement rejects `false` before `isTrue()` can run. Also covers the metadata and `onFail` overloads, and pins that a refinement still reports at the current path rather than the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)