### PR TITLE
build: report the published-API diff against the last release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,25 @@ jobs:
           cache: maven
       - name: Build and test
         run: mvn -B --no-transfer-progress verify
+      # The API diff is a detector, so the build must fail when it did not run — a plugin
+      # declaration dropped from a module POM would otherwise leave `verify` green, the job
+      # summary empty and nobody any the wiser, which is the silence this check exists to
+      # end. The module list is spelled out here on purpose rather than derived from the
+      # POMs: derived, it would shrink along with the declaration it is meant to catch.
+      # Reporting the result is a separate step below, and is allowed to fail on its own.
+      - name: Verify API diff reports
+        if: success()
+        run: |
+          status=0
+          for report in raoh/target/japicmp/api-diff.md \
+                        raoh-json/target/japicmp/api-diff.md \
+                        raoh-jooq/target/japicmp/api-diff.md; do
+            if [ ! -s "$report" ]; then
+              echo "::error::No API diff report at $report — is the japicmp plugin still declared in that module's POM?"
+              status=1
+            fi
+          done
+          exit $status
       # JaCoCo (configured in the parent pom) writes per-module reports under
       # target/site/jacoco during `verify`. Surface them as a job-summary table and
       # a downloadable HTML artifact. Reporting only — no coverage thresholds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,40 @@ jobs:
           name: jacoco-coverage
           path: '**/target/site/jacoco/'
           if-no-files-found: warn
+      # japicmp (configured in the parent pom) diffs the published API of raoh, raoh-json
+      # and raoh-jooq against the last release during `verify`, writing a report under
+      # target/japicmp. Show it here so a change to the API surface is visible on the PR
+      # that makes it. Reporting only — before 1.0 the build does not fail on a break; see
+      # the plugin's comment in the parent pom.
+      - name: Public API diff
+        if: always()
+        # Reporting only: never let a summary-formatting hiccup red an otherwise-green build.
+        continue-on-error: true
+        run: |
+          baseline=$(sed -n 's#.*<japicmp.baseline>\(.*\)</japicmp.baseline>.*#\1#p' pom.xml)
+          {
+            echo "## Public API diff (baseline ${baseline})"
+            for f in $(find . -path '*/target/japicmp/api-diff.md' | sort); do
+              mod=$(echo "$f" | sed -E 's#\./([^/]+)/target.*#\1#')
+              size=$(wc -c < "$f")
+              echo "### $mod"
+              # The job summary caps at 1 MiB. A report that big belongs in the artifact.
+              if [ "$size" -le 262144 ]; then
+                # Drop the report's own H1 and demote its headings two levels, so its
+                # sections nest under the module heading instead of outranking it.
+                sed -e '/^# Compatibility Report$/d' -e 's/^#/###/' "$f"
+              else
+                echo "Report is ${size} bytes — see the japicmp-api-diff artifact."
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload API diff reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: japicmp-api-diff
+          path: '**/target/japicmp/'
+          if-no-files-found: warn
 
   nullcheck:
     name: NullAway null-analysis gate (JDK 25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ detailed from the current development cycle onward.
   string literals, so a decomposed literal passed to `oneOf` will not match a value normalized to NFC
   ([#106](https://github.com/kawasima/raoh/issues/106)).
 
+- **Published-API diff in the build.** `japicmp` compares `raoh`, `raoh-json` and `raoh-jooq`
+  against the last release during `verify`, and CI puts the per-module report in the job summary
+  and the `japicmp-api-diff` artifact. Nothing used to report a change to the API surface, so the
+  breaks in this release are in this file only because someone noticed them. Reporting only for
+  now: before 1.0 the breaks are deliberate and frequent, and a build that fails on each one turns
+  the exclusion list into the thing you edit to get back to green. At 1.0 the `breakBuild*` flags
+  go to true and an intentional break needs an explicit exclusion
+  ([#117](https://github.com/kawasima/raoh/issues/117)).
+
 ### Fixed
 
 - **A schema can no longer lose a field by being wrapped.** `FieldDecoder` was both a `Decoder` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,11 @@ permanent. Everything before step 5 is reversible; treat step 5 as the point of 
    [X.Y.Z]: https://github.com/kawasima/raoh/compare/v<prev>...vX.Y.Z
    ```
 
+   Cross-check the breaking-change list against the japicmp report — the `japicmp-api-diff`
+   artifact from the last CI run, or `*/target/japicmp/api-diff.md` after a local `mvn verify`.
+   It lists every removed, modified and added type in `raoh`, `raoh-json` and `raoh-jooq`
+   against the baseline, which is what the CHANGELOG is supposed to be describing.
+
 3. Set the release version in all POMs:
 
    ```sh
@@ -165,15 +170,22 @@ permanent. Everything before step 5 is reversible; treat step 5 as the point of 
    Order matters. `--target main` resolves against the *remote* branch, so creating the release
    before pushing tags the previous commit.
 
-7. Back on `develop`, bump to the next SNAPSHOT and push:
+7. Back on `develop`, bump to the next SNAPSHOT, move the API-diff baseline to the release just
+   made, and push:
 
    ```sh
    git checkout develop
    ./scripts/bump-version.sh X.Y.(Z+1)-SNAPSHOT
+   # set <japicmp.baseline> in the root pom.xml to X.Y.Z
    git push origin develop
    ```
 
    Commit: `chore: bump version to X.Y.(Z+1)-SNAPSHOT`
+
+   Set the baseline *after* running the script, never before: `bump-version.sh` replaces the
+   current version string anywhere it appears in a POM, so a baseline already reading `X.Y.Z`
+   would be rewritten to the SNAPSHOT along with everything else. Left behind, the next cycle's
+   diff covers two releases at once.
 
 8. Verify the release landed:
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,77 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>3.1.0</jackson.version>
         <junit.version>5.11.4</junit.version>
+        <!--
+            The release the published-API diff compares against. It stays on the previous
+            release while a cycle is in flight — that is what makes the diff describe the
+            cycle — and moves forward in step 7 of the release flow, together with the bump
+            to the next SNAPSHOT. A baseline left behind makes the diff grow by a release
+            at a time until it says nothing about the change in front of you.
+        -->
+        <japicmp.baseline>0.6.0</japicmp.baseline>
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!--
+                    Public API diff against the last release, for the library modules that
+                    declare it (raoh, raoh-json, raoh-jooq). Reporting only: before 1.0 the
+                    breaks are deliberate and frequent, and a build that fails on each one
+                    turns the exclusion list into the thing you edit to get back to green —
+                    which is the opposite of acknowledging a break. The report is what the
+                    CHANGELOG's breaking-change list gets written from.
+
+                    At 1.0, set both breakBuild* flags to true. From then on an intentional
+                    break needs an explicit <exclude>, and that list is the acknowledgement.
+                -->
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>0.23.1</version>
+                    <configuration>
+                        <!--
+                            Pinned to a released coordinate rather than LATEST/RELEASE, so the
+                            comparison resolves from Central and does not depend on what happens
+                            to be in the local repository.
+                        -->
+                        <oldVersion>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${japicmp.baseline}</version>
+                                <type>jar</type>
+                            </dependency>
+                        </oldVersion>
+                        <parameter>
+                            <onlyModified>true</onlyModified>
+                            <!--
+                                A dependent module's baseline was compiled against the baseline of
+                                raoh, but the comparison runs with the current raoh on the classpath,
+                                so a type this cycle removed cannot be resolved there. Ignore only
+                                our own types: a break in raoh belongs to raoh's own report, while a
+                                third-party classpath gap still fails loudly.
+                            -->
+                            <ignoreMissingClassesByRegularExpressions>
+                                <ignoreMissingClassesByRegularExpression>net\.unit8\.raoh\..*</ignoreMissingClassesByRegularExpression>
+                            </ignoreMissingClassesByRegularExpressions>
+                            <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
+                            <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
+                        </parameter>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>api-diff</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>cmp</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/raoh-jooq/pom.xml
+++ b/raoh-jooq/pom.xml
@@ -51,6 +51,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Public API diff against ${japicmp.baseline}; configured in the parent POM. -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <!--
             NullAway null-analysis gate for the @NullMarked contract of this module.

--- a/raoh-json/pom.xml
+++ b/raoh-json/pom.xml
@@ -53,6 +53,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Public API diff against ${japicmp.baseline}; configured in the parent POM. -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <!--
             NullAway null-analysis gate for the @NullMarked contract of this module.

--- a/raoh/pom.xml
+++ b/raoh/pom.xml
@@ -34,6 +34,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Public API diff against ${japicmp.baseline}; configured in the parent POM. -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <!--
             NullAway null-analysis gate for the @NullMarked contract of this module.


### PR DESCRIPTION
Part of #117 — this delivers the diff and the reporting; the gate the issue asks for arrives at 1.0, so the issue stays open.

## What

`japicmp` diffs the published API of `raoh`, `raoh-json` and `raoh-jooq` against the last release during `verify`. CI fails if a report was not produced, puts each module's report in the job summary, and uploads the full report as the `japicmp-api-diff` artifact.

## Reporting, not a gate — for now

The issue asks for a build that fails on an unacknowledged break. Not yet, and the reason is in the `## [Unreleased]` heading of this very CHANGELOG: this is a breaking release, and so were the ones before it. A gate that fires on nearly every PR makes the exclusion list the thing you edit to get back to green, which is the opposite of acknowledging a break.

What the issue also complains about is silence — that the breaks are recorded only because a human noticed. A report fixes that today. At 1.0 the two `breakBuild*` flags go to true, and from then on an intentional break needs an explicit `<exclude>`; that list is the acknowledgement. That step is what keeps #117 open.

## The detector is itself checked

The summary step runs with `continue-on-error` and the artifact upload with `if-no-files-found: warn`, so on their own they would let a japicmp declaration dropped from a module POM pass as a green build with an empty summary — fail-open in the one check whose purpose is to stop the build from staying silent. A separate step asserts the three reports exist and are non-empty, and fails the job otherwise. Generating and displaying are now separate responsibilities.

The module list in that step is spelled out rather than derived from the POMs. Derived, it would shrink together with the declaration it is meant to catch.

## Baseline

Pinned to a released coordinate (`<japicmp.baseline>0.6.0</japicmp.baseline>`), so the comparison resolves from Central instead of depending on what the local repository happens to hold — the concern the issue raises about a check that only passes on a warm machine.

It moves forward in step 7 of the release flow, together with the bump to the next SNAPSHOT, and CLAUDE.md now says so. Order matters there: `bump-version.sh` replaces the current version string anywhere it appears in a POM, so a baseline set before running it would be rewritten to the SNAPSHOT along with everything else.

## One wrinkle

`raoh-json` 0.6.0 was compiled against `raoh` 0.6.0, but the comparison runs with the current `raoh` on the classpath, where `FieldDecoder` no longer exists — japicmp fails to load the old jar. Passing `oldClassPathDependencies` switches it to two separate classpaths and then the *new* side has none, so that trade is worse. Missing classes are instead ignored for `net.unit8.raoh.*` only: a break in `raoh` belongs to `raoh`'s own report, while a gap in a third-party classpath still fails loudly.

## What it produces

The first report is a useful check on this release. `raoh` comes out as semver MAJOR and lists, among others:

| Status | Type | Compatibility Changes |
|---|---|---|
| Removed | `net.unit8.raoh.decode.FieldDecoder` | Class removed, Superclass removed, Interface removed, Method removed |
| Modified | `net.unit8.raoh.decode.Decoders` | Method removed, Method return type changed, Method added |
| Modified | `net.unit8.raoh.decode.builtin.StringDecoder` | Class now final, Method added to public class |
| Added | `net.unit8.raoh.decode.combinator.CombinePart` | — |

which is the CHANGELOG's breaking-change list, arrived at mechanically. `raoh-json` and `raoh-jooq` each report the `field`/`flat` return type change.

## Verification

- `mvn clean verify` — green across the reactor; reports written for the three library modules, `raoh-gsh*` untouched.
- The new check was exercised both ways locally: green with the three reports present, and failing with `::error::No API diff report at raoh-json/...` when one is removed.
- The CI summary script was run locally against the generated reports: 235 KB total, comfortably under the 1 MiB job-summary cap, headings nested correctly under each module.